### PR TITLE
Fix --out flag and argument ordering for import/refresh

### DIFF
--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -11,20 +11,37 @@ import (
 	"github.com/ran-codes/notion-sync/internal/sync"
 )
 
+// boolFlags lists flags that don't take a value argument.
+var boolFlags = map[string]bool{
+	"--force": true, "-f": true,
+}
+
 // reorderArgs moves flag arguments (starting with "-") before positional arguments
 // so that Go's flag package can parse them regardless of order.
 func reorderArgs(args []string) []string {
 	var flags, positional []string
 	for i := 0; i < len(args); i++ {
-		if strings.HasPrefix(args[i], "-") {
-			flags = append(flags, args[i])
-			// If next arg exists and doesn't start with "-", it's the flag's value
+		arg := args[i]
+
+		// "--" marks end of flags; keep everything after as positional.
+		if arg == "--" {
+			positional = append(positional, args[i:]...)
+			break
+		}
+
+		if strings.HasPrefix(arg, "-") {
+			flags = append(flags, arg)
+			// Don't consume next arg if flag already has "=" value or is boolean.
+			if strings.Contains(arg, "=") || boolFlags[arg] {
+				continue
+			}
+			// Consume next arg as the flag's value if it exists and isn't a flag.
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				flags = append(flags, args[i+1])
 				i++
 			}
 		} else {
-			positional = append(positional, args[i])
+			positional = append(positional, arg)
 		}
 	}
 	return append(flags, positional...)


### PR DESCRIPTION
## Summary
- Go's `flag` package stops parsing flags at the first non-flag argument, so `notion-sync import <id> --out ./folder` silently ignored `--out` and fell back to the default `./notion` output folder
- Added `reorderArgs()` helper that moves flag arguments before positional arguments before parsing, fixing this for both `import` and `refresh` commands
- Added `--out` as an alias for `--output` on the import command
- Fixed `reorderArgs()` to correctly handle boolean flags (`--force`/`-f`), `--flag=value` syntax, and `--` end-of-flags marker

## Test plan
- [x] Verified `notion-sync import <id> --out ./scratch` now creates files in `scratch/` instead of `notion/`
- [x] Verified `notion-sync refresh <folder> --force` correctly parses flags after positional arg
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)