### PR TITLE
Use UUID-based filenames with one-time migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ FreshDatabaseImport() or RefreshDatabase()
 Each synced database folder contains `_database.json`:
 
 ```json
-{ "databaseId": "...", "title": "...", "url": "...", "folderPath": "...", "lastSyncedAt": "...", "entryCount": N }
+{ "databaseId": "...", "title": "...", "url": "...", "folderPath": "...", "lastSyncedAt": "...", "entryCount": N, "syncVersion": "v0.4.0" }
 ```
 
 ### Progress Phases

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -100,6 +100,9 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Expose version to sync package for metadata
+	sync.Version = version
+
 	// Migrate API key on startup
 	config.MigrateAPIKeyToKeychain()
 

--- a/internal/sync/claudemd.go
+++ b/internal/sync/claudemd.go
@@ -13,9 +13,15 @@ This folder contains data synced from Notion using [notion-sync](https://github.
 
 Each synced Notion database gets its own subfolder containing:
 - Markdown files (one per page) with YAML frontmatter
-- ` + "`_database.json`" + ` — metadata (databaseId, title, url, lastSyncedAt, entryCount)
+- ` + "`_database.json`" + ` — metadata (databaseId, title, url, lastSyncedAt, entryCount, syncVersion)
 
 **Multi-source databases** (e.g. Notion databases with multiple linked sources) have an extra level of subfolders, one per data source.
+
+## Filenames
+
+Database entries use UUID-based filenames (` + "`{notion-id}.md`" + `). This makes filenames stable — renaming a page in Notion does not change the local filename. The page title is available in frontmatter.
+
+Standalone pages (imported via ` + "`notion-sync import --page`" + `) use title-based filenames.
 
 ## Frontmatter format
 
@@ -33,6 +39,10 @@ notion-url: "<url>"
 ## Soft deletes
 
 Pages removed from Notion are not deleted from disk. Instead, ` + "`notion-deleted: true`" + ` is added to frontmatter.
+
+## Migration notes
+
+**Title-based → UUID filenames (v0.4+):** Older versions used title-based filenames (e.g. ` + "`My Page.md`" + `). Migration to UUID filenames is automatic — just run ` + "`notion-sync refresh <folder>`" + ` and existing files are renamed in place. No manual steps required.
 `
 
 // WriteClaudeMD writes a generic CLAUDE.md to the workspace root.

--- a/internal/sync/database.go
+++ b/internal/sync/database.go
@@ -120,9 +120,8 @@ func FreshDatabaseImport(opts DatabaseImportOptions, onProgress ProgressCallback
 		if err != nil {
 			return nil, fmt.Errorf("query data source %s: %w", src.Title, err)
 		}
-		fileNameMap := buildFileNameMap(entries)
 		countBefore := result.Total
-		importEntries(opts.Client, entries, src.FolderPath, opts.DatabaseID, result, src.Title, onProgress, fileNameMap)
+		importEntries(opts.Client, entries, src.FolderPath, opts.DatabaseID, result, src.Title, onProgress)
 
 		// Write per-source metadata for multi-source databases
 		if len(sources) > 1 {
@@ -169,40 +168,6 @@ func FreshDatabaseImport(opts DatabaseImportOptions, onProgress ProgressCallback
 	return result, nil
 }
 
-// buildFileNameMap detects duplicate titles among entries and returns a map of
-// pageID → disambiguated filename (without .md extension) for pages that need renaming.
-// Pages with unique titles are not included in the map (empty string = use default).
-func buildFileNameMap(entries []notion.Page) map[string]string {
-	// Count occurrences of each sanitized name
-	type pageInfo struct {
-		id       string
-		safeName string
-	}
-	var pages []pageInfo
-	nameCount := make(map[string]int)
-
-	for _, entry := range entries {
-		title := getPageTitle(&entry)
-		safeName := util.SanitizeFileName(title)
-		if safeName == "" {
-			safeName = "Untitled"
-		}
-		pages = append(pages, pageInfo{id: entry.ID, safeName: safeName})
-		nameCount[safeName]++
-	}
-
-	// Build map for duplicates only
-	result := make(map[string]string)
-	for _, p := range pages {
-		if nameCount[p.safeName] >= 2 {
-			// Remove dashes from notion ID for the suffix
-			cleanID := strings.ReplaceAll(p.id, "-", "")
-			result[p.id] = p.safeName + "-" + cleanID
-		}
-	}
-	return result
-}
-
 // importEntries processes a batch of entries, updating result counters and calling onProgress.
 func importEntries(
 	client NotionClient,
@@ -211,7 +176,6 @@ func importEntries(
 	result *DatabaseFreezeResult,
 	title string,
 	onProgress ProgressCallback,
-	fileNameMap map[string]string,
 ) {
 	total := len(entries)
 	startIdx := result.Total
@@ -227,12 +191,11 @@ func importEntries(
 		}
 
 		pageResult, err := FreezePage(FreezePageOptions{
-			Client:           client,
-			NotionID:         entry.ID,
-			OutputFolder:     folderPath,
-			DatabaseID:       databaseID,
-			Page:             &entry,
-			OverrideFileName: fileNameMap[entry.ID],
+			Client:       client,
+			NotionID:     entry.ID,
+			OutputFolder: folderPath,
+			DatabaseID:   databaseID,
+			Page:         &entry,
 		})
 
 		if err != nil {
@@ -283,8 +246,15 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 		log.Printf("warning: failed to write CLAUDE.md: %v", err)
 	}
 
+	// Clean up legacy SQLite database files (removed in v0.3)
+	removeLegacySQLite(workspacePath)
+
 	// --ids mode: fetch only specific pages, skip full query/diff/delete
 	if len(opts.PageIDs) > 0 {
+		// Migrate any existing title-based filenames to UUID-based.
+		localFiles, _ := scanLocalFiles(opts.FolderPath)
+		migrateToUUIDFilenames(opts.FolderPath, localFiles)
+
 		total := len(opts.PageIDs)
 		dbTitle := metadata.Title
 
@@ -372,7 +342,6 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 	}
 
 	total := len(entries)
-	fileNameMap := buildFileNameMap(entries)
 
 	if onProgress != nil {
 		onProgress(ProgressPhase{Phase: PhaseDiffing, Total: total})
@@ -383,6 +352,9 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 	if err != nil {
 		return nil, fmt.Errorf("scan local files: %w", err)
 	}
+
+	// Migrate title-based filenames to UUID-based filenames (one-time).
+	migrateToUUIDFilenames(opts.FolderPath, localFiles)
 
 	// Track results
 	result := &DatabaseFreezeResult{
@@ -426,13 +398,12 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 		}
 
 		pageResult, err := FreezePage(FreezePageOptions{
-			Client:           opts.Client,
-			NotionID:         entry.ID,
-			OutputFolder:     opts.FolderPath,
-			DatabaseID:       databaseID,
-			Page:             &entry,
-			Force:            opts.Force,
-			OverrideFileName: fileNameMap[entry.ID],
+			Client:       opts.Client,
+			NotionID:     entry.ID,
+			OutputFolder: opts.FolderPath,
+			DatabaseID:   databaseID,
+			Page:         &entry,
+			Force:        opts.Force,
 		})
 
 		if err != nil {
@@ -448,18 +419,6 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 			result.Updated++
 		case "skipped":
 			result.Skipped++
-		}
-	}
-
-	// Clean up orphaned files from filename disambiguation.
-	// If a page was previously saved as "Title.md" but now needs "Title-{id}.md",
-	// remove the old file to avoid duplicates.
-	for id, info := range localFiles {
-		if override, ok := fileNameMap[id]; ok {
-			newPath := filepath.Join(opts.FolderPath, override+".md")
-			if info.filePath != newPath {
-				os.Remove(info.filePath)
-			}
 		}
 	}
 
@@ -496,6 +455,41 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 type localFileInfo struct {
 	filePath   string
 	lastEdited string
+}
+
+// removeLegacySQLite deletes leftover _notion_sync.sqlite and _notion_sync.db
+// files from the workspace root. These were removed in v0.3.
+func removeLegacySQLite(workspacePath string) {
+	for _, name := range []string{"_notion_sync.sqlite", "_notion_sync.db"} {
+		p := filepath.Join(workspacePath, name)
+		if _, err := os.Stat(p); err == nil {
+			if err := os.Remove(p); err == nil {
+				log.Printf("removed legacy %s", name)
+			}
+		}
+	}
+}
+
+// migrateToUUIDFilenames renames title-based .md files to UUID-based filenames.
+// For each file in localFiles, if the filename doesn't match "{notion-id}.md",
+// it renames the file and updates the map entry in place.
+func migrateToUUIDFilenames(folderPath string, localFiles map[string]localFileInfo) {
+	for notionID, info := range localFiles {
+		expectedName := notionID + ".md"
+		expectedPath := filepath.Join(folderPath, expectedName)
+		if info.filePath == expectedPath {
+			continue
+		}
+		if err := os.Rename(info.filePath, expectedPath); err != nil {
+			log.Printf("warning: failed to rename %s to %s: %v", filepath.Base(info.filePath), expectedName, err)
+			continue
+		}
+		log.Printf("migrated: %s -> %s", filepath.Base(info.filePath), expectedName)
+		localFiles[notionID] = localFileInfo{
+			filePath:   expectedPath,
+			lastEdited: info.lastEdited,
+		}
+	}
 }
 
 func scanLocalFiles(folderPath string) (map[string]localFileInfo, error) {

--- a/internal/sync/database_integration_test.go
+++ b/internal/sync/database_integration_test.go
@@ -146,17 +146,11 @@ func TestRefreshDatabase_DeletionDetection(t *testing.T) {
 	}
 	mock.dataSources[dsID] = &notion.DataSourceDetail{ID: dsID}
 
-	// Write 3 local .md files
-	pages := []struct {
-		id, title string
-	}{
-		{"page-1", "Page One"},
-		{"page-2", "Page Two"},
-		{"page-3", "Page Three"},
-	}
-	for _, p := range pages {
-		content := "---\nnotion-id: " + p.id + "\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\nnotion-database-id: " + dbID + "\n---\nBody\n"
-		os.WriteFile(filepath.Join(dbFolder, p.title+".md"), []byte(content), 0644)
+	// Write 3 local .md files (UUID-based filenames)
+	pageIDs := []string{"page-1", "page-2", "page-3"}
+	for _, id := range pageIDs {
+		content := "---\nnotion-id: " + id + "\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\nnotion-database-id: " + dbID + "\n---\nBody\n"
+		os.WriteFile(filepath.Join(dbFolder, id+".md"), []byte(content), 0644)
 	}
 
 	// Write _database.json
@@ -189,7 +183,7 @@ func TestRefreshDatabase_DeletionDetection(t *testing.T) {
 	}
 
 	// Verify the deleted page's .md has notion-deleted: true
-	data, err := os.ReadFile(filepath.Join(dbFolder, "Page Two.md"))
+	data, err := os.ReadFile(filepath.Join(dbFolder, "page-2.md"))
 	if err != nil {
 		t.Fatalf("read deleted file: %v", err)
 	}
@@ -240,9 +234,9 @@ func TestRefreshMultiSource_Aggregation(t *testing.T) {
 		Title:        "Source1",
 		FolderPath:   sub1,
 	})
-	for _, p := range []struct{ id, title string }{{"p1", "Page1"}, {"p2", "Page2"}} {
-		content := "---\nnotion-id: " + p.id + "\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\n---\nBody\n"
-		os.WriteFile(filepath.Join(sub1, p.title+".md"), []byte(content), 0644)
+	for _, id := range []string{"p1", "p2"} {
+		content := "---\nnotion-id: " + id + "\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\n---\nBody\n"
+		os.WriteFile(filepath.Join(sub1, id+".md"), []byte(content), 0644)
 	}
 
 	// Create subfolder2 with 1 page
@@ -255,7 +249,7 @@ func TestRefreshMultiSource_Aggregation(t *testing.T) {
 		FolderPath:   sub2,
 	})
 	content := "---\nnotion-id: p3\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\n---\nBody\n"
-	os.WriteFile(filepath.Join(sub2, "Page3.md"), []byte(content), 0644)
+	os.WriteFile(filepath.Join(sub2, "p3.md"), []byte(content), 0644)
 
 	// Top-level metadata (no dataSourceId)
 	WriteDatabaseMetadata(dbFolder, &FrozenDatabase{
@@ -328,10 +322,10 @@ func TestFreshImport_Markdown(t *testing.T) {
 		t.Errorf("Created = %d, want 1", result.Created)
 	}
 
-	// .md file should exist
-	mdPath := filepath.Join(dir, "MarkdownDB", "TestPage.md")
+	// .md file should exist with UUID filename
+	mdPath := filepath.Join(dir, "MarkdownDB", "p1.md")
 	if _, err := os.Stat(mdPath); os.IsNotExist(err) {
-		t.Error("expected .md file to exist")
+		t.Error("expected p1.md file to exist")
 	}
 }
 
@@ -377,59 +371,49 @@ func TestFreshImport_DuplicateTitles(t *testing.T) {
 
 	dbFolder := filepath.Join(dir, "DupDB")
 
-	// "Same Name.md" should NOT exist (both pages need disambiguation)
-	if _, err := os.Stat(filepath.Join(dbFolder, "Same Name.md")); !os.IsNotExist(err) {
-		t.Error("expected 'Same Name.md' to NOT exist (should be disambiguated)")
+	// All files should use UUID filenames
+	expectedFiles := []struct {
+		id       string
+		filename string
+	}{
+		{"aaaa1111-2222-3333-4444-555566667777", "aaaa1111-2222-3333-4444-555566667777.md"},
+		{"bbbb1111-2222-3333-4444-555566667777", "bbbb1111-2222-3333-4444-555566667777.md"},
+		{"cccc1111-2222-3333-4444-555566667777", "cccc1111-2222-3333-4444-555566667777.md"},
 	}
 
-	// Both disambiguated files should exist
-	file1 := filepath.Join(dbFolder, "Same Name-aaaa111122223333444455556666777.md")
-	file2 := filepath.Join(dbFolder, "Same Name-bbbb111122223333444455556666777.md")
-
-	// Use glob since the exact dash-removal may vary
-	matches, _ := filepath.Glob(filepath.Join(dbFolder, "Same Name-*.md"))
-	if len(matches) != 2 {
-		t.Fatalf("expected 2 'Same Name-*.md' files, got %d: %v", len(matches), matches)
-	}
-
-	// Verify both have different notion-ids
-	ids := map[string]bool{}
-	for _, f := range matches {
-		data, err := os.ReadFile(f)
+	for _, ef := range expectedFiles {
+		path := filepath.Join(dbFolder, ef.filename)
+		data, err := os.ReadFile(path)
 		if err != nil {
-			t.Fatalf("read %s: %v", f, err)
+			t.Fatalf("expected %s to exist: %v", ef.filename, err)
 		}
 		fm, err := frontmatter.Parse(string(data))
 		if err != nil {
-			t.Fatalf("parse %s: %v", f, err)
+			t.Fatalf("parse %s: %v", ef.filename, err)
 		}
 		id, ok := fm["notion-id"].(string)
-		if !ok || id == "" {
-			t.Errorf("missing notion-id in %s", f)
+		if !ok || id != ef.id {
+			t.Errorf("%s: notion-id = %q, want %q", ef.filename, id, ef.id)
 		}
-		ids[id] = true
-	}
-	if len(ids) != 2 {
-		t.Errorf("expected 2 unique notion-ids, got %d", len(ids))
 	}
 
-	// "Unique.md" should exist with clean name
-	if _, err := os.Stat(filepath.Join(dbFolder, "Unique.md")); os.IsNotExist(err) {
-		t.Error("expected 'Unique.md' to exist (unique title, no disambiguation)")
+	// No title-based files should exist
+	if _, err := os.Stat(filepath.Join(dbFolder, "Same Name.md")); !os.IsNotExist(err) {
+		t.Error("expected 'Same Name.md' to NOT exist")
 	}
-
-	_ = file1
-	_ = file2
+	if _, err := os.Stat(filepath.Join(dbFolder, "Unique.md")); !os.IsNotExist(err) {
+		t.Error("expected 'Unique.md' to NOT exist")
+	}
 }
 
-func TestRefresh_DuplicateTitleRename(t *testing.T) {
+func TestRefresh_MigratesToUUIDFilenames(t *testing.T) {
 	dir := t.TempDir()
 	dbFolder := filepath.Join(dir, "TestDB")
 	os.MkdirAll(dbFolder, 0755)
 
 	mock := newMockClient()
-	dbID := "db-dup-rename"
-	dsID := "ds-dup-rename"
+	dbID := "db-migrate"
+	dsID := "ds-migrate"
 
 	mock.databases[dbID] = &notion.Database{
 		ID:    dbID,
@@ -444,9 +428,11 @@ func TestRefresh_DuplicateTitleRename(t *testing.T) {
 	pageAID := "aaaa0000-1111-2222-3333-444455556666"
 	pageBID := "bbbb0000-1111-2222-3333-444455556666"
 
-	// Pre-existing local file: PageA.md with notion-id page-a
-	oldContent := "---\nnotion-id: " + pageAID + "\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\nnotion-database-id: " + dbID + "\n---\nOld body\n"
-	os.WriteFile(filepath.Join(dbFolder, "PageA.md"), []byte(oldContent), 0644)
+	// Pre-existing local files with title-based names
+	contentA := "---\nnotion-id: " + pageAID + "\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\nnotion-database-id: " + dbID + "\n---\nBody A\n"
+	contentB := "---\nnotion-id: " + pageBID + "\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\nnotion-database-id: " + dbID + "\n---\nBody B\n"
+	os.WriteFile(filepath.Join(dbFolder, "PageA.md"), []byte(contentA), 0644)
+	os.WriteFile(filepath.Join(dbFolder, "PageB.md"), []byte(contentB), 0644)
 
 	// Write _database.json
 	WriteDatabaseMetadata(dbFolder, &FrozenDatabase{
@@ -456,43 +442,40 @@ func TestRefresh_DuplicateTitleRename(t *testing.T) {
 		FolderPath:   dbFolder,
 	})
 
-	// Now mock returns 2 entries both titled "PageA" — triggers disambiguation
+	// Mock returns same entries, timestamps match → will be skipped after migration
 	mock.entries[dsID] = []notion.Page{
-		testPage(pageAID, "PageA", "2025-01-02T00:00:00Z"), // newer timestamp → will be processed
-		testPage(pageBID, "PageA", "2025-01-01T00:00:00Z"),
+		testPage(pageAID, "PageA", "2025-01-01T00:00:00Z"),
+		testPage(pageBID, "PageB", "2025-01-01T00:00:00Z"),
 	}
-	mock.blocks[pageAID] = []notion.Block{
-		{Type: "paragraph", Paragraph: &notion.ParagraphBlock{
-			RichText: []notion.RichText{{Type: "text", PlainText: "Body A", Text: &notion.TextContent{Content: "Body A"}}},
-		}},
-	}
-	mock.blocks[pageBID] = []notion.Block{
-		{Type: "paragraph", Paragraph: &notion.ParagraphBlock{
-			RichText: []notion.RichText{{Type: "text", PlainText: "Body B", Text: &notion.TextContent{Content: "Body B"}}},
-		}},
-	}
+	mock.blocks[pageAID] = []notion.Block{}
+	mock.blocks[pageBID] = []notion.Block{}
 
 	result, err := RefreshDatabase(RefreshOptions{
 		Client:     mock,
 		FolderPath: dbFolder,
-		Force:      true,
 	}, nil)
 	if err != nil {
 		t.Fatalf("RefreshDatabase: %v", err)
 	}
 
-	if result.Updated+result.Created != 2 {
-		t.Errorf("Updated+Created = %d, want 2", result.Updated+result.Created)
+	// Both should be skipped (timestamps match, migration just renames)
+	if result.Skipped != 2 {
+		t.Errorf("Skipped = %d, want 2", result.Skipped)
 	}
 
-	// Old "PageA.md" should be gone
+	// Old title-based files should be gone
 	if _, err := os.Stat(filepath.Join(dbFolder, "PageA.md")); !os.IsNotExist(err) {
 		t.Error("expected old 'PageA.md' to be removed")
 	}
+	if _, err := os.Stat(filepath.Join(dbFolder, "PageB.md")); !os.IsNotExist(err) {
+		t.Error("expected old 'PageB.md' to be removed")
+	}
 
-	// Two disambiguated files should exist
-	matches, _ := filepath.Glob(filepath.Join(dbFolder, "PageA-*.md"))
-	if len(matches) != 2 {
-		t.Fatalf("expected 2 'PageA-*.md' files, got %d: %v", len(matches), matches)
+	// UUID-named files should exist
+	if _, err := os.Stat(filepath.Join(dbFolder, pageAID+".md")); os.IsNotExist(err) {
+		t.Errorf("expected %s.md to exist", pageAID)
+	}
+	if _, err := os.Stat(filepath.Join(dbFolder, pageBID+".md")); os.IsNotExist(err) {
+		t.Errorf("expected %s.md to exist", pageBID)
 	}
 }

--- a/internal/sync/database_test.go
+++ b/internal/sync/database_test.go
@@ -3,10 +3,7 @@ package sync
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-
-	"github.com/ran-codes/notion-sync/internal/notion"
 )
 
 func TestScanLocalFiles(t *testing.T) {
@@ -278,81 +275,54 @@ func TestFindSubSourceFolders_Mixed(t *testing.T) {
 	}
 }
 
-func TestBuildFileNameMap_NoDuplicates(t *testing.T) {
-	entries := []notion.Page{
-		testPage("aaa-111", "Alpha", "2025-01-01T00:00:00Z"),
-		testPage("bbb-222", "Beta", "2025-01-01T00:00:00Z"),
-		testPage("ccc-333", "Gamma", "2025-01-01T00:00:00Z"),
+func TestMigrateToUUIDFilenames(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a title-based file with notion-id in frontmatter
+	content := "---\nnotion-id: abc-123\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\n---\nBody\n"
+	os.WriteFile(filepath.Join(dir, "My Page.md"), []byte(content), 0644)
+
+	localFiles, err := scanLocalFiles(dir)
+	if err != nil {
+		t.Fatalf("scanLocalFiles: %v", err)
 	}
-	m := buildFileNameMap(entries)
-	if len(m) != 0 {
-		t.Errorf("expected empty map for unique titles, got %d entries: %v", len(m), m)
+
+	migrateToUUIDFilenames(dir, localFiles)
+
+	// Old file should be gone
+	if _, err := os.Stat(filepath.Join(dir, "My Page.md")); !os.IsNotExist(err) {
+		t.Error("expected 'My Page.md' to be removed after migration")
+	}
+
+	// UUID file should exist
+	uuidPath := filepath.Join(dir, "abc-123.md")
+	if _, err := os.Stat(uuidPath); os.IsNotExist(err) {
+		t.Error("expected 'abc-123.md' to exist after migration")
+	}
+
+	// Map should be updated
+	if localFiles["abc-123"].filePath != uuidPath {
+		t.Errorf("localFiles path = %q, want %q", localFiles["abc-123"].filePath, uuidPath)
 	}
 }
 
-func TestBuildFileNameMap_TwoDuplicates(t *testing.T) {
-	entries := []notion.Page{
-		testPage("aaa-111", "Hello", "2025-01-01T00:00:00Z"),
-		testPage("bbb-222", "Hello", "2025-01-01T00:00:00Z"),
-		testPage("ccc-333", "World", "2025-01-01T00:00:00Z"),
-	}
-	m := buildFileNameMap(entries)
+func TestMigrateToUUIDFilenames_AlreadyUUID(t *testing.T) {
+	dir := t.TempDir()
 
-	// Both "Hello" pages should be in the map
-	if len(m) != 2 {
-		t.Fatalf("expected 2 entries, got %d: %v", len(m), m)
-	}
-	if m["aaa-111"] != "Hello-aaa111" {
-		t.Errorf("aaa-111 = %q, want Hello-aaa111", m["aaa-111"])
-	}
-	if m["bbb-222"] != "Hello-bbb222" {
-		t.Errorf("bbb-222 = %q, want Hello-bbb222", m["bbb-222"])
-	}
-	// "World" should NOT be in the map
-	if _, ok := m["ccc-333"]; ok {
-		t.Error("ccc-333 (unique title) should not be in the map")
-	}
-}
+	// Write a file already named by UUID
+	content := "---\nnotion-id: abc-123\nnotion-last-edited: \"2025-01-01T00:00:00Z\"\n---\nBody\n"
+	os.WriteFile(filepath.Join(dir, "abc-123.md"), []byte(content), 0644)
 
-func TestBuildFileNameMap_ThreeDuplicates(t *testing.T) {
-	entries := []notion.Page{
-		testPage("a1a1-b2b2", "Dup", "2025-01-01T00:00:00Z"),
-		testPage("c3c3-d4d4", "Dup", "2025-01-01T00:00:00Z"),
-		testPage("e5e5-f6f6", "Dup", "2025-01-01T00:00:00Z"),
+	localFiles, err := scanLocalFiles(dir)
+	if err != nil {
+		t.Fatalf("scanLocalFiles: %v", err)
 	}
-	m := buildFileNameMap(entries)
-	if len(m) != 3 {
-		t.Fatalf("expected 3 entries, got %d: %v", len(m), m)
-	}
-	for _, entry := range entries {
-		cleanID := strings.ReplaceAll(entry.ID, "-", "")
-		want := "Dup-" + cleanID
-		if m[entry.ID] != want {
-			t.Errorf("%s = %q, want %q", entry.ID, m[entry.ID], want)
-		}
-	}
-}
 
-func TestBuildFileNameMap_UntitledCollision(t *testing.T) {
-	// Two pages with empty titles → both become "Untitled"
-	p1 := testPage("id-1", "", "2025-01-01T00:00:00Z")
-	p1.Properties = map[string]notion.Property{
-		"Name": {Type: "title", Title: []notion.RichText{}},
-	}
-	p2 := testPage("id-2", "", "2025-01-01T00:00:00Z")
-	p2.Properties = map[string]notion.Property{
-		"Name": {Type: "title", Title: []notion.RichText{}},
-	}
-	entries := []notion.Page{p1, p2}
-	m := buildFileNameMap(entries)
-	if len(m) != 2 {
-		t.Fatalf("expected 2 entries, got %d: %v", len(m), m)
-	}
-	if m["id-1"] != "Untitled-id1" {
-		t.Errorf("id-1 = %q, want Untitled-id1", m["id-1"])
-	}
-	if m["id-2"] != "Untitled-id2" {
-		t.Errorf("id-2 = %q, want Untitled-id2", m["id-2"])
+	migrateToUUIDFilenames(dir, localFiles)
+
+	// File should still exist unchanged
+	if _, err := os.Stat(filepath.Join(dir, "abc-123.md")); os.IsNotExist(err) {
+		t.Error("expected 'abc-123.md' to still exist")
 	}
 }
 

--- a/internal/sync/metadata.go
+++ b/internal/sync/metadata.go
@@ -34,6 +34,10 @@ func ReadDatabaseMetadata(folderPath string) (*FrozenDatabase, error) {
 func WriteDatabaseMetadata(folderPath string, metadata *FrozenDatabase) error {
 	metaPath := filepath.Join(folderPath, DatabaseMetadataFile)
 
+	if Version != "" {
+		metadata.SyncVersion = Version
+	}
+
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
 		return err
@@ -66,6 +70,10 @@ func ReadPageMetadata(folderPath string) (*FrozenPage, error) {
 // WritePageMetadata writes _page.json to a folder.
 func WritePageMetadata(folderPath string, metadata *FrozenPage) error {
 	metaPath := filepath.Join(folderPath, PageMetadataFile)
+
+	if Version != "" {
+		metadata.SyncVersion = Version
+	}
 
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -16,13 +16,12 @@ import (
 
 // FreezePageOptions contains options for freezing a page.
 type FreezePageOptions struct {
-	Client           NotionClient
-	NotionID         string
-	OutputFolder     string
-	DatabaseID       string
-	Page             *notion.Page // Pre-fetched page (optional)
-	Force            bool         // Skip timestamp check and always re-freeze
-	OverrideFileName string       // If set, use this instead of computing from title (without .md extension)
+	Client       NotionClient
+	NotionID     string
+	OutputFolder string
+	DatabaseID   string
+	Page         *notion.Page // Pre-fetched page (optional)
+	Force        bool         // Skip timestamp check and always re-freeze
 }
 
 // FreezePage fetches a page from Notion and writes it as a Markdown file.
@@ -38,14 +37,19 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 	}
 
 	title := getPageTitle(page)
-	safeName := opts.OverrideFileName
-	if safeName == "" {
-		safeName = util.SanitizeFileName(title)
+
+	var filePath string
+	if opts.DatabaseID != "" {
+		// Database entry: use UUID filename
+		filePath = filepath.Join(opts.OutputFolder, opts.NotionID+".md")
+	} else {
+		// Standalone page: keep title-based filename
+		safeName := util.SanitizeFileName(title)
 		if safeName == "" {
 			safeName = "Untitled"
 		}
+		filePath = filepath.Join(opts.OutputFolder, safeName+".md")
 	}
-	filePath := filepath.Join(opts.OutputFolder, safeName+".md")
 
 	// Check for re-freeze: compare last_edited_time
 	exists := fileExists(filePath)
@@ -65,7 +69,7 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 		}
 
 		if exists && storedEdited != "" && timestampsEqual(storedEdited, page.LastEditedTime) {
-			return &PageFreezeResult{Status: "skipped", FilePath: filePath, Title: safeName}, nil
+			return &PageFreezeResult{Status: "skipped", FilePath: filePath, Title: title}, nil
 		}
 	}
 
@@ -136,7 +140,7 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 		status = "updated"
 	}
 
-	return &PageFreezeResult{Status: status, FilePath: filePath, Title: safeName}, nil
+	return &PageFreezeResult{Status: status, FilePath: filePath, Title: title}, nil
 }
 
 // StandalonePageImportOptions contains options for importing a standalone page.
@@ -261,7 +265,9 @@ func mapPropertiesToFrontmatter(properties map[string]notion.Property, fm map[st
 	for key, prop := range properties {
 		switch prop.Type {
 		case "title":
-			// Already used as filename, skip
+			if len(prop.Title) > 0 {
+				fm[key] = markdown.ConvertRichText(prop.Title)
+			}
 
 		case "rich_text":
 			fm[key] = markdown.ConvertRichText(prop.RichText)

--- a/internal/sync/page_test.go
+++ b/internal/sync/page_test.go
@@ -165,9 +165,9 @@ func TestMapPropertiesToFrontmatter(t *testing.T) {
 	fm := map[string]interface{}{}
 	mapPropertiesToFrontmatter(props, fm)
 
-	// Title should be skipped (used as filename)
-	if _, ok := fm["Name"]; ok {
-		t.Error("title property should not be in frontmatter")
+	// Title should be included in frontmatter
+	if fm["Name"] != "Test" {
+		t.Errorf("Name = %v, want \"Test\"", fm["Name"])
 	}
 
 	assertFM := func(key string, want interface{}) {

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -1,5 +1,8 @@
 package sync
 
+// Version is set by main.go at startup from the build-time version string.
+var Version string
+
 // FrozenDatabase represents metadata stored in _database.json.
 type FrozenDatabase struct {
 	DatabaseID   string `json:"databaseId"`
@@ -9,6 +12,7 @@ type FrozenDatabase struct {
 	FolderPath   string `json:"folderPath"`
 	LastSyncedAt string `json:"lastSyncedAt"`
 	EntryCount   int    `json:"entryCount"`
+	SyncVersion  string `json:"syncVersion,omitempty"`
 }
 
 // FrozenPage represents metadata stored in _page.json for standalone pages.
@@ -18,6 +22,7 @@ type FrozenPage struct {
 	URL          string `json:"url"`
 	FolderPath   string `json:"folderPath"`
 	LastSyncedAt string `json:"lastSyncedAt"`
+	SyncVersion  string `json:"syncVersion,omitempty"`
 }
 
 // DatabaseFreezeResult represents the result of a database sync operation.


### PR DESCRIPTION
## Context
- Title-based filenames cause orphaned files when pages are renamed in Notion, require complex duplicate disambiguation logic (`buildFileNameMap`), and don't allow deterministic file lookup
- Primary consumers are agents, so human-readable filenames aren't needed
- Existing synced folders need a seamless migration path from title-based to UUID-based names

See #39, See #40

## Changes
- **UUID filenames**: `FreezePage` now uses `{notion-id}.md` for database entries; standalone pages keep title-based naming
- **Removed disambiguation**: deleted `buildFileNameMap()`, `OverrideFileName` field, and orphan cleanup block (~47 lines removed)
- **One-time migration**: [`migrateToUUIDFilenames()`](https://github.com/ran-codes/notion-sync/blob/b705ddbe902f183b5386ae804d0e0960c6f3f196/internal/sync/database.go#L476) renames existing title-based files to UUID during refresh, updating the local file map in-place
- **Title in frontmatter**: title property is now written to frontmatter instead of being skipped (discoverable in UUID-named files)
- **Legacy SQLite cleanup**: [`removeLegacySQLite()`](https://github.com/ran-codes/notion-sync/blob/b705ddbe902f183b5386ae804d0e0960c6f3f196/internal/sync/database.go#L462) deletes leftover `_notion_sync.sqlite`/`.db` files during refresh
- **`syncVersion` in metadata**: [`_database.json`](https://github.com/ran-codes/notion-sync/blob/b705ddbe902f183b5386ae804d0e0960c6f3f196/internal/sync/types.go#L7) and `_page.json` now record which notion-sync version produced them
- **Agent migration doc**: workspace [`CLAUDE.md`](https://github.com/ran-codes/notion-sync/blob/b705ddbe902f183b5386ae804d0e0960c6f3f196/internal/sync/claudemd.go#L8) updated with UUID filename scheme and migration notes (automatic on `refresh`)
- **Tests**: replaced 4 `buildFileNameMap` tests with 2 migration tests; updated 5 integration tests for UUID filenames

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)