### PR TITLE
chore: add new Claude Code skills and enhance critical-code-reviewer

### DIFF
--- a/.claude/skills/critical-code-reviewer/SKILL.md
+++ b/.claude/skills/critical-code-reviewer/SKILL.md
@@ -36,12 +36,13 @@ Outdated descriptions and misleading comments should be noted in your review.
 ### 3. The Slop Detector
 
 Identify and reject:
-- **Obvious comments**: `// increment counter` above `counter++` — an insult to the reader
-- **Lazy naming**: `data`, `temp`, `result`, `handle`, `process`, `df`, `x`, `val` — words that communicate nothing
+- **Obvious comments**: `// increment counter` above `counter++` or `# loop through items` above a for loop—an insult to the reader
+- **Lazy naming**: `data`, `temp`, `result`, `handle`, `process`, `df`, `df2`, `x`, `val`—words that communicate nothing
 - **Copy-paste artifacts**: Similar blocks that scream "I didn't think about abstraction"
-- **Cargo cult code**: Patterns used without understanding why
+- **Cargo cult code**: Patterns used without understanding why (e.g., `useEffect` with wrong dependencies, `async/await` wrapped around synchronous code, `.apply()` in pandas where vectorization works)
 - **Premature abstraction AND missing abstraction**: Both are failures of judgment
 - **Dead code**: Commented-out blocks, unreachable branches, unused imports/variables
+- **Overuse of comments**: Well-named functions and variables should explain intent without comments
 
 ### 4. Structural Contempt
 
@@ -51,20 +52,38 @@ Code organization reveals thinking. Flag:
 - Inconsistent patterns within the same PR
 - Import chaos and dependency sprawl
 - Components with 500+ lines (React/Vue/Svelte)
+- Notebooks with no clear narrative flow (Jupyter/R Markdown)
 - CSS/styling scattered across inline, modules, and global without reason
 
 ### 5. The Adversarial Lens
 
 - Every unhandled Promise will reject at 3 AM
-- Every `None`/`null`/`undefined` will appear where you don't expect it
+- Every `None`/`null`/`undefined`/`NA` will appear where you don't expect it
 - Every API response will be malformed
 - Every user input is malicious (XSS, injection, type coercion attacks)
 - Every "temporary" solution is permanent
 - Every `any` type in TypeScript is a bug waiting to happen
 - Every missing `try/except` or `.catch()` is a silent failure
+- Every fire-and-forget promise is a silent failure
 - Every missing `await` is a race condition
 
 ### 6. Language-Specific Red Flags
+
+**Python:**
+- Bare `except:` clauses swallowing all errors
+- `except Exception:` that catches but doesn't re-raise
+- Mutable default arguments (`def foo(items=[])`)
+- Global state mutations
+- `import *` polluting namespace
+- Ignoring type hints in typed codebases
+
+**R:**
+- `T` and `F` instead of `TRUE` and `FALSE`
+- Relying on partial argument matching
+- Vectorized conditions in `if` statements
+- Ignoring vectorization for explicit loops
+- Not using early returns
+- Using `return()` at the end of functions unnecessarily
 
 **JavaScript/TypeScript:**
 - `==` instead of `===`
@@ -74,6 +93,7 @@ Code organization reveals thinking. Flag:
 - Uncontrolled re-renders in React (missing memoization, unstable references)
 - `useEffect` dependency array lies, stale closures, missing cleanup functions
 - `key` prop abuse (using index as key for dynamic lists)
+- Inline object/function props causing unnecessary re-renders
 - Unhandled promise rejections
 - Missing `await` on async calls
 
@@ -92,14 +112,18 @@ Code organization reveals thinking. Flag:
 
 ## Operating Constraints
 
-- If reviewing partial code, state what you can't verify
-- When context is missing, flag the *risk* rather than assuming failure — mark as "Verify" not "Blocking"
-- **Verify findings against the current file state, not just the diff.** Before reporting an issue, read the current file to confirm it still exists.
+When reviewing partial code:
+- If reviewing partial code, state what you can't verify (e.g., "Can't assess whether this duplicates existing utilities without seeing the full codebase")
+- When context is missing, flag the *risk* rather than assuming failure—mark as "Verify" not "Blocking"
+- For iterative reviews, focus on the delta—don't re-litigate resolved items
+- If you only see a snippet, acknowledge the boundaries of your review
+- **Verify findings against the current file state, not just the diff.** PR diffs may show intermediate states from earlier commits that were already resolved in subsequent commits on the same branch. Before reporting an issue, read the current file to confirm it still exists.
 
 ## When Uncertain
 
 - Flag the pattern and explain your concern, but mark it as "Verify" rather than "Blocking"
-- Ask: "Is [X] intentional here? If so, add a comment explaining why."
+- Ask: "Is [X] intentional here? If so, add a comment explaining why—this pattern usually indicates [problem]"
+- For unfamiliar frameworks or domain-specific patterns, note the concern and defer to team conventions
 
 ## Review Protocol
 
@@ -113,10 +137,11 @@ Code organization reveals thinking. Flag:
 - Direct, not theatrical
 - Diagnose the WHY: Don't just say it's wrong; explain the failure mode
 - Be specific: Quote the offending line, show the fix or pattern
+- Offer advice: Outline better patterns or solutions when multiple options exist
 
 **The Exit Condition:**
 
-After critical issues, state "remaining items are minor" or skip them entirely. If code is genuinely well-constructed, say so.
+After critical issues, state "remaining items are minor" or skip them entirely. If code is genuinely well-constructed, say so. Skepticism means honest evaluation, not performative negativity.
 
 ## Git Integration
 
@@ -130,15 +155,26 @@ Ask yourself:
 - What happens when this code meets real users/data/scale?
 - Have I flagged actual problems, or am I manufacturing issues?
 
+If you can't answer the first three, you haven't reviewed deeply enough.
+
 ## Next Steps
 
-At the end of the review, suggest next steps that the user can take.
+At the end of the review, suggest next steps that the user can take:
 
 **Discuss and address review questions:**
 
-If the user chooses to discuss, use the AskUserQuestion tool to systematically talk through each of the issues identified in your review. Group questions by related severity or topic and offer resolution options and clearly mark your recommended choice.
+If the user chooses to discuss, use the AskUserQuestion tool to systematically talk through each of the issues identified in your review. Group questions by related severity or topic and offer resolution options and clearly mark your recommended choice
 
-NOTE: If you are operating as a subagent or as an agent for another coding assistant, do not include next steps and only output your review.
+
+**Add the review feedback to a pull request:**
+
+When the user asks to post findings as a PR comment, use the template at `templates/pr-comment.md` (relative to this skill's directory). Do NOT post automatically — only when the user explicitly asks.
+
+**Other:**
+
+You can offer additional next step options based on the context of your conversation.
+
+NOTE: If you are operating as a subagent or as an agent for another coding assistant, e.g. you are an agent for Claude Code, do not include next steps and only output your review.
 
 ## Response Format
 
@@ -159,7 +195,7 @@ NOTE: If you are operating as a subagent or as an agent for another coding assis
 Request Changes | Needs Discussion | Approve
 
 ## Next Steps
-[Numbered options for proceeding]
+[Numbered options for proceeding, e.g., discuss issues, add to PR]
 ```
 
 Note: Approval means "no blocking issues found after rigorous review", not "perfect code." Don't manufacture problems to avoid approving.

--- a/.claude/skills/critical-code-reviewer/templates/pr-comment.md
+++ b/.claude/skills/critical-code-reviewer/templates/pr-comment.md
@@ -1,0 +1,98 @@
+# PR Comment Template
+
+When the user asks to post review findings as a PR comment, use this format.
+
+## Structure
+
+The structure adapts based on the verdict:
+
+### When verdict is **Request Changes** or **Needs Discussion**
+
+```markdown
+## Code Review (Pass XXXX)
+
+> [!CAUTION]
+> **Verdict: Request Changes**
+> {One-sentence rationale.}
+
+### Action Items
+
+- [ ] **{Issue title}** — `{file:line}` {Description of the issue and what to do about it.}
+- [ ] ...
+
+### Suggestions
+
+- **{Topic}** — {Optional/cosmetic recommendation that won't block merge.}
+- ...
+
+### Notes
+
+- **{Topic}** — {Observation or confirmation that doesn't require action.}
+- ...
+
+---
+
+Review feedback assisted by the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).
+```
+
+### When verdict is **Approve**
+
+```markdown
+## Code Review (Pass XXXX)
+
+> [!NOTE]
+> **Verdict: Approve**
+> {One-sentence rationale.}
+
+### Suggestions
+
+- **{Topic}** — {Optional/cosmetic recommendation that won't block merge.}
+- ...
+
+### Notes
+
+- **{Topic}** — {Observation or confirmation that doesn't require action.}
+- ...
+
+---
+
+Review feedback assisted by the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).
+```
+
+When approved, there are no **Action Items** — everything remaining is optional. Use **Suggestions** for cosmetic or non-breaking recommendations. If there are no suggestions either, omit that section entirely.
+
+## Verdict
+
+The verdict callout appears **below** the `## Code Review` heading and **above** the first `###` section. Use a GitHub blockquote callout based on severity:
+
+| Verdict              | Callout type   |
+| -------------------- | -------------- |
+| **Approve**          | `> [!NOTE]`    |
+| **Needs Discussion** | `> [!WARNING]` |
+| **Request Changes**  | `> [!CAUTION]` |
+
+The rationale line should be one sentence explaining why — e.g., "No blocking issues after rigorous review" or "3 blocking issues must be resolved before merge."
+
+## Sections by verdict
+
+| Section                        | Request Changes / Needs Discussion            | Approve                                       |
+| ------------------------------ | --------------------------------------------- | --------------------------------------------- |
+| **Action Items** (`- [ ]`)     | Required — blocking issues that must be fixed | Omitted — nothing blocks merge                |
+| **Suggestions** (`- **bold**`) | Optional — non-blocking recommendations       | Optional — cosmetic/polish items              |
+| **Notes** (`- **bold**`)       | Always — observations, confirmations, context | Always — observations, confirmations, context |
+
+## Pass Numbering
+
+Before posting, scan the PR's existing comments for previous `## Code Review (Pass N)` headings. Set the pass number to the next increment. If no previous code review comments exist, use `Pass 1`.
+
+To scan: `gh pr view {PR_NUMBER} --repo {REPO} --comments --json comments --jq '.comments[].body'` and search for `Code Review (Pass`.
+
+## Rules
+
+- **Action items** are checkbox items (`- [ ]`). These are blocking issues, required changes, and verify items — things that must be resolved before merge. Only appear when verdict is NOT Approve.
+- **Suggestions** are bold bullet points (no checkboxes). These are optional, cosmetic, or non-breaking recommendations. They appear in any verdict but are the primary feedback section when approved.
+- **Notes** are bold bullet points (no checkboxes). These are confirmations, observations, and context — things worth recording but that don't need action.
+- Keep it concise. The full review conversation has the details; the PR comment is the summary.
+- Bold the issue/topic title, use `file:line` references where applicable.
+- Always end with the attribution footer.
+- Do NOT post automatically — only when the user explicitly asks.

--- a/.claude/skills/critical-code-reviewer/templates/pr-comment.md
+++ b/.claude/skills/critical-code-reviewer/templates/pr-comment.md
@@ -32,7 +32,7 @@ The structure adapts based on the verdict:
 
 ---
 
-Review feedback assisted by the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).
+Review feedback assisted by the [critical-code-reviewer skill](https://github.com/Drexel-UHC/notion-sync/blob/main/.claude/skills/critical-code-reviewer/SKILL.md).
 ```
 
 ### When verdict is **Approve**
@@ -56,7 +56,7 @@ Review feedback assisted by the [critical-code-reviewer skill](https://github.co
 
 ---
 
-Review feedback assisted by the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).
+Review feedback assisted by the [critical-code-reviewer skill](https://github.com/Drexel-UHC/notion-sync/blob/main/.claude/skills/critical-code-reviewer/SKILL.md).
 ```
 
 When approved, there are no **Action Items** — everything remaining is optional. Use **Suggestions** for cosmetic or non-breaking recommendations. If there are no suggestions either, omit that section entirely.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.claude/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A concise description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+disable-model-invocation: true
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).

--- a/.claude/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.claude/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.claude/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: tdd
+description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, use the project's domain glossary so that test names and interface vocabulary match the project's language, and respect ADRs in the area you're touching.
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Identify opportunities for [deep modules](deep-modules.md) (small interface, deep implementation)
+- [ ] Design interfaces for [testability](interface-design.md)
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Get user approval on the plan
+
+Ask: "What should the public interface look like? Which behaviors are most important to test?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/.claude/skills/tdd/deep-modules.md
+++ b/.claude/skills/tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/.claude/skills/tdd/interface-design.md
+++ b/.claude/skills/tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area**
+   - Fewer methods = fewer tests needed
+   - Fewer params = simpler test setup

--- a/.claude/skills/tdd/mocking.md
+++ b/.claude/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.claude/skills/tdd/refactoring.md
+++ b/.claude/skills/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/.claude/skills/tdd/tests.md
+++ b/.claude/skills/tdd/tests.md
@@ -1,0 +1,61 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```

--- a/.claude/skills/to-issues/SKILL.md
+++ b/.claude/skills/to-issues/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: to-issues
+description: Break a plan, spec, or PRD into independently-grabbable issue proposals using tracer-bullet vertical slices, and write them to src_{concise_title}.md at the repo root. Use when user wants to convert a plan into issues, create implementation tickets, or break down work into issues.
+---
+
+# To Issues
+
+Break a plan into independently-grabbable issues using vertical slices (tracer bullets). Writes proposals to `src_{concise_title}.md` at the repo root — does NOT publish to GitHub directly.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes a file path or reference as an argument, read it in full.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+### 3. Draft vertical slices
+
+Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+
+<vertical-slice-rules>
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Prefer many thin slices over few thick ones
+</vertical-slice-rules>
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Type**: HITL / AFK
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories this addresses (if the source material has them)
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+- Are the correct slices marked as HITL and AFK?
+
+Iterate until the user approves the breakdown.
+
+### 5. Write proposals to src_{concise_title}.md
+
+Once the user approves, derive a concise title (2–4 words, kebab-case) from the conversation topic and write all issue proposals to `src_{concise_title}.md` at the repo root. Use the issue body template below for each entry. Tell the user the file has been written and its path.
+
+List issues in dependency order (blockers first).
+
+<issue-template>
+## [Title]
+
+**Type**: HITL / AFK
+**Blocked by**: [issue title or "None — can start immediately"]
+
+### Parent
+
+A reference to the parent issue or PRD (if applicable, otherwise omit).
+
+### What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+### Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+</issue-template>
+
+Do NOT close or modify any existing files other than the output `src_{concise_title}.md`.

--- a/.claude/skills/to-prd/SKILL.md
+++ b/.claude/skills/to-prd/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: to-prd
+description: Turn the current conversation context into a PRD and write it to src_{concise_title}.md at the repo root. Use when user wants to create a PRD from the current context.
+---
+
+This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — synthesize from existing context, present a draft, then check once before writing.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
+
+2. Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
+
+A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
+
+Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
+
+3. Derive a concise title (2–4 words, kebab-case) from the conversation topic. Write the PRD using the template below to `src_{concise_title}.md` at the repo root. Tell the user the file has been written and its path.
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,27 @@ When the user says "the agent docs" or asks about downstream documentation, they
   - **No heavyweight agents for simple operations.** If a skill just needs to read/grep a handful of files, do it inline. If you think a Task agent is needed, ask me first.
 - Refer to context7 first if have any questions about claude code, notion mcp or github cli
 
+## Skills
+
+Custom skills live in `.claude/skills/`. Invoke with `/skill-name`.
+
+| Skill | Description |
+|-------|-------------|
+| `/ship` | Ship code via PR — branching, committing, pushing, and creating/updating PRs |
+| `/critical-code-reviewer` | Rigorous adversarial code review — security, slop, edge cases |
+| `/grill-me` | Relentless design interview — stress-tests a plan by walking every branch of the decision tree |
+| `/grill-with-docs` | Grilling session that sharpens terminology against the domain model and updates CONTEXT.md + ADRs inline |
+| `/tdd` | Test-driven development with red-green-refactor loop and TDD philosophy guides |
+| `/to-prd` | Synthesizes conversation + codebase into a PRD, written to `src_{title}.md` at repo root |
+| `/to-issues` | Breaks a plan/PRD into vertical-slice issue proposals, written to `src_{title}.md` at repo root |
+| `/improve-codebase-architecture` | Surfaces deepening opportunities — shallow modules to consolidate for testability and AI-navigability |
+| `/test` | Run all tests (unit + system + cleanup) |
+| `/test-single-datasource-db` | Integration test against the single data source test database |
+| `/test-double-datasource-db` | Integration test against the double data source test database |
+| `/test-standalone-page` | Integration test for standalone page import/refresh/list |
+| `/release` | Tag and publish a new release interactively |
+| `/clean` | Clean up merged branches |
+
 ## Quick Start (for agents)
 
 ```sh


### PR DESCRIPTION
## Context
- Several new development workflow skills were built and needed to be registered in the repo
- The `critical-code-reviewer` skill needed stronger language-specific heuristics (Python, R) and a PR comment output template
- CLAUDE.md lacked a skills reference table, making it hard to discover available slash commands

## Changes
- Add 6 new skills: `/grill-me`, `/grill-with-docs`, `/tdd`, `/to-issues`, `/to-prd`, `/improve-codebase-architecture`
- Enhance `/critical-code-reviewer` with Python/R red flag sections, tighter slop detector criteria, a `templates/pr-comment.md` output template, and clearer operating constraints for partial/iterative reviews
- Update `CLAUDE.md` with a skills reference table listing all available slash commands and their descriptions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)