### PR TITLE
feat: add --ids flag to selectively refresh specific pages

### DIFF
--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -54,14 +54,15 @@ var usage = `notion-sync — Sync Notion databases to Markdown (v` + version + `
 
 Usage:
   notion-sync import <database-id> [--output <folder>] [--api-key <key>]
-  notion-sync refresh <database-folder> [--force] [--api-key <key>]
+  notion-sync refresh <database-folder> [--ids id1,id2] [--force] [--api-key <key>]
   notion-sync list [<output-folder>]
   notion-sync config set <key> <value>
 
 Commands:
   import    Import a Notion database to local Markdown files
   refresh   Refresh an existing synced database (incremental update)
-            --force, -f  Resync all entries, ignoring timestamps
+            --ids id1,id2  Refresh only specific pages by ID
+            --force, -f    Resync all entries, ignoring timestamps
   list      List all synced databases in a folder
   config    Manage configuration (apiKey, defaultOutputFolder)
 
@@ -213,6 +214,7 @@ func runRefresh(args []string) error {
 	apiKey := fs.String("api-key", "", "Notion API key")
 	force := fs.Bool("force", false, "Resync all entries, ignoring timestamps")
 	forceShort := fs.Bool("f", false, "Resync all entries (shorthand)")
+	ids := fs.String("ids", "", "Comma-separated Notion page IDs to refresh")
 
 	if err := fs.Parse(reorderArgs(args)); err != nil {
 		return err
@@ -220,7 +222,7 @@ func runRefresh(args []string) error {
 
 	if fs.NArg() == 0 {
 		return fmt.Errorf("missing database folder path\n" +
-			"Usage: notion-sync refresh <database-folder> [--force] [--api-key <key>]\n" +
+			"Usage: notion-sync refresh <database-folder> [--ids id1,id2] [--force] [--api-key <key>]\n" +
 			"Example: notion-sync refresh ./notion/My\\ Database")
 	}
 
@@ -240,9 +242,27 @@ func runRefresh(args []string) error {
 	folderPath := fs.Arg(0)
 	forceRefresh := *force || *forceShort
 
+	// Parse --ids flag
+	var pageIDs []string
+	if *ids != "" {
+		for _, raw := range strings.Split(*ids, ",") {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			normalized, err := notion.NormalizeNotionID(raw)
+			if err != nil {
+				return fmt.Errorf("invalid ID %q: %w", raw, err)
+			}
+			pageIDs = append(pageIDs, normalized)
+		}
+	}
+
 	client := notion.NewClient(key)
 
-	if forceRefresh {
+	if len(pageIDs) > 0 {
+		fmt.Printf("Refreshing %d specific page(s)...\n", len(pageIDs))
+	} else if forceRefresh {
 		fmt.Println("Force refreshing database (ignoring timestamps)...")
 	} else {
 		fmt.Println("Refreshing database...")
@@ -253,6 +273,7 @@ func runRefresh(args []string) error {
 		Client:     client,
 		FolderPath: folderPath,
 		Force:      forceRefresh,
+		PageIDs:    pageIDs,
 	}, func(p sync.ProgressPhase) {
 		if p.Phase == sync.PhaseImporting {
 			dbTitle = p.Title

--- a/internal/sync/database.go
+++ b/internal/sync/database.go
@@ -25,7 +25,8 @@ type DatabaseImportOptions struct {
 type RefreshOptions struct {
 	Client     *notion.Client
 	FolderPath string
-	Force      bool // Skip timestamp comparison and resync all entries
+	Force      bool     // Skip timestamp comparison and resync all entries
+	PageIDs    []string // If set, only refresh these specific page IDs
 }
 
 // FreshDatabaseImport imports all entries from a Notion database.
@@ -143,6 +144,63 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 
 	databaseID := metadata.DatabaseID
 
+	// --ids mode: fetch only specific pages, skip full query/diff/delete
+	if len(opts.PageIDs) > 0 {
+		total := len(opts.PageIDs)
+		dbTitle := metadata.Title
+
+		result := &DatabaseFreezeResult{
+			Title:      dbTitle,
+			FolderPath: opts.FolderPath,
+			Total:      total,
+		}
+
+		if onProgress != nil {
+			onProgress(ProgressPhase{Phase: PhaseStaleDetected, Stale: total, Total: total})
+		}
+
+		for i, pageID := range opts.PageIDs {
+			if onProgress != nil {
+				onProgress(ProgressPhase{Phase: PhaseImporting, Current: i + 1, Total: total, Title: dbTitle})
+			}
+
+			pageResult, err := FreezePage(FreezePageOptions{
+				Client:       opts.Client,
+				NotionID:     pageID,
+				OutputFolder: opts.FolderPath,
+				DatabaseID:   databaseID,
+				Force:        true,
+			})
+
+			if err != nil {
+				result.Failed++
+				result.Errors = append(result.Errors, fmt.Sprintf("Entry %s: %v", pageID, err))
+				continue
+			}
+
+			switch pageResult.Status {
+			case "created":
+				result.Created++
+			case "updated":
+				result.Updated++
+			case "skipped":
+				result.Skipped++
+			}
+		}
+
+		// Update metadata timestamp but preserve entry count
+		metadata.LastSyncedAt = time.Now().UTC().Format(time.RFC3339)
+		if err := WriteDatabaseMetadata(opts.FolderPath, metadata); err != nil {
+			return nil, fmt.Errorf("write metadata: %w", err)
+		}
+
+		if onProgress != nil {
+			onProgress(ProgressPhase{Phase: PhaseComplete})
+		}
+
+		return result, nil
+	}
+
 	if onProgress != nil {
 		onProgress(ProgressPhase{Phase: PhaseQuerying})
 	}
@@ -231,6 +289,7 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 			OutputFolder: opts.FolderPath,
 			DatabaseID:   databaseID,
 			Page:         &entry,
+			Force:        opts.Force,
 		})
 
 		if err != nil {

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -19,6 +19,7 @@ type FreezePageOptions struct {
 	OutputFolder string
 	DatabaseID   string
 	Page         *notion.Page // Pre-fetched page (optional)
+	Force        bool         // Skip timestamp check and always re-freeze
 }
 
 // FreezePage fetches a page from Notion and writes it as a Markdown file.
@@ -42,7 +43,7 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 
 	// Check for re-freeze: compare last_edited_time
 	exists := fileExists(filePath)
-	if exists {
+	if !opts.Force && exists {
 		content, err := os.ReadFile(filePath)
 		if err == nil {
 			fm, _ := frontmatter.Parse(string(content))


### PR DESCRIPTION
## Summary

- Adds `--ids id1,id2` flag to `notion-sync refresh` for targeted page re-downloads
- Pages specified via `--ids` always bypass FreezePage's timestamp check (`Force: true`), since the intent is to force re-download (e.g. reverse-relation changes that don't update `last_edited_time`)
- Also passes `Force` through to FreezePage in the normal `--force` path, closing a gap where `--force` skipped at the database level but FreezePage's inner timestamp check could still skip pages

## Test plan

Using **complex test database** (`2fe57008-e885-8003-b1f3-cc05981dc6b0`):

```sh
# Build local binary
go build ./cmd/notion-sync

# Setup: import the test database
./notion-sync.exe import 2fe57008-e885-8003-b1f3-cc05981dc6b0 --output ./test-output

# 1. Incremental refresh (no flags) — should skip all 25 pages (no changes)
./notion-sync.exe refresh "./test-output/test database obsdiain complex"

# 2. --ids single page — should re-download (updated: 1), never skip
./notion-sync.exe refresh "./test-output/test database obsdiain complex" --ids 2fe57008-e885-81c1-aadf-ffc79ed8b8af

# 3. --ids multiple pages — should re-download both (updated: 2)
./notion-sync.exe refresh "./test-output/test database obsdiain complex" --ids 2fe57008-e885-81c1-aadf-ffc79ed8b8af,2fe57008-e885-8187-8270-dea9ccb27b41

# 4. --force — should re-download all 25 pages (updated: 25), never skip
./notion-sync.exe refresh "./test-output/test database obsdiain complex" --force
```

| # | Command | Expected |
|---|---------|----------|
| 1 | `refresh` (no flags) | Skipped: 25, Updated: 0 |
| 2 | `refresh --ids <one>` | Updated: 1, Skipped: 0 |
| 3 | `refresh --ids <two>` | Updated: 2, Skipped: 0 |
| 4 | `refresh --force` | Updated: 25, Skipped: 0 |

- [x] `go build ./cmd/notion-sync` compiles
- [x] `go test ./...` all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)