### PR TITLE
feat: append trailing newline to .md and JSON outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ When the user says "the agent docs" or asks about downstream documentation, they
   - **Minimize tool calls.** Use Grep, Read, Glob directly — they're fast and parallel. Never spawn a Task agent (subagent) for simple file reads or searches.
   - **No heavyweight agents for simple operations.** If a skill just needs to read/grep a handful of files, do it inline. If you think a Task agent is needed, ask me first.
 - Refer to context7 first if have any questions about claude code, notion mcp or github cli
+- **Never commit directly to `main`.** Always work in a branch and ship via `/ship` (PR). No exceptions.
 - **Never close/merge without explicit approval**
   - Never write `closes`, `fixes`, or `resolves` in commit messages or PR descriptions — these auto-close issues on merge. Use `ref #N` to reference only.
   - Never merge into `main` by any mechanism (direct push of a merge commit, `gh pr merge`, etc.) without the user explicitly saying to merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ When the user says "the agent docs" or asks about downstream documentation, they
   - **Minimize tool calls.** Use Grep, Read, Glob directly — they're fast and parallel. Never spawn a Task agent (subagent) for simple file reads or searches.
   - **No heavyweight agents for simple operations.** If a skill just needs to read/grep a handful of files, do it inline. If you think a Task agent is needed, ask me first.
 - Refer to context7 first if have any questions about claude code, notion mcp or github cli
+- **Never close/merge without explicit approval**
+  - Never write `closes`, `fixes`, or `resolves` in commit messages or PR descriptions — these auto-close issues on merge. Use `ref #N` to reference only.
+  - Never merge into `main` by any mechanism (direct push of a merge commit, `gh pr merge`, etc.) without the user explicitly saying to merge.
 
 ## Skills
 

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -591,7 +591,7 @@ func runClean(args []string) error {
 	if *dryRun {
 		label = "Would modify"
 	}
-	fmt.Printf("Scanned: %d .md files\n", r.FilesScanned)
+	fmt.Printf("Scanned: %d files\n", r.FilesScanned)
 	fmt.Printf("%s: %d files (%d URLs stripped, %d trailing newlines added)\n", label, r.FilesChanged, r.URLsStripped, r.NewlinesFixed)
 	return nil
 }

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -592,7 +592,7 @@ func runClean(args []string) error {
 		label = "Would modify"
 	}
 	fmt.Printf("Scanned: %d .md files\n", r.FilesScanned)
-	fmt.Printf("%s: %d files (%d URLs stripped)\n", label, r.FilesChanged, r.URLsStripped)
+	fmt.Printf("%s: %d files (%d URLs stripped, %d trailing newlines added)\n", label, r.FilesChanged, r.URLsStripped, r.NewlinesFixed)
 	return nil
 }
 

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -33,15 +33,19 @@ var presignedURLPattern = regexp.MustCompile(
 
 // Result summarizes a clean run.
 type Result struct {
-	FilesScanned int
-	FilesChanged int
-	URLsStripped int
-	DryRun       bool
+	FilesScanned  int
+	FilesChanged  int
+	URLsStripped  int
+	NewlinesFixed int
+	DryRun        bool
 }
 
-// Folder walks `root` recursively and strips pre-signed query strings from
-// every `.md` file it finds. When dryRun is true, files are not modified;
-// the result reports what would have changed.
+// Folder walks `root` recursively and applies cleanups to eligible files:
+//   - strips pre-signed S3 query strings from `.md` files
+//   - appends a trailing newline to `.md` and `.json` files that are missing one
+//
+// When dryRun is true, files are not modified; the result reports what would
+// have changed.
 func Folder(root string, dryRun bool) (*Result, error) {
 	r := &Result{DryRun: dryRun}
 
@@ -52,35 +56,54 @@ func Folder(root string, dryRun bool) (*Result, error) {
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+
+		name := strings.ToLower(d.Name())
+		isMd := strings.HasSuffix(name, ".md")
+		isJSON := strings.HasSuffix(name, ".json")
+
+		if !isMd && !isJSON {
 			return nil
 		}
-
-		r.FilesScanned++
 
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", path, err)
 		}
 
-		stripped, count := stripContent(string(content))
-		if count == 0 {
+		changed := false
+		out := string(content)
+
+		if isMd {
+			r.FilesScanned++
+			stripped, count := stripContent(out)
+			if count > 0 {
+				out = stripped
+				r.URLsStripped += count
+				changed = true
+			}
+		}
+
+		if len(out) > 0 && out[len(out)-1] != '\n' {
+			out += "\n"
+			r.NewlinesFixed++
+			changed = true
+		}
+
+		if !changed {
 			return nil
 		}
 
 		r.FilesChanged++
-		r.URLsStripped += count
 
 		if dryRun {
 			return nil
 		}
 
-		// Preserve the existing file mode by reading then writing.
 		info, err := os.Stat(path)
 		if err != nil {
 			return fmt.Errorf("stat %s: %w", path, err)
 		}
-		if err := os.WriteFile(path, []byte(stripped), info.Mode()); err != nil {
+		if err := os.WriteFile(path, []byte(out), info.Mode()); err != nil {
 			return fmt.Errorf("write %s: %w", path, err)
 		}
 		return nil

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -73,8 +73,9 @@ func Folder(root string, dryRun bool) (*Result, error) {
 		changed := false
 		out := string(content)
 
+		r.FilesScanned++
+
 		if isMd {
-			r.FilesScanned++
 			stripped, count := stripContent(out)
 			if count > 0 {
 				out = stripped

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -140,6 +140,92 @@ PDF:
 	}
 }
 
+func TestFolder_AddsMissingTrailingNewline_Md(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	if err := os.WriteFile(path, []byte("---\nnotion-id: abc\n---\nBody without newline"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.NewlinesFixed != 1 {
+		t.Errorf("NewlinesFixed = %d, want 1", r.NewlinesFixed)
+	}
+
+	data, _ := os.ReadFile(path)
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("file still missing trailing newline")
+	}
+}
+
+func TestFolder_LeavesExistingTrailingNewlineAlone(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	original := "---\nnotion-id: abc\n---\nBody with newline\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.NewlinesFixed != 0 {
+		t.Errorf("NewlinesFixed = %d, want 0", r.NewlinesFixed)
+	}
+
+	data, _ := os.ReadFile(path)
+	if string(data) != original {
+		t.Errorf("file content changed unexpectedly")
+	}
+}
+
+func TestFolder_AddsMissingTrailingNewline_Json(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(path, []byte(`{"databaseId":"abc"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.NewlinesFixed != 1 {
+		t.Errorf("NewlinesFixed = %d, want 1", r.NewlinesFixed)
+	}
+
+	data, _ := os.ReadFile(path)
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("json file still missing trailing newline")
+	}
+}
+
+func TestFolder_DryRunDoesNotFixNewlines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	original := "---\nnotion-id: abc\n---\nNo newline"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.NewlinesFixed != 1 {
+		t.Errorf("dry-run NewlinesFixed = %d, want 1", r.NewlinesFixed)
+	}
+
+	data, _ := os.ReadFile(path)
+	if string(data) != original {
+		t.Errorf("dry-run modified file")
+	}
+}
+
 func TestFolder_SkipsNonMarkdown(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "_database.json"),

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -226,11 +226,9 @@ func TestFolder_DryRunDoesNotFixNewlines(t *testing.T) {
 	}
 }
 
-func TestFolder_SkipsNonMarkdown(t *testing.T) {
+func TestFolder_SkipsNonMarkdownNonJSON(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "_database.json"),
-		[]byte(`{"foo": "https://prod-files-secure.s3.us-west-2.amazonaws.com/x?X-Amz-Signature=abc"}`),
-		0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "data.csv"), []byte("a,b,c"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -238,8 +236,27 @@ func TestFolder_SkipsNonMarkdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.FilesScanned != 0 {
-		t.Errorf("non-md file should not be scanned, got FilesScanned=%d", r.FilesScanned)
+	if r.FilesScanned != 0 || r.FilesChanged != 0 {
+		t.Errorf("csv file should not be touched, got %+v", r)
+	}
+}
+
+func TestFolder_JSONURLsNotStripped(t *testing.T) {
+	dir := t.TempDir()
+	content := `{"foo": "https://prod-files-secure.s3.us-west-2.amazonaws.com/x?X-Amz-Signature=abc"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "_database.json"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsStripped != 0 {
+		t.Errorf("URLs should not be stripped from JSON files, got URLsStripped=%d", r.URLsStripped)
+	}
+	if r.FilesChanged != 0 {
+		t.Errorf("file already has trailing newline, should be unchanged, got FilesChanged=%d", r.FilesChanged)
 	}
 }
 

--- a/internal/sync/metadata.go
+++ b/internal/sync/metadata.go
@@ -43,7 +43,7 @@ func WriteDatabaseMetadata(folderPath string, metadata *FrozenDatabase) error {
 		return err
 	}
 
-	return os.WriteFile(metaPath, data, 0644)
+	return os.WriteFile(metaPath, append(data, '\n'), 0644)
 }
 
 // ReadPageMetadata reads _page.json from a folder.
@@ -80,7 +80,7 @@ func WritePageMetadata(folderPath string, metadata *FrozenPage) error {
 		return err
 	}
 
-	return os.WriteFile(metaPath, data, 0644)
+	return os.WriteFile(metaPath, append(data, '\n'), 0644)
 }
 
 // ListSyncedPages scans the pages/ subdirectory for folders containing _page.json.

--- a/internal/sync/metadata_test.go
+++ b/internal/sync/metadata_test.go
@@ -103,6 +103,36 @@ func TestListSyncedDatabases(t *testing.T) {
 	}
 }
 
+func TestWriteDatabaseMetadata_TrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	meta := &FrozenDatabase{DatabaseID: "abc", Title: "T", EntryCount: 1}
+	if err := WriteDatabaseMetadata(dir, meta); err != nil {
+		t.Fatalf("WriteDatabaseMetadata: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, DatabaseMetadataFile))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("file does not end with newline; last byte = %q", data[len(data)-1])
+	}
+}
+
+func TestWritePageMetadata_TrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	meta := &FrozenPage{PageID: "abc", Title: "T"}
+	if err := WritePageMetadata(dir, meta); err != nil {
+		t.Fatalf("WritePageMetadata: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, PageMetadataFile))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("file does not end with newline; last byte = %q", data[len(data)-1])
+	}
+}
+
 func TestListSyncedDatabases_NonexistentDir(t *testing.T) {
 	databases, err := ListSyncedDatabases(filepath.Join(t.TempDir(), "nope"))
 	if err != nil {

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -123,7 +123,7 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 	}
 
 	content := frontmatter.BuildOrdered(fm, keyOrder, md)
-	if !strings.HasSuffix(content, "\n") {
+	if len(content) > 0 && content[len(content)-1] != '\n' {
 		content += "\n"
 	}
 

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -123,6 +123,9 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 	}
 
 	content := frontmatter.BuildOrdered(fm, keyOrder, md)
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
 
 	// Write markdown file
 	if err := os.MkdirAll(opts.OutputFolder, 0755); err != nil {

--- a/internal/sync/page_test.go
+++ b/internal/sync/page_test.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ran-codes/notion-sync/internal/notion"
@@ -449,5 +451,43 @@ func TestMapPropertiesToFrontmatter_UnknownTypeSkipped(t *testing.T) {
 
 	if len(fm) != 0 {
 		t.Errorf("expected empty frontmatter for unknown types, got %v", fm)
+	}
+}
+
+func TestFreezePage_TrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	page := testPage("page-id-001", "My Page", "2025-01-01T00:00:00Z")
+	client := newMockClient()
+	client.pages["page-id-001"] = &page
+	// paragraph block so md body ends without \n (joins produce "Hello world" with no newline)
+	client.blocks["page-id-001"] = []notion.Block{
+		{
+			ID:   "block-1",
+			Type: "paragraph",
+			Paragraph: &notion.ParagraphBlock{
+				RichText: []notion.RichText{
+					{Type: "text", PlainText: "Hello world", Text: &notion.TextContent{Content: "Hello world"}},
+				},
+			},
+		},
+	}
+
+	_, err := FreezePage(FreezePageOptions{
+		Client:       client,
+		NotionID:     "page-id-001",
+		OutputFolder: dir,
+		DatabaseID:   "db-123",
+		Page:         &page,
+	})
+	if err != nil {
+		t.Fatalf("FreezePage: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "page-id-001.md"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("md file does not end with newline; last byte = %q", data[len(data)-1])
 	}
 }


### PR DESCRIPTION
## Context
- POSIX requires text files to end with `\n`; synced files were missing it
- Caused `\ No newline at end of file` git diff noise and editor auto-add churn
- Addresses https://github.com/Drexel-UHC/notion-sync/issues/48

## Changes
- `page.go` — `FreezePage` ensures `.md` content ends with `\n`
- `metadata.go` — `WriteDatabaseMetadata` / `WritePageMetadata` append `\n` to JSON
- `clean.go` — `Folder` fixes missing trailing newlines in `.md` + `.json`; adds `NewlinesFixed` to `Result`
- `main.go` — `clean` output reports trailing newlines added
- `CLAUDE.md` — added rules: never commit to main, never use closing keywords in commits

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)