### PR TITLE
Add --version flag with build-time injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
         run: |
-          go build -ldflags="-s -w" -o notion-sync-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/notion-sync
+          go build -ldflags="-s -w -X main.version=${GITHUB_REF_NAME#v}" -o notion-sync-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/notion-sync
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -11,6 +11,9 @@ import (
 	"github.com/ran-codes/notion-sync/internal/sync"
 )
 
+// version is set at build time via -ldflags.
+var version = "dev"
+
 // boolFlags lists flags that don't take a value argument.
 var boolFlags = map[string]bool{
 	"--force": true, "-f": true,
@@ -47,7 +50,7 @@ func reorderArgs(args []string) []string {
 	return append(flags, positional...)
 }
 
-const usage = `notion-sync — Sync Notion databases to Markdown
+var usage = `notion-sync — Sync Notion databases to Markdown (v` + version + `)
 
 Usage:
   notion-sync import <database-id> [--output <folder>] [--api-key <key>]
@@ -80,9 +83,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Handle help flags
+	// Handle help and version flags
 	if os.Args[1] == "--help" || os.Args[1] == "-h" {
 		fmt.Print(usage)
+		os.Exit(0)
+	}
+	if os.Args[1] == "--version" || os.Args[1] == "-v" {
+		fmt.Printf("notion-sync %s\n", version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Summary
- Added `--version` / `-v` global flag that prints the current version
- Added build-time version injection via `-ldflags -X main.version` in the release workflow
- Version also shown in `--help` output: `notion-sync — Sync Notion databases to Markdown (v0.1.2)`
- Local dev builds show `dev` as the version

## Test plan
- [x] `notion-sync --version` prints `notion-sync dev` for local builds
- [x] `notion-sync --version` prints `notion-sync 0.1.2` when built with `-ldflags "-X main.version=0.1.2"`
- [x] `notion-sync --help` first line includes version
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)