### PR TITLE
feat: push command — reverse sync frontmatter properties to Notion

### DIFF
--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -77,7 +77,7 @@ Commands:
   push      Push local frontmatter property changes back to Notion (properties only, no body)
             Refuses to push files where Notion has been edited since last sync, unless --force.
             --force, -f    Push even if Notion has newer edits (overwrites Notion-side changes)
-            --dry-run      Show what would be pushed without writing to Notion
+            --dry-run      Show what would be pushed without writing to Notion (still reads from Notion for conflict detection)
   list      List all synced databases and pages in a folder
   clean     Strip AWS S3 pre-signed query strings from existing .md files in a folder.
             Useful one-time backfill after upgrading. No API calls.
@@ -415,7 +415,7 @@ func runPush(args []string) error {
 	apiKey := fs.String("api-key", "", "Notion API key")
 	force := fs.Bool("force", false, "Push even if Notion has newer edits")
 	forceShort := fs.Bool("f", false, "Push even if Notion has newer edits (shorthand)")
-	dryRun := fs.Bool("dry-run", false, "Show what would be pushed without writing")
+	dryRun := fs.Bool("dry-run", false, "Show what would be pushed without writing to Notion")
 
 	if err := fs.Parse(reorderArgs(args)); err != nil {
 		return err
@@ -479,7 +479,11 @@ func runPush(args []string) error {
 		fmt.Printf("Done: \"%s\"\n", result.Title)
 	}
 	fmt.Printf("  Total:     %d\n", result.Total)
-	fmt.Printf("  Pushed:    %d\n", result.Pushed)
+	if *dryRun {
+		fmt.Printf("  Would push: %d\n", result.Pushed)
+	} else {
+		fmt.Printf("  Pushed:     %d\n", result.Pushed)
+	}
 	fmt.Printf("  Skipped:   %d\n", result.Skipped)
 
 	if result.Conflicts > 0 {
@@ -499,11 +503,14 @@ func runPush(args []string) error {
 	if result.Conflicts > 0 {
 		return fmt.Errorf("%d file(s) have conflicts; use --force to overwrite", result.Conflicts)
 	}
+	if result.Failed > 0 {
+		return fmt.Errorf("%d file(s) failed to push", result.Failed)
+	}
 
 	return nil
 }
 
-//// 2.5 List ----
+//// 2.4 List ----
 
 func runList(args []string) error {
 	outputFolder := "./notion"

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -60,6 +60,7 @@ var usage = `notion-sync — Sync Notion databases and pages to Markdown (v` + v
 Usage:
   notion-sync import <database-or-page-id> [--output <folder>] [--api-key <key>] [--keep-presigned-params]
   notion-sync refresh <folder> [--ids id1,id2] [--force] [--api-key <key>] [--keep-presigned-params]
+  notion-sync push <folder> [--force] [--dry-run] [--api-key <key>]
   notion-sync list [<output-folder>]
   notion-sync clean <folder> [--dry-run]
   notion-sync config set <key> <value>
@@ -73,6 +74,10 @@ Commands:
             --ids id1,id2  Refresh only specific pages by ID (databases only)
             --force, -f    Resync all entries, ignoring timestamps
             --keep-presigned-params  Keep AWS S3 pre-signed query strings on file URLs
+  push      Push local frontmatter property changes back to Notion (properties only, no body)
+            Refuses to push files where Notion has been edited since last sync, unless --force.
+            --force, -f    Push even if Notion has newer edits (overwrites Notion-side changes)
+            --dry-run      Show what would be pushed without writing to Notion
   list      List all synced databases and pages in a folder
   clean     Strip AWS S3 pre-signed query strings from existing .md files in a folder.
             Useful one-time backfill after upgrading. No API calls.
@@ -84,6 +89,8 @@ Examples:
   notion-sync refresh ./notion/My\ Database
   notion-sync refresh ./notion/pages/My\ Page_abc12345
   notion-sync refresh ./notion/My\ Database --force
+  notion-sync push ./notion/My\ Database
+  notion-sync push ./notion/My\ Database --dry-run
   notion-sync clean ./notion --dry-run
   notion-sync list ./notion
 
@@ -126,6 +133,8 @@ func main() {
 		err = runImport(args)
 	case "refresh":
 		err = runRefresh(args)
+	case "push":
+		err = runPush(args)
 	case "list":
 		err = runList(args)
 	case "clean":
@@ -399,7 +408,102 @@ func runRefreshPage(client *notion.Client, folderPath string, force, stripPresig
 	return nil
 }
 
-//// 2.3 List ----
+//// 2.3 Push ----
+
+func runPush(args []string) error {
+	fs := flag.NewFlagSet("push", flag.ExitOnError)
+	apiKey := fs.String("api-key", "", "Notion API key")
+	force := fs.Bool("force", false, "Push even if Notion has newer edits")
+	forceShort := fs.Bool("f", false, "Push even if Notion has newer edits (shorthand)")
+	dryRun := fs.Bool("dry-run", false, "Show what would be pushed without writing")
+
+	if err := fs.Parse(reorderArgs(args)); err != nil {
+		return err
+	}
+
+	if fs.NArg() == 0 {
+		return fmt.Errorf("missing folder path\n" +
+			"Usage: notion-sync push <folder> [--force] [--dry-run] [--api-key <key>]\n" +
+			"Example: notion-sync push ./notion/My\\ Database")
+	}
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	key := *apiKey
+	if key == "" {
+		key = cfg.APIKey
+	}
+	if msg := config.ValidateAPIKey(key); msg != "" {
+		return fmt.Errorf("%s", msg)
+	}
+
+	folderPath := fs.Arg(0)
+	forceFlag := *force || *forceShort
+
+	if *dryRun {
+		fmt.Println("Pushing properties (dry run)...")
+	} else if forceFlag {
+		fmt.Println("Force pushing properties (ignoring conflicts)...")
+	} else {
+		fmt.Println("Pushing properties to Notion...")
+	}
+
+	client := notion.NewClient(key)
+	var dbTitle string
+
+	result, err := sync.PushDatabase(sync.PushOptions{
+		Client:     client,
+		FolderPath: folderPath,
+		Force:      forceFlag,
+		DryRun:     *dryRun,
+	}, func(p sync.ProgressPhase) {
+		if p.Phase == sync.PhasePushing {
+			dbTitle = p.Title
+		}
+		fmt.Printf("\r%-60s", formatPushProgress(p, dbTitle))
+	})
+
+	if err != nil {
+		fmt.Println()
+		return err
+	}
+
+	fmt.Println()
+
+	if *dryRun {
+		fmt.Printf("Dry run: \"%s\"\n", result.Title)
+	} else {
+		fmt.Printf("Done: \"%s\"\n", result.Title)
+	}
+	fmt.Printf("  Total:     %d\n", result.Total)
+	fmt.Printf("  Pushed:    %d\n", result.Pushed)
+	fmt.Printf("  Skipped:   %d\n", result.Skipped)
+
+	if result.Conflicts > 0 {
+		fmt.Printf("  Conflicts: %d (Notion has newer edits — use --force to overwrite)\n", result.Conflicts)
+		for _, f := range result.ConflictFiles {
+			fmt.Printf("    - %s\n", f)
+		}
+	}
+
+	if result.Failed > 0 {
+		fmt.Printf("  Failed:    %d\n", result.Failed)
+		for _, e := range result.Errors {
+			fmt.Printf("    - %s\n", e)
+		}
+	}
+
+	if result.Conflicts > 0 {
+		return fmt.Errorf("%d file(s) have conflicts; use --force to overwrite", result.Conflicts)
+	}
+
+	return nil
+}
+
+//// 2.5 List ----
 
 func runList(args []string) error {
 	outputFolder := "./notion"
@@ -448,7 +552,7 @@ func runList(args []string) error {
 	return nil
 }
 
-//// 2.4 Clean ----
+//// 2.6 Clean ----
 
 func runClean(args []string) error {
 	fs := flag.NewFlagSet("clean", flag.ExitOnError)
@@ -485,7 +589,7 @@ func runClean(args []string) error {
 	return nil
 }
 
-//// 2.5 Config ----
+//// 2.7 Config ----
 
 func runConfig(args []string) error {
 	if len(args) == 0 {
@@ -573,6 +677,23 @@ func printAPIKeyStatus(key string) {
 }
 
 // 3. Helpers ----
+
+func formatPushProgress(p sync.ProgressPhase, dbTitle string) string {
+	switch p.Phase {
+	case sync.PhasePushScanning:
+		return "Scanning local files..."
+	case sync.PhasePushing:
+		title := dbTitle
+		if title == "" {
+			title = p.Title
+		}
+		return fmt.Sprintf("Pushing \"%s\"... %d/%d", title, p.Current, p.Total)
+	case sync.PhaseComplete:
+		return "Done"
+	default:
+		return ""
+	}
+}
 
 func formatProgress(p sync.ProgressPhase, dbTitle string) string {
 	switch p.Phase {

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -221,6 +221,20 @@ func (c *Client) QueryDataSource(dataSourceID string, startCursor *string) (*Pag
 	return &result, nil
 }
 
+// UpdatePage updates page properties via PATCH /pages/{id}.
+func (c *Client) UpdatePage(pageID string, properties map[string]interface{}) (*Page, error) {
+	body := map[string]interface{}{"properties": properties}
+	respBody, err := c.request("PATCH", "/pages/"+pageID, body)
+	if err != nil {
+		return nil, err
+	}
+	var page Page
+	if err := json.Unmarshal(respBody, &page); err != nil {
+		return nil, fmt.Errorf("unmarshal page: %w", err)
+	}
+	return &page, nil
+}
+
 // GetPage retrieves a page by ID.
 func (c *Client) GetPage(pageID string) (*Page, error) {
 	respBody, err := c.request("GET", "/pages/"+pageID, nil)

--- a/internal/notion/types.go
+++ b/internal/notion/types.go
@@ -4,13 +4,21 @@ import "time"
 
 // Database represents a Notion database response.
 type Database struct {
-	Object      string       `json:"object"`
-	ID          string       `json:"id"`
-	CreatedTime time.Time    `json:"created_time"`
-	LastEdited  time.Time    `json:"last_edited_time"`
-	Title       []RichText   `json:"title"`
-	URL         string       `json:"url"`
-	DataSources []DataSource `json:"data_sources,omitempty"`
+	Object      string                      `json:"object"`
+	ID          string                      `json:"id"`
+	CreatedTime time.Time                   `json:"created_time"`
+	LastEdited  time.Time                   `json:"last_edited_time"`
+	Title       []RichText                  `json:"title"`
+	URL         string                      `json:"url"`
+	DataSources []DataSource                `json:"data_sources,omitempty"`
+	Properties  map[string]DatabaseProperty `json:"properties,omitempty"`
+}
+
+// DatabaseProperty represents a property schema entry in a database.
+type DatabaseProperty struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 // DataSource represents a data source reference within a database.

--- a/internal/sync/agents.go
+++ b/internal/sync/agents.go
@@ -58,6 +58,7 @@ notion-frozen-at: "<RFC 3339 — when this file was last written>"
 notion-last-edited: "<RFC 3339 — Notion's last_edited_time>"
 notion-database-id: "<database-uuid>"   # only present for database entries
 # notion-deleted: true                  # only present if the entry was removed in Notion (soft delete)
+# notion-last-pushed: "<RFC 3339>"      # only present after a push — when properties were last written back
 
 # ... all Notion properties below ...
 Title Property: "Page Name"
@@ -70,23 +71,23 @@ PDF:
 
 ### Property → frontmatter mapping
 
-| Notion type                     | Frontmatter value                          |
-| ------------------------------- | ------------------------------------------ |
-| ` + "`title`" + `                         | filename (database entries) or ` + "`title`" + ` key (pages) |
-| ` + "`rich_text`" + `                     | plain markdown string                      |
-| ` + "`number`" + `                        | number or ` + "`null`" + `                            |
-| ` + "`select`" + `                        | option name or ` + "`null`" + `                       |
-| ` + "`multi_select`" + `                  | array of option names                      |
-| ` + "`status`" + `                        | status name or ` + "`null`" + `                       |
-| ` + "`date`" + `                          | ` + "`start`" + ` or ` + "`start → end`" + `                     |
-| ` + "`checkbox`" + `                      | ` + "`true`" + ` or ` + "`false`" + `                            |
-| ` + "`url`" + ` / ` + "`email`" + ` / ` + "`phone_number`" + ` | string or ` + "`null`" + `                            |
-| ` + "`relation`" + `                      | array of page IDs                          |
-| ` + "`people`" + `                        | array of names (or IDs as fallback)        |
-| ` + "`files`" + `                         | array of URLs (see "File URLs" below)      |
-| ` + "`created_time`" + ` / ` + "`last_edited_time`" + ` | RFC 3339 timestamp                |
-| ` + "`unique_id`" + `                     | ` + "`PREFIX-N`" + ` or ` + "`N`" + `                            |
-| ` + "`created_by`" + ` / ` + "`last_edited_by`" + ` | user name (or ID as fallback)        |
+| Notion type                     | Frontmatter value                          | Pushable? |
+| ------------------------------- | ------------------------------------------ | --------- |
+| ` + "`title`" + `                         | filename (database entries) or ` + "`title`" + ` key (pages) | no |
+| ` + "`rich_text`" + `                     | plain markdown string                      | yes |
+| ` + "`number`" + `                        | number or ` + "`null`" + `                            | yes |
+| ` + "`select`" + `                        | option name or ` + "`null`" + `                       | yes |
+| ` + "`multi_select`" + `                  | array of option names                      | yes |
+| ` + "`status`" + `                        | status name or ` + "`null`" + `                       | yes |
+| ` + "`date`" + `                          | ` + "`start`" + ` or ` + "`start → end`" + `                     | yes |
+| ` + "`checkbox`" + `                      | ` + "`true`" + ` or ` + "`false`" + `                            | yes |
+| ` + "`url`" + ` / ` + "`email`" + ` / ` + "`phone_number`" + ` | string or ` + "`null`" + `                            | yes |
+| ` + "`relation`" + `                      | array of page IDs                          | yes |
+| ` + "`people`" + `                        | array of names (or IDs as fallback)        | no — Notion-managed |
+| ` + "`files`" + `                         | array of URLs (see "File URLs" below)      | no — Notion-managed |
+| ` + "`created_time`" + ` / ` + "`last_edited_time`" + ` | RFC 3339 timestamp                | no — read-only |
+| ` + "`unique_id`" + `                     | ` + "`PREFIX-N`" + ` or ` + "`N`" + `                            | no — read-only |
+| ` + "`created_by`" + ` / ` + "`last_edited_by`" + ` | user name (or ID as fallback)        | no — read-only |
 
 Skipped (not in frontmatter): ` + "`formula`" + `, ` + "`rollup`" + `, ` + "`button`" + `, ` + "`verification`" + ` — they're computed or non-portable.
 
@@ -150,6 +151,18 @@ For multi-source databases, the **top-level** ` + "`_database.json`" + ` has no 
 - ` + "`refresh --force`" + ` resyncs every entry regardless of timestamp.
 - ` + "`refresh --ids id1,id2`" + ` resyncs specific pages by ID.
 - ` + "`clean <folder>`" + ` strips presigned URLs from existing files **without** any API call — used as a one-time backfill after upgrading.
+
+## Push semantics (writing local changes back to Notion)
+
+` + "`notion-sync push <folder>`" + ` is the reverse direction: it reads frontmatter from local ` + "`.md`" + ` files and writes property changes back to Notion. **Page body content is never modified.**
+
+Key facts for downstream agents:
+
+- Only **pushable** properties (see table above) are written back. Notion-managed fields (` + "`people`" + `, ` + "`files`" + `, ` + "`created_time`" + `, etc.) are silently skipped even if present in frontmatter.
+- **Conflict detection**: before pushing, the tool compares the local ` + "`notion-last-edited`" + ` timestamp with Notion's current ` + "`last_edited_time`" + `. If they differ (someone edited in Notion since last sync), the file is skipped and reported as a conflict. Use ` + "`--force`" + ` to overwrite.
+- After a successful push, the tool writes ` + "`notion-last-pushed: <timestamp>`" + ` into the file's frontmatter and updates ` + "`notion-last-edited`" + ` to the post-push value returned by Notion.
+- Files with ` + "`notion-deleted: true`" + ` are never pushed.
+- ` + "`push --dry-run`" + ` reports what would be pushed without making any Notion API calls.
 `
 
 // WriteAgentsMD writes the generated AGENTS.md to the workspace root.

--- a/internal/sync/client.go
+++ b/internal/sync/client.go
@@ -9,6 +9,7 @@ type NotionClient interface {
 	GetDataSource(dataSourceID string) (*notion.DataSourceDetail, error)
 	QueryAllEntries(dataSourceID string) ([]notion.Page, error)
 	GetPage(pageID string) (*notion.Page, error)
+	UpdatePage(pageID string, properties map[string]interface{}) (*notion.Page, error)
 	FetchAllBlocks(blockID string) ([]notion.Block, error)
 	FetchBlockTree(pageID string, progress func(fetched, found int)) (*notion.BlockTree, error)
 }

--- a/internal/sync/mock_client_test.go
+++ b/internal/sync/mock_client_test.go
@@ -8,11 +8,17 @@ import (
 
 // mockNotionClient is a test double that returns pre-configured data by ID.
 type mockNotionClient struct {
-	databases   map[string]*notion.Database
-	dataSources map[string]*notion.DataSourceDetail
-	entries     map[string][]notion.Page // keyed by dataSourceID
-	pages       map[string]*notion.Page
-	blocks      map[string][]notion.Block // keyed by blockID
+	databases      map[string]*notion.Database
+	dataSources    map[string]*notion.DataSourceDetail
+	entries        map[string][]notion.Page // keyed by dataSourceID
+	pages          map[string]*notion.Page
+	blocks         map[string][]notion.Block // keyed by blockID
+	updateRequests []updateRequest           // recorded UpdatePage calls
+}
+
+type updateRequest struct {
+	PageID     string
+	Properties map[string]interface{}
 }
 
 func newMockClient() *mockNotionClient {
@@ -50,6 +56,15 @@ func (m *mockNotionClient) QueryAllEntries(dataSourceID string) ([]notion.Page, 
 }
 
 func (m *mockNotionClient) GetPage(pageID string) (*notion.Page, error) {
+	page, ok := m.pages[pageID]
+	if !ok {
+		return nil, fmt.Errorf("page %s not found", pageID)
+	}
+	return page, nil
+}
+
+func (m *mockNotionClient) UpdatePage(pageID string, properties map[string]interface{}) (*notion.Page, error) {
+	m.updateRequests = append(m.updateRequests, updateRequest{PageID: pageID, Properties: properties})
 	page, ok := m.pages[pageID]
 	if !ok {
 		return nil, fmt.Errorf("page %s not found", pageID)

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -99,7 +99,14 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 			notionPage = page
 		}
 
-		properties := buildPropertyPayload(f.fm, database.Properties)
+		properties, validationErrs := buildPropertyPayload(f.fm, database.Properties)
+		if len(validationErrs) > 0 {
+			result.Failed++
+			for _, e := range validationErrs {
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", filepath.Base(f.path), e))
+			}
+			continue
+		}
 		if len(properties) == 0 {
 			result.Skipped++
 			continue
@@ -144,38 +151,46 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 
 // buildPropertyPayload constructs the Notion API property update payload from frontmatter.
 // Uses the database schema to determine property types; skips read-only / Notion-native properties.
-func buildPropertyPayload(fm map[string]interface{}, schema map[string]notion.DatabaseProperty) map[string]interface{} {
-	notionKeys := map[string]bool{
-		"notion-id": true, "notion-url": true, "notion-frozen-at": true,
-		"notion-last-edited": true, "notion-database-id": true,
-		"notion-deleted": true, "notion-last-pushed": true,
-	}
-	skipTypes := map[string]bool{
-		"title": true, "people": true,
-		"created_time": true, "last_edited_time": true,
-		"created_by": true, "last_edited_by": true,
-		"formula": true, "rollup": true, "button": true,
-		"unique_id": true, "verification": true, "files": true,
-	}
+var pushNotionKeys = map[string]bool{
+	"notion-id": true, "notion-url": true, "notion-frozen-at": true,
+	"notion-last-edited": true, "notion-database-id": true,
+	"notion-deleted": true, "notion-last-pushed": true,
+}
 
+var pushSkipTypes = map[string]bool{
+	"title": true, "people": true,
+	"created_time": true, "last_edited_time": true,
+	"created_by": true, "last_edited_by": true,
+	"formula": true, "rollup": true, "button": true,
+	"unique_id": true, "verification": true, "files": true,
+}
+
+func buildPropertyPayload(fm map[string]interface{}, schema map[string]notion.DatabaseProperty) (map[string]interface{}, []string) {
 	result := make(map[string]interface{})
+	var errs []string
 	for key, val := range fm {
-		if notionKeys[key] {
+		if pushNotionKeys[key] {
 			continue
 		}
 		prop, ok := schema[key]
 		if !ok {
 			continue
 		}
-		if skipTypes[prop.Type] {
+		if pushSkipTypes[prop.Type] {
 			continue
+		}
+		if prop.Type == "rich_text" {
+			if s := coerceString(val); len(s) > 2000 {
+				errs = append(errs, fmt.Sprintf("%q exceeds Notion's 2000-char limit for rich_text (got %d chars)", key, len(s)))
+				continue
+			}
 		}
 		payload := buildPropertyValue(prop.Type, val)
 		if payload != nil {
 			result[key] = payload
 		}
 	}
-	return result
+	return result, errs
 }
 
 func buildPropertyValue(propType string, val interface{}) interface{} {
@@ -334,11 +349,14 @@ func updateAfterPush(filePath, newLastEdited, pushedAt string) error {
 	s := strings.ReplaceAll(string(content), "\r\n", "\n")
 
 	// Update notion-last-edited if we have a new value from Notion.
+	// Search for "\nnotion-last-edited:" (newline-anchored) to avoid matching
+	// the substring inside a property value on a different line.
 	if newLastEdited != "" {
-		if idx := strings.Index(s, "notion-last-edited:"); idx != -1 {
-			end := strings.Index(s[idx:], "\n")
+		if idx := strings.Index(s, "\nnotion-last-edited:"); idx != -1 {
+			keyStart := idx + 1 // skip the leading \n
+			end := strings.Index(s[keyStart:], "\n")
 			if end != -1 {
-				s = s[:idx] + "notion-last-edited: " + newLastEdited + s[idx+end:]
+				s = s[:keyStart] + "notion-last-edited: " + newLastEdited + s[keyStart+end:]
 			}
 		}
 	}
@@ -346,19 +364,21 @@ func updateAfterPush(filePath, newLastEdited, pushedAt string) error {
 	pushedLine := "notion-last-pushed: " + pushedAt
 
 	// Update existing notion-last-pushed.
-	if idx := strings.Index(s, "notion-last-pushed:"); idx != -1 {
-		end := strings.Index(s[idx:], "\n")
+	if idx := strings.Index(s, "\nnotion-last-pushed:"); idx != -1 {
+		keyStart := idx + 1
+		end := strings.Index(s[keyStart:], "\n")
 		if end != -1 {
-			s = s[:idx] + pushedLine + s[idx+end:]
+			s = s[:keyStart] + pushedLine + s[keyStart+end:]
 		}
 		return os.WriteFile(filePath, []byte(s), 0644)
 	}
 
 	// Insert after notion-last-edited.
-	if idx := strings.Index(s, "notion-last-edited:"); idx != -1 {
-		end := strings.Index(s[idx:], "\n")
+	if idx := strings.Index(s, "\nnotion-last-edited:"); idx != -1 {
+		keyStart := idx + 1
+		end := strings.Index(s[keyStart:], "\n")
 		if end != -1 {
-			insertAt := idx + end
+			insertAt := keyStart + end
 			s = s[:insertAt] + "\n" + pushedLine + s[insertAt:]
 			return os.WriteFile(filePath, []byte(s), 0644)
 		}

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -1,0 +1,378 @@
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ran-codes/notion-sync/internal/frontmatter"
+	"github.com/ran-codes/notion-sync/internal/notion"
+)
+
+// PushDatabase pushes local frontmatter property changes back to Notion.
+// Only page properties are updated; page body content is never modified.
+func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, error) {
+	metadata, err := ReadDatabaseMetadata(opts.FolderPath)
+	if err != nil {
+		return nil, fmt.Errorf("read metadata: %w", err)
+	}
+	if metadata == nil {
+		return nil, fmt.Errorf("no %s found in %s. Use 'import' to import the database first", DatabaseMetadataFile, opts.FolderPath)
+	}
+
+	database, err := opts.Client.GetDatabase(metadata.DatabaseID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch database schema: %w", err)
+	}
+	if len(database.Properties) == 0 {
+		return nil, fmt.Errorf("database has no property schema; try re-importing the database first")
+	}
+
+	result := &PushResult{
+		Title:      metadata.Title,
+		FolderPath: opts.FolderPath,
+	}
+
+	if onProgress != nil {
+		onProgress(ProgressPhase{Phase: PhasePushScanning})
+	}
+
+	type fileEntry struct {
+		path string
+		fm   map[string]interface{}
+	}
+
+	dirEntries, err := os.ReadDir(opts.FolderPath)
+	if err != nil {
+		return nil, fmt.Errorf("read folder: %w", err)
+	}
+
+	var files []fileEntry
+	for _, entry := range dirEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		filePath := filepath.Join(opts.FolderPath, entry.Name())
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+		fm, err := frontmatter.Parse(string(content))
+		if err != nil || fm == nil {
+			continue
+		}
+		if _, ok := fm["notion-id"].(string); !ok {
+			continue
+		}
+		if deleted, ok := fm["notion-deleted"].(bool); ok && deleted {
+			continue
+		}
+		files = append(files, fileEntry{filePath, fm})
+	}
+
+	result.Total = len(files)
+
+	for i, f := range files {
+		if onProgress != nil {
+			onProgress(ProgressPhase{Phase: PhasePushing, Current: i + 1, Total: result.Total, Title: metadata.Title})
+		}
+
+		notionID := f.fm["notion-id"].(string)
+		localLastEdited, _ := f.fm["notion-last-edited"].(string)
+
+		// Conflict check: compare local last-edited timestamp with Notion's current value.
+		var notionPage *notion.Page
+		if !opts.Force {
+			page, err := opts.Client.GetPage(notionID)
+			if err != nil {
+				result.Failed++
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.path), err))
+				continue
+			}
+			if !timestampsEqual(localLastEdited, page.LastEditedTime) {
+				result.Conflicts++
+				result.ConflictFiles = append(result.ConflictFiles, filepath.Base(f.path))
+				continue
+			}
+			notionPage = page
+		}
+
+		properties := buildPropertyPayload(f.fm, database.Properties)
+		if len(properties) == 0 {
+			result.Skipped++
+			continue
+		}
+
+		if opts.DryRun {
+			result.Pushed++
+			continue
+		}
+
+		updated, err := opts.Client.UpdatePage(notionID, properties)
+		if err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.path), err))
+			continue
+		}
+
+		// Use the returned last_edited_time if available, otherwise fall back to the
+		// value we already fetched during conflict check.
+		newLastEdited := ""
+		if updated != nil && updated.LastEditedTime != "" {
+			newLastEdited = updated.LastEditedTime
+		} else if notionPage != nil {
+			newLastEdited = notionPage.LastEditedTime
+		}
+
+		pushedAt := time.Now().UTC().Format(time.RFC3339)
+		if err := updateAfterPush(f.path, newLastEdited, pushedAt); err != nil {
+			// Non-fatal: push succeeded, just couldn't update local timestamps.
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: update timestamps: %v", filepath.Base(f.path), err))
+		}
+
+		result.Pushed++
+	}
+
+	if onProgress != nil {
+		onProgress(ProgressPhase{Phase: PhaseComplete})
+	}
+
+	return result, nil
+}
+
+// buildPropertyPayload constructs the Notion API property update payload from frontmatter.
+// Uses the database schema to determine property types; skips read-only / Notion-native properties.
+func buildPropertyPayload(fm map[string]interface{}, schema map[string]notion.DatabaseProperty) map[string]interface{} {
+	notionKeys := map[string]bool{
+		"notion-id": true, "notion-url": true, "notion-frozen-at": true,
+		"notion-last-edited": true, "notion-database-id": true,
+		"notion-deleted": true, "notion-last-pushed": true,
+	}
+	skipTypes := map[string]bool{
+		"title": true, "people": true,
+		"created_time": true, "last_edited_time": true,
+		"created_by": true, "last_edited_by": true,
+		"formula": true, "rollup": true, "button": true,
+		"unique_id": true, "verification": true, "files": true,
+	}
+
+	result := make(map[string]interface{})
+	for key, val := range fm {
+		if notionKeys[key] {
+			continue
+		}
+		prop, ok := schema[key]
+		if !ok {
+			continue
+		}
+		if skipTypes[prop.Type] {
+			continue
+		}
+		payload := buildPropertyValue(prop.Type, val)
+		if payload != nil {
+			result[key] = payload
+		}
+	}
+	return result
+}
+
+func buildPropertyValue(propType string, val interface{}) interface{} {
+	switch propType {
+	case "rich_text":
+		s := coerceString(val)
+		return map[string]interface{}{
+			"rich_text": []interface{}{
+				map[string]interface{}{
+					"type": "text",
+					"text": map[string]interface{}{"content": s},
+				},
+			},
+		}
+
+	case "number":
+		if val == nil {
+			return map[string]interface{}{"number": nil}
+		}
+		switch v := val.(type) {
+		case float64:
+			return map[string]interface{}{"number": v}
+		case int:
+			return map[string]interface{}{"number": float64(v)}
+		}
+		return nil
+
+	case "select":
+		if val == nil {
+			return map[string]interface{}{"select": nil}
+		}
+		s := coerceString(val)
+		if s == "" {
+			return map[string]interface{}{"select": nil}
+		}
+		return map[string]interface{}{"select": map[string]interface{}{"name": s}}
+
+	case "multi_select":
+		items := coerceStringSlice(val)
+		opts := make([]interface{}, 0, len(items))
+		for _, name := range items {
+			opts = append(opts, map[string]interface{}{"name": name})
+		}
+		return map[string]interface{}{"multi_select": opts}
+
+	case "status":
+		if val == nil {
+			return nil
+		}
+		s := coerceString(val)
+		if s == "" {
+			return nil
+		}
+		return map[string]interface{}{"status": map[string]interface{}{"name": s}}
+
+	case "date":
+		if val == nil {
+			return map[string]interface{}{"date": nil}
+		}
+		return parseDatePayload(coerceString(val))
+
+	case "checkbox":
+		if b, ok := val.(bool); ok {
+			return map[string]interface{}{"checkbox": b}
+		}
+		return nil
+
+	case "url":
+		if val == nil {
+			return map[string]interface{}{"url": nil}
+		}
+		return map[string]interface{}{"url": coerceString(val)}
+
+	case "email":
+		if val == nil {
+			return map[string]interface{}{"email": nil}
+		}
+		return map[string]interface{}{"email": coerceString(val)}
+
+	case "phone_number":
+		if val == nil {
+			return map[string]interface{}{"phone_number": nil}
+		}
+		return map[string]interface{}{"phone_number": coerceString(val)}
+
+	case "relation":
+		ids := coerceStringSlice(val)
+		rels := make([]interface{}, 0, len(ids))
+		for _, id := range ids {
+			rels = append(rels, map[string]interface{}{"id": id})
+		}
+		return map[string]interface{}{"relation": rels}
+	}
+	return nil
+}
+
+func parseDatePayload(s string) interface{} {
+	if s == "" {
+		return map[string]interface{}{"date": nil}
+	}
+	if strings.Contains(s, " → ") {
+		parts := strings.SplitN(s, " → ", 2)
+		return map[string]interface{}{
+			"date": map[string]interface{}{
+				"start": strings.TrimSpace(parts[0]),
+				"end":   strings.TrimSpace(parts[1]),
+			},
+		}
+	}
+	return map[string]interface{}{
+		"date": map[string]interface{}{"start": s},
+	}
+}
+
+func coerceString(val interface{}) string {
+	if val == nil {
+		return ""
+	}
+	switch v := val.(type) {
+	case string:
+		return v
+	case float64:
+		return fmt.Sprintf("%g", v)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	}
+	return fmt.Sprintf("%v", val)
+}
+
+func coerceStringSlice(val interface{}) []string {
+	if val == nil {
+		return nil
+	}
+	switch v := val.(type) {
+	case []interface{}:
+		result := make([]string, 0, len(v))
+		for _, item := range v {
+			result = append(result, coerceString(item))
+		}
+		return result
+	case []string:
+		return v
+	}
+	return nil
+}
+
+// updateAfterPush updates notion-last-edited and adds notion-last-pushed in the file's frontmatter.
+func updateAfterPush(filePath, newLastEdited, pushedAt string) error {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	s := strings.ReplaceAll(string(content), "\r\n", "\n")
+
+	// Update notion-last-edited if we have a new value from Notion.
+	if newLastEdited != "" {
+		if idx := strings.Index(s, "notion-last-edited:"); idx != -1 {
+			end := strings.Index(s[idx:], "\n")
+			if end != -1 {
+				s = s[:idx] + "notion-last-edited: " + newLastEdited + s[idx+end:]
+			}
+		}
+	}
+
+	pushedLine := "notion-last-pushed: " + pushedAt
+
+	// Update existing notion-last-pushed.
+	if idx := strings.Index(s, "notion-last-pushed:"); idx != -1 {
+		end := strings.Index(s[idx:], "\n")
+		if end != -1 {
+			s = s[:idx] + pushedLine + s[idx+end:]
+		}
+		return os.WriteFile(filePath, []byte(s), 0644)
+	}
+
+	// Insert after notion-last-edited.
+	if idx := strings.Index(s, "notion-last-edited:"); idx != -1 {
+		end := strings.Index(s[idx:], "\n")
+		if end != -1 {
+			insertAt := idx + end
+			s = s[:insertAt] + "\n" + pushedLine + s[insertAt:]
+			return os.WriteFile(filePath, []byte(s), 0644)
+		}
+	}
+
+	// Fallback: insert before closing ---.
+	if strings.HasPrefix(s, "---\n") {
+		endIdx := strings.Index(s[4:], "\n---")
+		if endIdx != -1 {
+			insertAt := 4 + endIdx
+			s = s[:insertAt] + "\n" + pushedLine + s[insertAt:]
+			return os.WriteFile(filePath, []byte(s), 0644)
+		}
+	}
+
+	return nil
+}

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -22,7 +22,7 @@ func TestBuildPropertyPayload_SkipsNotionKeys(t *testing.T) {
 		"notion-last-pushed": "2024-01-01T00:00:00Z",
 	}
 	schema := map[string]notion.DatabaseProperty{}
-	got := buildPropertyPayload(fm, schema)
+	got, _ := buildPropertyPayload(fm, schema)
 	if len(got) != 0 {
 		t.Errorf("expected empty payload, got %v", got)
 	}
@@ -47,7 +47,7 @@ func TestBuildPropertyPayload_SkipsReadOnlyTypes(t *testing.T) {
 		"Rollup": "sum", "UniqueID": "ID-1",
 		"Attachments": []interface{}{"url"},
 	}
-	got := buildPropertyPayload(fm, schema)
+	got, _ := buildPropertyPayload(fm, schema)
 	if len(got) != 0 {
 		t.Errorf("expected empty payload for read-only types, got %v", got)
 	}
@@ -55,9 +55,24 @@ func TestBuildPropertyPayload_SkipsReadOnlyTypes(t *testing.T) {
 
 func TestBuildPropertyPayload_SkipsUnknownProperties(t *testing.T) {
 	fm := map[string]interface{}{"SomeProp": "value"}
-	got := buildPropertyPayload(fm, map[string]notion.DatabaseProperty{})
+	got, _ := buildPropertyPayload(fm, map[string]notion.DatabaseProperty{})
 	if len(got) != 0 {
 		t.Errorf("expected empty payload for unknown property, got %v", got)
+	}
+}
+
+func TestBuildPropertyPayload_RichTextTooLong(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{"Notes": {Type: "rich_text"}}
+	fm := map[string]interface{}{"Notes": strings.Repeat("x", 2001)}
+	got, errs := buildPropertyPayload(fm, schema)
+	if len(got) != 0 {
+		t.Error("expected property to be excluded from payload")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 validation error, got %d", len(errs))
+	}
+	if !strings.Contains(errs[0], "2000-char limit") {
+		t.Errorf("unexpected error message: %s", errs[0])
 	}
 }
 
@@ -398,6 +413,38 @@ func TestPushDatabase_WritesLastPushed(t *testing.T) {
 	got, _ := os.ReadFile(filePath)
 	if !strings.Contains(string(got), "notion-last-pushed:") {
 		t.Error("expected notion-last-pushed to be written to file after push")
+	}
+}
+
+func TestUpdateAfterPush_DoesNotCorruptValueContainingKey(t *testing.T) {
+	dir := t.TempDir()
+	// A property value contains the substring "notion-last-edited:" — the function
+	// must not match inside this value when updating the actual key.
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"Notes: \"see notion-last-edited: for tracking\"\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"---\n"
+	filePath := filepath.Join(dir, "page.md")
+	if err := os.WriteFile(filePath, []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateAfterPush(filePath, "2024-06-01T00:00:00Z", "2024-06-01T01:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(filePath)
+	s := string(got)
+
+	if !strings.Contains(s, "Notes: \"see notion-last-edited: for tracking\"") {
+		t.Error("Notes value was corrupted")
+	}
+	if !strings.Contains(s, "notion-last-edited: 2024-06-01T00:00:00Z") {
+		t.Error("notion-last-edited was not updated")
+	}
+	if !strings.Contains(s, "notion-last-pushed: 2024-06-01T01:00:00Z") {
+		t.Error("notion-last-pushed was not written")
 	}
 }
 

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -1,0 +1,411 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ran-codes/notion-sync/internal/notion"
+)
+
+// --- buildPropertyPayload tests ---
+
+func TestBuildPropertyPayload_SkipsNotionKeys(t *testing.T) {
+	fm := map[string]interface{}{
+		"notion-id":          "abc",
+		"notion-url":         "https://notion.so/abc",
+		"notion-frozen-at":   "2024-01-01T00:00:00Z",
+		"notion-last-edited": "2024-01-01T00:00:00Z",
+		"notion-database-id": "db1",
+		"notion-deleted":     false,
+		"notion-last-pushed": "2024-01-01T00:00:00Z",
+	}
+	schema := map[string]notion.DatabaseProperty{}
+	got := buildPropertyPayload(fm, schema)
+	if len(got) != 0 {
+		t.Errorf("expected empty payload, got %v", got)
+	}
+}
+
+func TestBuildPropertyPayload_SkipsReadOnlyTypes(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Assignee":    {Type: "people"},
+		"Created":     {Type: "created_time"},
+		"LastEdited":  {Type: "last_edited_time"},
+		"CreatedBy":   {Type: "created_by"},
+		"EditedBy":    {Type: "last_edited_by"},
+		"Formula":     {Type: "formula"},
+		"Rollup":      {Type: "rollup"},
+		"UniqueID":    {Type: "unique_id"},
+		"Attachments": {Type: "files"},
+	}
+	fm := map[string]interface{}{
+		"Assignee": "Alice", "Created": "2024-01-01",
+		"LastEdited": "2024-01-01", "CreatedBy": "Alice",
+		"EditedBy": "Bob", "Formula": "calc",
+		"Rollup": "sum", "UniqueID": "ID-1",
+		"Attachments": []interface{}{"url"},
+	}
+	got := buildPropertyPayload(fm, schema)
+	if len(got) != 0 {
+		t.Errorf("expected empty payload for read-only types, got %v", got)
+	}
+}
+
+func TestBuildPropertyPayload_SkipsUnknownProperties(t *testing.T) {
+	fm := map[string]interface{}{"SomeProp": "value"}
+	got := buildPropertyPayload(fm, map[string]notion.DatabaseProperty{})
+	if len(got) != 0 {
+		t.Errorf("expected empty payload for unknown property, got %v", got)
+	}
+}
+
+func TestBuildPropertyValue_RichText(t *testing.T) {
+	got := buildPropertyValue("rich_text", "hello world")
+	rt := got.(map[string]interface{})["rich_text"].([]interface{})
+	if len(rt) != 1 {
+		t.Fatalf("expected 1 rich_text item, got %d", len(rt))
+	}
+	text := rt[0].(map[string]interface{})["text"].(map[string]interface{})["content"]
+	if text != "hello world" {
+		t.Errorf("expected 'hello world', got %v", text)
+	}
+}
+
+func TestBuildPropertyValue_Number(t *testing.T) {
+	got := buildPropertyValue("number", float64(42)).(map[string]interface{})
+	if got["number"] != float64(42) {
+		t.Errorf("expected 42, got %v", got["number"])
+	}
+
+	got = buildPropertyValue("number", nil).(map[string]interface{})
+	if got["number"] != nil {
+		t.Errorf("expected nil, got %v", got["number"])
+	}
+}
+
+func TestBuildPropertyValue_Select(t *testing.T) {
+	got := buildPropertyValue("select", "Option A").(map[string]interface{})
+	sel := got["select"].(map[string]interface{})
+	if sel["name"] != "Option A" {
+		t.Errorf("expected 'Option A', got %v", sel["name"])
+	}
+
+	got = buildPropertyValue("select", nil).(map[string]interface{})
+	if got["select"] != nil {
+		t.Errorf("expected nil select, got %v", got["select"])
+	}
+}
+
+func TestBuildPropertyValue_MultiSelect(t *testing.T) {
+	got := buildPropertyValue("multi_select", []interface{}{"A", "B"}).(map[string]interface{})
+	items := got["multi_select"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].(map[string]interface{})["name"] != "A" {
+		t.Errorf("expected 'A', got %v", items[0])
+	}
+}
+
+func TestBuildPropertyValue_Checkbox(t *testing.T) {
+	got := buildPropertyValue("checkbox", true).(map[string]interface{})
+	if got["checkbox"] != true {
+		t.Errorf("expected true, got %v", got["checkbox"])
+	}
+}
+
+func TestBuildPropertyValue_Date(t *testing.T) {
+	got := buildPropertyValue("date", "2024-01-15").(map[string]interface{})
+	d := got["date"].(map[string]interface{})
+	if d["start"] != "2024-01-15" {
+		t.Errorf("expected '2024-01-15', got %v", d["start"])
+	}
+	if _, hasEnd := d["end"]; hasEnd {
+		t.Error("expected no end for single date")
+	}
+}
+
+func TestBuildPropertyValue_DateRange(t *testing.T) {
+	got := buildPropertyValue("date", "2024-01-15 → 2024-01-20").(map[string]interface{})
+	d := got["date"].(map[string]interface{})
+	if d["start"] != "2024-01-15" {
+		t.Errorf("expected '2024-01-15', got %v", d["start"])
+	}
+	if d["end"] != "2024-01-20" {
+		t.Errorf("expected '2024-01-20', got %v", d["end"])
+	}
+}
+
+func TestBuildPropertyValue_Relation(t *testing.T) {
+	got := buildPropertyValue("relation", []interface{}{"id1", "id2"}).(map[string]interface{})
+	rels := got["relation"].([]interface{})
+	if len(rels) != 2 {
+		t.Fatalf("expected 2 relations, got %d", len(rels))
+	}
+	if rels[0].(map[string]interface{})["id"] != "id1" {
+		t.Errorf("expected 'id1', got %v", rels[0])
+	}
+}
+
+// --- PushDatabase integration tests ---
+
+func TestPushDatabase_PushesProperties(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write _database.json
+	writeDatabaseMeta(t, dir, "db-001")
+
+	// Write a .md file
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-url: https://notion.so/page-001\n" +
+		"notion-frozen-at: 2024-01-01T00:00:00Z\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"notion-database-id: db-001\n" +
+		"Status: In Progress\n" +
+		"Priority: 1\n" +
+		"---\n# Content\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:    "db-001",
+		Title: []notion.RichText{{PlainText: "Test DB"}},
+		Properties: map[string]notion.DatabaseProperty{
+			"Status":   {Type: "select"},
+			"Priority": {Type: "number"},
+		},
+	}
+	client.pages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2024-01-01T00:00:00Z",
+	}
+
+	result, err := PushDatabase(PushOptions{
+		Client:     client,
+		FolderPath: dir,
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Pushed != 1 {
+		t.Errorf("expected 1 pushed, got %d", result.Pushed)
+	}
+	if result.Conflicts != 0 {
+		t.Errorf("expected 0 conflicts, got %d", result.Conflicts)
+	}
+	if len(client.updateRequests) != 1 {
+		t.Fatalf("expected 1 UpdatePage call, got %d", len(client.updateRequests))
+	}
+
+	req := client.updateRequests[0]
+	if req.PageID != "page-001" {
+		t.Errorf("expected page-001, got %s", req.PageID)
+	}
+	if _, ok := req.Properties["Status"]; !ok {
+		t.Error("expected Status in payload")
+	}
+	if _, ok := req.Properties["Priority"]; !ok {
+		t.Error("expected Priority in payload")
+	}
+}
+
+func TestPushDatabase_DetectsConflict(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Done\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": {Type: "select"},
+		},
+	}
+	// Notion has a newer timestamp
+	client.pages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2024-06-01T00:00:00Z",
+	}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Conflicts != 1 {
+		t.Errorf("expected 1 conflict, got %d", result.Conflicts)
+	}
+	if len(client.updateRequests) != 0 {
+		t.Error("expected no UpdatePage calls on conflict")
+	}
+}
+
+func TestPushDatabase_ForceSkipsConflictCheck(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Done\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": {Type: "select"},
+		},
+	}
+	client.pages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2024-06-01T00:00:00Z",
+	}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, Force: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Pushed != 1 {
+		t.Errorf("expected 1 pushed, got %d", result.Pushed)
+	}
+	if len(client.updateRequests) != 1 {
+		t.Errorf("expected 1 UpdatePage call, got %d", len(client.updateRequests))
+	}
+}
+
+func TestPushDatabase_DryRunNoWrite(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Done\n" +
+		"---\n"
+	filePath := filepath.Join(dir, "page-001.md")
+	if err := os.WriteFile(filePath, []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": {Type: "select"},
+		},
+	}
+	client.pages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2024-01-01T00:00:00Z",
+	}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, DryRun: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Pushed != 1 {
+		t.Errorf("expected 1 in dry-run pushed count, got %d", result.Pushed)
+	}
+	if len(client.updateRequests) != 0 {
+		t.Error("expected no UpdatePage calls in dry-run mode")
+	}
+
+	// File should be unchanged (no notion-last-pushed added)
+	got, _ := os.ReadFile(filePath)
+	if strings.Contains(string(got), "notion-last-pushed") {
+		t.Error("dry-run should not modify files")
+	}
+}
+
+func TestPushDatabase_SkipsDeletedEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"notion-deleted: true\n" +
+		"Status: Done\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Total != 0 {
+		t.Errorf("expected 0 total (deleted skipped), got %d", result.Total)
+	}
+}
+
+func TestPushDatabase_WritesLastPushed(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Done\n" +
+		"---\n"
+	filePath := filepath.Join(dir, "page-001.md")
+	if err := os.WriteFile(filePath, []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+	client.pages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2024-01-01T00:00:00Z",
+	}
+
+	if _, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(filePath)
+	if !strings.Contains(string(got), "notion-last-pushed:") {
+		t.Error("expected notion-last-pushed to be written to file after push")
+	}
+}
+
+// writeDatabaseMeta writes a minimal _database.json for tests.
+func writeDatabaseMeta(t *testing.T, dir, dbID string) {
+	t.Helper()
+	meta := &FrozenDatabase{DatabaseID: dbID, Title: "Test DB"}
+	if err := WriteDatabaseMetadata(dir, meta); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -64,4 +64,27 @@ const (
 	PhaseStaleDetected = "stale-detected"
 	PhaseImporting     = "importing"
 	PhaseComplete      = "complete"
+	PhasePushScanning  = "push-scanning"
+	PhasePushing       = "pushing"
 )
+
+// PushOptions contains options for pushing local frontmatter changes to Notion.
+type PushOptions struct {
+	Client     NotionClient
+	FolderPath string
+	Force      bool // skip conflict check
+	DryRun     bool // report planned changes without writing
+}
+
+// PushResult contains the result of a push operation.
+type PushResult struct {
+	Title         string
+	FolderPath    string
+	Total         int
+	Pushed        int
+	Skipped       int
+	Conflicts     int
+	Failed        int
+	Errors        []string
+	ConflictFiles []string
+}


### PR DESCRIPTION
## Context
- notion-sync has been one-way (Notion → local markdown) since the start
- Users editing frontmatter properties locally (bulk status updates, tagging, date changes) had no way to push those edits back
- Phase 1 of [#45](https://github.com/ran-codes/notion-sync/issues/45): properties-only push (body content is never touched)
- The full issue captures the rationale for keeping body push as a separate, opt-in phase

## Changes

**New command: `notion-sync push <folder>`**
- Reads frontmatter from all `.md` files in a synced database folder
- Builds a `PATCH /pages/{id}` payload for each file and calls Notion
- Conflict detection: compares `notion-last-edited` in the file against the live Notion `last_edited_time`; refuses to push if Notion is newer (unless `--force`)
- `--dry-run` reports what would be pushed without making write calls
- After a successful push: writes `notion-last-pushed` and updates `notion-last-edited` in the file so the next `refresh` doesn't re-sync unnecessarily

**Read-only properties skipped on push** (per design discussion on #45):
`people`, `files`, `title`, `created_time`, `last_edited_time`, `created_by`, `last_edited_by`, `formula`, `rollup`, `button`, `unique_id`, `verification`

**Files changed**
- [`internal/sync/push.go`](https://github.com/ran-codes/notion-sync/blob/9e380df2be16855097e436b2ed81c3a47c9c53d1/internal/sync/push.go) — `PushDatabase`, inverse property mapping, conflict detection, post-push file update
- [`internal/sync/push_test.go`](https://github.com/ran-codes/notion-sync/blob/9e380df2be16855097e436b2ed81c3a47c9c53d1/internal/sync/push_test.go) — 11 unit tests covering all property types, conflict/force/dry-run, file update
- [`internal/notion/client.go`](https://github.com/ran-codes/notion-sync/blob/9e380df2be16855097e436b2ed81c3a47c9c53d1/internal/notion/client.go) — `UpdatePage` (`PATCH /pages/{id}`)
- [`internal/notion/types.go`](https://github.com/ran-codes/notion-sync/blob/9e380df2be16855097e436b2ed81c3a47c9c53d1/internal/notion/types.go) — `DatabaseProperty` struct + `Properties` field on `Database` (needed to know property types for payload construction)
- [`internal/sync/types.go`](https://github.com/ran-codes/notion-sync/blob/9e380df2be16855097e436b2ed81c3a47c9c53d1/internal/sync/types.go) — `PushOptions`, `PushResult`, push phase constants
- [`internal/sync/agents.go`](https://github.com/ran-codes/notion-sync/blob/9e380df2be16855097e436b2ed81c3a47c9c53d1/internal/sync/agents.go) — updated downstream AGENTS.md: `notion-last-pushed` field, pushable column in property table, push semantics section
- [`cmd/notion-sync/main.go`](https://github.com/ran-codes/notion-sync/blob/9e380df2be16855097e436b2ed81c3a47c9c53d1/cmd/notion-sync/main.go) — `push` subcommand wired up with `--force`, `--dry-run`, `--api-key`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)