### PR TITLE
fix: refresh no longer re-syncs all pages on every run

### DIFF
--- a/internal/frontmatter/frontmatter_test.go
+++ b/internal/frontmatter/frontmatter_test.go
@@ -47,6 +47,28 @@ Body`,
 				"tags": []interface{}{"one", "two"},
 			},
 		},
+		{
+			name: "quoted ISO 8601 timestamp with milliseconds returns string",
+			content: `---
+notion-last-edited: "2025-01-15T10:30:00.000Z"
+---
+Body`,
+			expected: map[string]interface{}{
+				// Quoted strings stay as-is in yaml.v3 (already a string, not time.Time).
+				// timestampsEqual() handles .000Z vs Z comparison.
+				"notion-last-edited": "2025-01-15T10:30:00.000Z",
+			},
+		},
+		{
+			name: "unquoted ISO 8601 timestamp returns string",
+			content: `---
+notion-last-edited: 2025-01-15T10:30:00Z
+---
+Body`,
+			expected: map[string]interface{}{
+				"notion-last-edited": "2025-01-15T10:30:00Z",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/frontmatter/parser.go
+++ b/internal/frontmatter/parser.go
@@ -3,6 +3,7 @@ package frontmatter
 
 import (
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -26,7 +27,27 @@ func Parse(content string) (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	normalizeMapValues(result)
+
 	return result, nil
+}
+
+// normalizeMapValues converts any time.Time values back to RFC3339 strings.
+// yaml.v3 automatically parses ISO 8601 strings into time.Time, which breaks
+// downstream .(string) type assertions.
+func normalizeMapValues(m map[string]interface{}) {
+	for k, v := range m {
+		switch val := v.(type) {
+		case time.Time:
+			m[k] = val.Format(time.RFC3339)
+		case []interface{}:
+			for i, item := range val {
+				if t, ok := item.(time.Time); ok {
+					val[i] = t.Format(time.RFC3339)
+				}
+			}
+		}
+	}
 }
 
 // GetBody extracts the body content after frontmatter.

--- a/internal/sync/database.go
+++ b/internal/sync/database.go
@@ -206,7 +206,7 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 		}
 
 		if local, ok := localFiles[entry.ID]; ok {
-			if local.lastEdited == entry.LastEditedTime {
+			if timestampsEqual(local.lastEdited, entry.LastEditedTime) {
 				result.Skipped++
 				continue
 			}
@@ -327,6 +327,20 @@ func scanLocalFiles(folderPath string) (map[string]localFileInfo, error) {
 	}
 
 	return result, nil
+}
+
+// timestampsEqual compares two RFC3339 timestamp strings, tolerating
+// differences like ".000Z" vs "Z" that represent the same instant.
+func timestampsEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+	ta, errA := time.Parse(time.RFC3339Nano, a)
+	tb, errB := time.Parse(time.RFC3339Nano, b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return ta.Equal(tb)
 }
 
 func markAsDeleted(filePath string) error {

--- a/internal/sync/database_test.go
+++ b/internal/sync/database_test.go
@@ -140,6 +140,56 @@ func TestMarkAsDeleted_NoFrontmatter(t *testing.T) {
 	}
 }
 
+func TestTimestampsEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical strings", "2025-01-15T10:30:00Z", "2025-01-15T10:30:00Z", true},
+		{".000Z vs Z", "2025-01-15T10:30:00.000Z", "2025-01-15T10:30:00Z", true},
+		{"different times", "2025-01-15T10:30:00Z", "2025-01-15T11:00:00Z", false},
+		{"both empty", "", "", true},
+		{"one empty", "2025-01-15T10:30:00Z", "", false},
+		{"unparseable a", "not-a-time", "2025-01-15T10:30:00Z", false},
+		{"unparseable b", "2025-01-15T10:30:00Z", "not-a-time", false},
+		{"both unparseable", "nope", "nada", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := timestampsEqual(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("timestampsEqual(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanLocalFiles_MillisecondTimestamp(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a file with .000Z timestamp (what yaml.v3 might produce after normalization)
+	content := "---\nnotion-id: ms-page\nnotion-last-edited: 2025-06-01T12:00:00.000Z\n---\nBody\n"
+	os.WriteFile(filepath.Join(dir, "page.md"), []byte(content), 0644)
+
+	files, err := scanLocalFiles(dir)
+	if err != nil {
+		t.Fatalf("scanLocalFiles: %v", err)
+	}
+
+	info, ok := files["ms-page"]
+	if !ok {
+		t.Fatal("missing entry for ms-page")
+	}
+
+	// After normalization, .000Z should become Z
+	want := "2025-06-01T12:00:00Z"
+	if info.lastEdited != want {
+		t.Errorf("lastEdited = %q, want %q", info.lastEdited, want)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -48,7 +48,7 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 			fm, _ := frontmatter.Parse(string(content))
 			if fm != nil {
 				if storedEdited, ok := fm["notion-last-edited"].(string); ok {
-					if storedEdited == page.LastEditedTime {
+					if timestampsEqual(storedEdited, page.LastEditedTime) {
 						return &PageFreezeResult{Status: "skipped", FilePath: filePath, Title: safeName}, nil
 					}
 				}


### PR DESCRIPTION
## Summary

- **Normalize `time.Time` back to strings in frontmatter parser** — `yaml.v3` auto-parses ISO 8601 timestamps into `time.Time`, causing `.(string)` type assertions to fail silently and making every page look "stale"
- **Add `timestampsEqual()` for fuzzy RFC3339 comparison** — Notion's API sometimes returns `.000Z` vs `Z` for the same instant, so exact string equality is fragile
- **Use `timestampsEqual()` in both `RefreshDatabase` and `FreezePage`** skip paths

Fixes #9

## Test plan

- [x] `TestParse` — quoted and unquoted ISO 8601 timestamps return `string`, not `time.Time`
- [x] `TestTimestampsEqual` — 8 table-driven cases (identical, `.000Z` vs `Z`, different times, empty, unparseable)
- [x] `TestScanLocalFiles_MillisecondTimestamp` — end-to-end: `.md` file with `.000Z` is read and normalized
- [x] Full suite passes: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)