### PR TITLE
Add API key validation and config get command

### DIFF
--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -158,10 +158,8 @@ func runImport(args []string) error {
 	if key == "" {
 		key = cfg.APIKey
 	}
-	if key == "" {
-		return fmt.Errorf("no API key provided.\n" +
-			"Set it via: notion-sync config set apiKey <key> (stored in OS keychain)\n" +
-			"Or pass --api-key <key>, or set NOTION_SYNC_API_KEY env var")
+	if msg := config.ValidateAPIKey(key); msg != "" {
+		return fmt.Errorf("%s", msg)
 	}
 
 	outputFolder := *output
@@ -286,8 +284,8 @@ func runRefresh(args []string) error {
 	if key == "" {
 		key = cfg.APIKey
 	}
-	if key == "" {
-		return fmt.Errorf("no API key provided")
+	if msg := config.ValidateAPIKey(key); msg != "" {
+		return fmt.Errorf("%s", msg)
 	}
 
 	folderPath := fs.Arg(0)
@@ -442,9 +440,20 @@ func runList(args []string) error {
 //// 2.4 Config ----
 
 func runConfig(args []string) error {
-	if len(args) < 3 || args[0] != "set" {
-		return fmt.Errorf("usage: notion-sync config set <key> <value>\n" +
-			"Keys: apiKey, defaultOutputFolder")
+	if len(args) == 0 {
+		return fmt.Errorf("usage: notion-sync config get [key]\n" +
+			"       notion-sync config set <key> <value>\n" +
+			"Keys: apiKey, defaultOutputFolder, outputMode")
+	}
+
+	if args[0] == "get" {
+		return runConfigGet(args[1:])
+	}
+
+	if args[0] != "set" || len(args) < 3 {
+		return fmt.Errorf("usage: notion-sync config get [key]\n" +
+			"       notion-sync config set <key> <value>\n" +
+			"Keys: apiKey, defaultOutputFolder, outputMode")
 	}
 
 	key := args[1]
@@ -463,12 +472,65 @@ func runConfig(args []string) error {
 		return fmt.Errorf("unknown config key: %s\nValid keys: %s", key, strings.Join(validKeys, ", "))
 	}
 
+	if key == "apiKey" {
+		if msg := config.ValidateAPIKey(value); msg != "" {
+			return fmt.Errorf("%s", msg)
+		}
+	}
+
 	if err := config.SaveConfig(key, value); err != nil {
 		return err
 	}
 
 	fmt.Printf("Saved %s\n", key)
 	return nil
+}
+
+func runConfigGet(args []string) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	// If a specific key is requested
+	if len(args) > 0 {
+		switch args[0] {
+		case "apiKey":
+			printAPIKeyStatus(cfg.APIKey)
+		case "defaultOutputFolder":
+			fmt.Println(cfg.DefaultOutputFolder)
+		case "outputMode":
+			if cfg.OutputMode == "" {
+				fmt.Println("(default: both)")
+			} else {
+				fmt.Println(cfg.OutputMode)
+			}
+		default:
+			return fmt.Errorf("unknown config key: %s", args[0])
+		}
+		return nil
+	}
+
+	// Show all config
+	fmt.Println("Config:")
+	fmt.Printf("  apiKey:              ")
+	printAPIKeyStatus(cfg.APIKey)
+	fmt.Printf("  defaultOutputFolder: %s\n", cfg.DefaultOutputFolder)
+	if cfg.OutputMode != "" {
+		fmt.Printf("  outputMode:          %s\n", cfg.OutputMode)
+	}
+	fmt.Printf("\n  Config file: %s\n", config.GetConfigPath())
+	return nil
+}
+
+func printAPIKeyStatus(key string) {
+	if key == "" {
+		fmt.Println("(not set)")
+	} else if len(key) > 8 {
+		fmt.Printf("...%s (set, %d chars)\n", key[len(key)-4:], len(key))
+	} else {
+		fmt.Printf("(set, %d chars)\n", len(key))
+	}
 }
 
 // 3. Helpers ----

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,6 +140,26 @@ func removeAPIKeyFromConfigFile() error {
 	return os.WriteFile(configPath, append(newData, '\n'), 0600)
 }
 
+// ValidateAPIKey checks if the key looks like a valid Notion API key.
+// Returns an error message if invalid, empty string if valid.
+func ValidateAPIKey(key string) string {
+	if key == "" {
+		return "no API key provided.\n" +
+			"Set it via: notion-sync config set apiKey <key> (stored in OS keychain)\n" +
+			"Or pass --api-key <key>, or set NOTION_SYNC_API_KEY env var"
+	}
+	if len(key) < 20 {
+		return fmt.Sprintf("API key is too short (%d chars). Notion API keys are ~50 characters and start with 'ntn_' or 'secret_'.\n"+
+			"Fix it via: notion-sync config set apiKey <your-key>", len(key))
+	}
+	hasValidPrefix := (len(key) >= 4 && key[:4] == "ntn_") || (len(key) >= 7 && key[:7] == "secret_")
+	if !hasValidPrefix {
+		return "API key has an unrecognized prefix. Notion API keys start with 'ntn_' or 'secret_'.\n" +
+			"Fix it via: notion-sync config set apiKey <your-key>"
+	}
+	return ""
+}
+
 // MigrateAPIKeyToKeychain migrates API key from config file to keyring.
 // Idempotent: skips if keychain already has a key or config file has none.
 func MigrateAPIKeyToKeychain() {


### PR DESCRIPTION
## Summary
- Add `ValidateAPIKey()` that checks key length (>=20 chars) and prefix (`ntn_` or `secret_`) with actionable error messages
- Validation runs on `import`, `refresh`, and `config set apiKey` — catches bad keys before any API call
- New `config get` command shows all config with masked API key (last 4 chars + length)

## Test plan
- [x] `./notion-sync.exe config get` — shows config with masked key
- [x] `./notion-sync.exe config get apiKey` — shows key status
- [x] `./notion-sync.exe config set apiKey bad` — rejects short key
- [x] `./notion-sync.exe import <id>` with bad key — clear validation error
- [x] `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)