### PR TITLE
Add Scoop distribution for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,12 @@ jobs:
           done
           ls -la release/
 
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum * > checksums.txt
+          cat checksums.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/scoop-update.yml
+++ b/.github/workflows/scoop-update.yml
@@ -1,0 +1,53 @@
+name: Update Scoop Manifest
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-scoop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Get release info
+        id: release
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Download Windows binary and compute hash
+        run: |
+          curl -fSL -o notion-sync-windows-amd64.exe \
+            "https://github.com/ran-codes/notion-sync/releases/download/${{ steps.release.outputs.tag }}/notion-sync-windows-amd64.exe"
+          SHA256=$(sha256sum notion-sync-windows-amd64.exe | awk '{print $1}')
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+        id: hash
+
+      - name: Update Scoop manifest
+        run: |
+          VERSION="${{ steps.release.outputs.version }}"
+          SHA256="${{ steps.hash.outputs.sha256 }}"
+
+          jq \
+            --arg ver "$VERSION" \
+            --arg hash "$SHA256" \
+            '.version = $ver | .architecture."64bit".url = "https://github.com/ran-codes/notion-sync/releases/download/v\($ver)/notion-sync-windows-amd64.exe" | .architecture."64bit".hash = $hash' \
+            bucket/notion-sync.json > bucket/notion-sync.json.tmp
+
+          mv bucket/notion-sync.json.tmp bucket/notion-sync.json
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/notion-sync.json
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "scoop: update manifest to v${{ steps.release.outputs.version }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ Given a Notion database ID, notion-sync fetches all entries via the Notion API a
 
 ## Install
 
-### Install script (recommended)
-
-**macOS / Linux** (or Windows Git Bash):
+### Install script (macOS / Linux)
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/ran-codes/notion-sync/main/scripts/install.sh | bash
 ```
 
-**Windows PowerShell:**
+### Scoop (Windows)
 
 ```powershell
-irm https://raw.githubusercontent.com/ran-codes/notion-sync/main/scripts/install.ps1 | iex
+scoop bucket add notion-sync https://github.com/ran-codes/notion-sync
+scoop install notion-sync
 ```
 
 ### Manual download

--- a/bucket/notion-sync.json
+++ b/bucket/notion-sync.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.1.0",
+    "description": "CLI tool to sync Notion databases to local Markdown files with YAML frontmatter.",
+    "homepage": "https://github.com/ran-codes/notion-sync",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ran-codes/notion-sync/releases/download/v0.1.0/notion-sync-windows-amd64.exe",
+            "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+        }
+    },
+    "bin": [
+        [
+            "notion-sync-windows-amd64.exe",
+            "notion-sync"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ran-codes/notion-sync"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ran-codes/notion-sync/releases/download/v$version/notion-sync-windows-amd64.exe"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/ran-codes/notion-sync/releases/download/v$version/checksums.txt",
+            "regex": "([a-fA-F0-9]{64})\\s+notion-sync-windows-amd64\\.exe"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Windows users on corporate/managed machines often hit "Access Denied" errors with direct binary installs because writing to `C:\Users\<name>\` or `PATH` directories requires elevated permissions. [Scoop](https://scoop.sh) solves this by installing everything under `~/scoop/` — no admin rights needed.

This PR adds Scoop as a first-class install method for Windows:

- **`bucket/notion-sync.json`** — Scoop manifest with `checkver` (auto-detects new GitHub releases) and `autoupdate` (constructs download URL + reads hash from `checksums.txt`)
- **`.github/workflows/scoop-update.yml`** — On each release publish, downloads the Windows binary, computes its SHA256, updates the manifest, and commits to main
- **`.github/workflows/release.yml`** — Now generates `checksums.txt` (SHA256 for all binaries) and attaches it to the release
- **`README.md`** — Replaced the PowerShell install script with Scoop instructions

## How it works

1. Tag `v0.1.1` → release workflow builds binaries + `checksums.txt`
2. Release published → `scoop-update.yml` downloads the Windows binary, computes its hash, updates `bucket/notion-sync.json`, commits to main
3. Users install via:
   ```powershell
   scoop bucket add notion-sync https://github.com/ran-codes/notion-sync
   scoop install notion-sync
   ```

No manual hash editing required — the workflow handles everything automatically on each release.

## Test plan

- [ ] Merge to main and tag `v0.1.1`
- [ ] Verify release includes `checksums.txt`
- [ ] Verify `scoop-update.yml` runs and updates `bucket/notion-sync.json` with real hash
- [ ] Run `scoop bucket add notion-sync https://github.com/ran-codes/notion-sync`
- [ ] Run `scoop install notion-sync`
- [ ] Run `notion-sync --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)