### PR TITLE
feat: drop per-file notion-frozen-at; extend clean migration

### DIFF
--- a/.claude/skills/test-single-datasource-db/SKILL.md
+++ b/.claude/skills/test-single-datasource-db/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test-single-datasource-db
 description: Run integration test against the single-data-source test database (import, refresh, --ids, --force, push)
-version: 2.1.0
+version: 2.2.0
 args: "[--verbose] [--no-cleanup]"
 ---
 
@@ -83,8 +83,9 @@ Grep the synced `.md` files in `./test-output/test database obsdiain complex/` f
 | `unique_id` | Present in at least one file, value matches pattern `PREFIX-N` or just `N` (digits) |
 | `created_by` | Present in at least one file, value is a non-empty string (user name or ID) |
 | `last_edited_by` | Present in at least one file, value is a non-empty string (user name or ID) |
+| `notion-frozen-at` | **Absent from every file** (regression guard — ref #54: the field was removed because it churned every entry's diff on every refresh) |
 
-- **Pass criteria:** All 3 keys found with valid non-null values.
+- **Pass criteria:** First 3 keys found with valid non-null values; `notion-frozen-at` produces zero matches across all `.md` files.
 
 ### Step 9: Verify file mtime preservation
 For each synced `.md` file, compare the file's modification time (via `stat`) against the `notion-last-edited` value in its frontmatter.

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -588,11 +588,15 @@ func runClean(args []string) error {
 	}
 
 	label := "Modified"
+	bumpLabel := "Stamped"
 	if *dryRun {
 		label = "Would modify"
+		bumpLabel = "Would stamp"
 	}
 	fmt.Printf("Scanned: %d files\n", r.FilesScanned)
-	fmt.Printf("%s: %d files (%d URLs stripped, %d trailing newlines added)\n", label, r.FilesChanged, r.URLsStripped, r.NewlinesFixed)
+	fmt.Printf("%s: %d files (%d URLs stripped, %d trailing newlines added, %d notion-frozen-at lines stripped)\n",
+		label, r.FilesChanged, r.URLsStripped, r.NewlinesFixed, r.FrozenAtStripped)
+	fmt.Printf("%s syncVersion in: %d folder(s)\n", bumpLabel, r.MetadataBumped)
 	return nil
 }
 

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -119,6 +119,8 @@ func Folder(root string, dryRun bool) (*Result, error) {
 		}
 
 		r.FilesChanged++
+		// Any cleanup in a folder — including a JSON file gaining a trailing
+		// newline — marks the folder dirty so its metadata gets re-stamped.
 		dirtyDirs[filepath.Dir(path)] = true
 
 		if dryRun {
@@ -152,7 +154,7 @@ func Folder(root string, dryRun bool) (*Result, error) {
 				r.MetadataBumped++
 			}
 		}
-	} else {
+	} else if sync.Version != "" {
 		for dir := range dirtyDirs {
 			if folderHasMetadata(dir) {
 				r.MetadataBumped++
@@ -176,7 +178,15 @@ func folderHasMetadata(dir string) bool {
 // bumpFolderMetadata re-writes _database.json or _page.json in dir (if present)
 // so the syncVersion field is stamped with the current binary's version.
 // Returns true if a metadata file was rewritten.
+//
+// If sync.Version is empty (a misconfigured caller that didn't wire the build
+// version), the bump is skipped entirely — rewriting without a version would
+// produce a file with no stamp while still incrementing MetadataBumped, which
+// is a misleading user-visible counter.
 func bumpFolderMetadata(dir string) (bool, error) {
+	if sync.Version == "" {
+		return false, nil
+	}
 	if dbMeta, err := sync.ReadDatabaseMetadata(dir); err == nil && dbMeta != nil {
 		if err := sync.WriteDatabaseMetadata(dir, dbMeta); err != nil {
 			return false, fmt.Errorf("rewrite %s: %w", sync.DatabaseMetadataFile, err)

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -1,13 +1,21 @@
-// Package clean strips AWS S3 pre-signed query strings from already-imported
-// Markdown files, without making any Notion API calls.
+// Package clean performs in-place cleanups on an already-imported notion-sync
+// workspace, without making any Notion API calls. It exists to absorb one-time
+// migrations after upgrading the binary so routine refreshes produce focused
+// diffs.
 //
-// Notion file URLs (PDFs, images, attachments) carry a query string
-// (X-Amz-Signature, X-Amz-Date, X-Amz-Credential, etc.) that rotates every
-// hour. The path is stable. Routine refreshes therefore produce a giant diff
-// of pure URL noise. This package walks already-imported .md files and
-// strips those query strings in-place, producing a one-time focused commit
-// after which routine refreshes (with the default-on stripping in the sync
-// path) stay clean.
+// Cleanups applied:
+//   - Strips Notion's S3 pre-signed query strings (X-Amz-Signature, etc.) from
+//     file URLs in .md content. The query string rotates hourly while the path
+//     is stable, so leaving them in produced large noise diffs on every refresh.
+//   - Removes the deprecated `notion-frozen-at` line from YAML frontmatter. The
+//     field used to be written on every freeze, which churned every entry's
+//     diff even when content was byte-identical.
+//   - Ensures .md and .json files end with a trailing newline.
+//
+// For each folder it modifies, the corresponding _database.json or _page.json
+// is re-written so the syncVersion field reflects the binary that performed
+// the cleanup — giving the workspace an audit trail of which notion-sync
+// version last touched it.
 package clean
 
 import (
@@ -17,6 +25,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/ran-codes/notion-sync/internal/sync"
 )
 
 // presignedURLPattern matches Notion's S3 pre-signed URLs. Anchored on the
@@ -33,21 +43,28 @@ var presignedURLPattern = regexp.MustCompile(
 
 // Result summarizes a clean run.
 type Result struct {
-	FilesScanned  int
-	FilesChanged  int
-	URLsStripped  int
-	NewlinesFixed int
-	DryRun        bool
+	FilesScanned     int
+	FilesChanged     int
+	URLsStripped     int
+	NewlinesFixed    int
+	FrozenAtStripped int
+	MetadataBumped   int
+	DryRun           bool
 }
 
 // Folder walks `root` recursively and applies cleanups to eligible files:
 //   - strips pre-signed S3 query strings from `.md` files
+//   - removes `notion-frozen-at:` lines from `.md` frontmatter
 //   - appends a trailing newline to `.md` and `.json` files that are missing one
+//
+// After the walk, any folder whose files were modified has its `_database.json`
+// or `_page.json` re-stamped with the current binary's syncVersion.
 //
 // When dryRun is true, files are not modified; the result reports what would
 // have changed.
 func Folder(root string, dryRun bool) (*Result, error) {
 	r := &Result{DryRun: dryRun}
+	dirtyDirs := make(map[string]bool)
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -82,6 +99,13 @@ func Folder(root string, dryRun bool) (*Result, error) {
 				r.URLsStripped += count
 				changed = true
 			}
+
+			defrozen, fcount := stripFrozenAt(out)
+			if fcount > 0 {
+				out = defrozen
+				r.FrozenAtStripped += fcount
+				changed = true
+			}
 		}
 
 		if len(out) > 0 && out[len(out)-1] != '\n' {
@@ -95,6 +119,7 @@ func Folder(root string, dryRun bool) (*Result, error) {
 		}
 
 		r.FilesChanged++
+		dirtyDirs[filepath.Dir(path)] = true
 
 		if dryRun {
 			return nil
@@ -112,7 +137,118 @@ func Folder(root string, dryRun bool) (*Result, error) {
 	if err != nil {
 		return r, err
 	}
+
+	// For each folder we touched, re-write its _database.json or _page.json so
+	// the syncVersion field reflects the binary that performed the cleanup. This
+	// gives users a record of which notion-sync version last mutated the
+	// workspace. Skipped in dry-run.
+	if !dryRun {
+		for dir := range dirtyDirs {
+			bumped, err := bumpFolderMetadata(dir)
+			if err != nil {
+				return r, err
+			}
+			if bumped {
+				r.MetadataBumped++
+			}
+		}
+	} else {
+		for dir := range dirtyDirs {
+			if folderHasMetadata(dir) {
+				r.MetadataBumped++
+			}
+		}
+	}
+
 	return r, nil
+}
+
+// folderHasMetadata reports whether a folder contains _database.json or _page.json.
+func folderHasMetadata(dir string) bool {
+	for _, name := range []string{sync.DatabaseMetadataFile, sync.PageMetadataFile} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// bumpFolderMetadata re-writes _database.json or _page.json in dir (if present)
+// so the syncVersion field is stamped with the current binary's version.
+// Returns true if a metadata file was rewritten.
+func bumpFolderMetadata(dir string) (bool, error) {
+	if dbMeta, err := sync.ReadDatabaseMetadata(dir); err == nil && dbMeta != nil {
+		if err := sync.WriteDatabaseMetadata(dir, dbMeta); err != nil {
+			return false, fmt.Errorf("rewrite %s: %w", sync.DatabaseMetadataFile, err)
+		}
+		return true, nil
+	}
+	if pageMeta, err := sync.ReadPageMetadata(dir); err == nil && pageMeta != nil {
+		if err := sync.WritePageMetadata(dir, pageMeta); err != nil {
+			return false, fmt.Errorf("rewrite %s: %w", sync.PageMetadataFile, err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// frozenAtKeyPattern matches a `notion-frozen-at:` line (with optional surrounding
+// whitespace) inside YAML frontmatter. The key is anchored at line start so it
+// won't match the substring inside another property's value.
+var frozenAtKeyPattern = regexp.MustCompile(`(?m)^[ \t]*notion-frozen-at[ \t]*:.*\r?\n?`)
+
+// stripFrozenAt removes any `notion-frozen-at:` line from the YAML frontmatter
+// of a Markdown file. Body content is not touched. Returns the modified content
+// and the number of lines stripped.
+//
+// The frontmatter is the region between the first `---` line at the start of
+// the file and the next `---` line.
+func stripFrozenAt(s string) (string, int) {
+	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
+		return s, 0
+	}
+	openLen := 4
+	if strings.HasPrefix(s, "---\r\n") {
+		openLen = 5
+	}
+
+	rest := s[openLen:]
+	closeIdx := indexOfFrontmatterClose(rest)
+	if closeIdx < 0 {
+		return s, 0
+	}
+
+	fmRegion := rest[:closeIdx]
+	stripped := frozenAtKeyPattern.ReplaceAllString(fmRegion, "")
+	count := strings.Count(fmRegion, "\n") - strings.Count(stripped, "\n")
+	if count <= 0 {
+		return s, 0
+	}
+	return s[:openLen] + stripped + rest[closeIdx:], count
+}
+
+// indexOfFrontmatterClose returns the byte offset (relative to rest) of the
+// closing `---` line of YAML frontmatter, or -1 if not found.
+func indexOfFrontmatterClose(rest string) int {
+	for i := 0; i < len(rest); {
+		// Find next newline.
+		nl := strings.Index(rest[i:], "\n")
+		var line string
+		if nl < 0 {
+			line = rest[i:]
+		} else {
+			line = rest[i : i+nl]
+		}
+		trimmed := strings.TrimRight(line, "\r")
+		if trimmed == "---" {
+			return i
+		}
+		if nl < 0 {
+			return -1
+		}
+		i += nl + 1
+	}
+	return -1
 }
 
 // stripContent returns the input with all S3 pre-signed query strings removed,

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ran-codes/notion-sync/internal/sync"
 )
 
 func TestStripContent_FrontmatterFileProperty(t *testing.T) {
@@ -257,6 +259,292 @@ func TestFolder_JSONURLsNotStripped(t *testing.T) {
 	}
 	if r.FilesChanged != 0 {
 		t.Errorf("file already has trailing newline, should be unchanged, got FilesChanged=%d", r.FilesChanged)
+	}
+}
+
+func TestFolder_StripsFrozenAtLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	original := `---
+notion-id: abc
+notion-url: https://notion.so/abc
+notion-frozen-at: "2024-01-01T00:00:00Z"
+notion-last-edited: "2024-01-02T00:00:00Z"
+notion-database-id: db-1
+---
+
+body
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FrozenAtStripped != 1 {
+		t.Errorf("FrozenAtStripped = %d, want 1", r.FrozenAtStripped)
+	}
+	if r.FilesChanged != 1 {
+		t.Errorf("FilesChanged = %d, want 1", r.FilesChanged)
+	}
+
+	got, _ := os.ReadFile(path)
+	if strings.Contains(string(got), "notion-frozen-at") {
+		t.Errorf("file still contains notion-frozen-at:\n%s", got)
+	}
+	for _, keep := range []string{"notion-id: abc", "notion-last-edited:", "notion-database-id: db-1", "body"} {
+		if !strings.Contains(string(got), keep) {
+			t.Errorf("expected %q to remain in file:\n%s", keep, got)
+		}
+	}
+}
+
+func TestFolder_StripsFrozenAtLine_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	original := `---
+notion-id: abc
+notion-frozen-at: "2024-01-01T00:00:00Z"
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FrozenAtStripped != 1 {
+		t.Errorf("dry-run FrozenAtStripped = %d, want 1", r.FrozenAtStripped)
+	}
+
+	got, _ := os.ReadFile(path)
+	if string(got) != original {
+		t.Errorf("dry-run mutated file:\n%s", got)
+	}
+}
+
+func TestFolder_StripsFrozenAtLine_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	cleanContent := `---
+notion-id: abc
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(path, []byte(cleanContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FrozenAtStripped != 0 {
+		t.Errorf("FrozenAtStripped = %d, want 0 (already clean)", r.FrozenAtStripped)
+	}
+
+	got, _ := os.ReadFile(path)
+	if string(got) != cleanContent {
+		t.Errorf("idempotent run mutated content:\n%s", got)
+	}
+}
+
+func TestFolder_StripsFrozenAtLine_OnlyInFrontmatter(t *testing.T) {
+	// A body line that happens to contain "notion-frozen-at:" must NOT be touched.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	original := `---
+notion-id: abc
+---
+
+This page documents the deprecated notion-frozen-at: "2024-01-01" key.
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), `deprecated notion-frozen-at: "2024-01-01"`) {
+		t.Errorf("body line was modified — should only strip from frontmatter:\n%s", got)
+	}
+}
+
+func TestFolder_BumpsSyncVersionInDirtyDatabaseFolder(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+
+	dbJSON := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://notion.so/db-1",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.5.0"
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "_database.json"), []byte(dbJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	md := `---
+notion-id: abc
+notion-frozen-at: "2024-01-01T00:00:00Z"
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, "abc.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.MetadataBumped != 1 {
+		t.Errorf("MetadataBumped = %d, want 1", r.MetadataBumped)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "_database.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), `"syncVersion": "v0.99.0-test"`) {
+		t.Errorf("syncVersion not bumped:\n%s", got)
+	}
+	if !strings.Contains(string(got), `"databaseId": "db-1"`) {
+		t.Errorf("databaseId field lost:\n%s", got)
+	}
+	if !strings.Contains(string(got), `"entryCount": 1`) {
+		t.Errorf("entryCount field lost:\n%s", got)
+	}
+}
+
+func TestFolder_LeavesCleanFolderMetadataUntouched(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+
+	dbJSON := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://notion.so/db-1",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.5.0"
+}
+`
+	dbPath := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(dbPath, []byte(dbJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// .md file with no notion-frozen-at, no presigned URLs, trailing newline already present.
+	md := `---
+notion-id: abc
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, "abc.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FilesChanged != 0 {
+		t.Errorf("FilesChanged = %d, want 0 (folder was already clean)", r.FilesChanged)
+	}
+	if r.MetadataBumped != 0 {
+		t.Errorf("MetadataBumped = %d, want 0 (no .md changes ⇒ no metadata bump)", r.MetadataBumped)
+	}
+
+	got, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != dbJSON {
+		t.Errorf("_database.json was rewritten despite folder being clean:\n%s", got)
+	}
+}
+
+func TestFolder_BumpsSyncVersionInDirtyStandalonePageFolder(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	root := t.TempDir()
+	pageDir := filepath.Join(root, "pages", "MyPage_abc12345")
+	if err := os.MkdirAll(pageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	pageJSON := `{
+  "pageId": "page-1",
+  "title": "MyPage",
+  "url": "https://notion.so/page-1",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "syncVersion": "v0.5.0"
+}
+`
+	if err := os.WriteFile(filepath.Join(pageDir, "_page.json"), []byte(pageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	md := `---
+notion-id: page-1
+notion-frozen-at: "2024-01-01T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(filepath.Join(pageDir, "MyPage.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.MetadataBumped != 1 {
+		t.Errorf("MetadataBumped = %d, want 1", r.MetadataBumped)
+	}
+
+	got, err := os.ReadFile(filepath.Join(pageDir, "_page.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), `"syncVersion": "v0.99.0-test"`) {
+		t.Errorf("syncVersion not bumped in _page.json:\n%s", got)
+	}
+	if !strings.Contains(string(got), `"pageId": "page-1"`) {
+		t.Errorf("pageId field lost:\n%s", got)
 	}
 }
 

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -439,6 +439,67 @@ body
 	}
 }
 
+func TestFolder_SkipsMetadataBumpWhenVersionUnset(t *testing.T) {
+	// If sync.Version is empty (misconfigured caller), bumping would rewrite
+	// the file without a stamp while still claiming MetadataBumped. Skip both.
+	prev := sync.Version
+	sync.Version = ""
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+
+	dbJSON := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://notion.so/db-1",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.5.0"
+}
+`
+	dbPath := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(dbPath, []byte(dbJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	md := `---
+notion-id: abc
+notion-frozen-at: "2024-01-01T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, "abc.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.MetadataBumped != 0 {
+		t.Errorf("MetadataBumped = %d, want 0 when sync.Version is empty", r.MetadataBumped)
+	}
+
+	got, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != dbJSON {
+		t.Errorf("_database.json was rewritten despite empty sync.Version:\n%s", got)
+	}
+
+	// Dry-run path should also stay silent.
+	r2, err := Folder(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r2.MetadataBumped != 0 {
+		t.Errorf("dry-run MetadataBumped = %d, want 0 when sync.Version is empty", r2.MetadataBumped)
+	}
+}
+
 func TestFolder_LeavesCleanFolderMetadataUntouched(t *testing.T) {
 	prev := sync.Version
 	sync.Version = "v0.99.0-test"

--- a/internal/sync/agents.go
+++ b/internal/sync/agents.go
@@ -54,7 +54,6 @@ Every ` + "`.md`" + ` file starts with YAML frontmatter. The first block is alwa
 ---
 notion-id: "<page-uuid>"
 notion-url: "https://www.notion.so/..."
-notion-frozen-at: "<RFC 3339 — when this file was last written>"
 notion-last-edited: "<RFC 3339 — Notion's last_edited_time>"
 notion-database-id: "<database-uuid>"   # only present for database entries
 # notion-deleted: true                  # only present if the entry was removed in Notion (soft delete)
@@ -150,7 +149,7 @@ For multi-source databases, the **top-level** ` + "`_database.json`" + ` has no 
 - Default ` + "`refresh`" + ` is incremental: entries whose ` + "`notion-last-edited`" + ` matches the local copy are skipped.
 - ` + "`refresh --force`" + ` resyncs every entry regardless of timestamp.
 - ` + "`refresh --ids id1,id2`" + ` resyncs specific pages by ID.
-- ` + "`clean <folder>`" + ` strips presigned URLs from existing files **without** any API call — used as a one-time backfill after upgrading.
+- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call — strips presigned URLs, removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line, and ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files. Any folder it modifies has its ` + "`_database.json`" + ` or ` + "`_page.json`" + ` re-stamped with the current ` + "`syncVersion`" + ` so the workspace records which binary last touched it. Used as a one-time backfill after upgrading.
 
 ## Push semantics (writing local changes back to Notion)
 

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -101,7 +101,6 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 	fm := map[string]interface{}{
 		"notion-id":          opts.NotionID,
 		"notion-url":         page.URL,
-		"notion-frozen-at":   time.Now().UTC().Format(time.RFC3339),
 		"notion-last-edited": page.LastEditedTime,
 	}
 	if opts.DatabaseID != "" {
@@ -117,7 +116,6 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 	keyOrder := []string{
 		"notion-id",
 		"notion-url",
-		"notion-frozen-at",
 		"notion-last-edited",
 		"notion-database-id",
 	}

--- a/internal/sync/page_test.go
+++ b/internal/sync/page_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ran-codes/notion-sync/internal/notion"
@@ -451,6 +452,36 @@ func TestMapPropertiesToFrontmatter_UnknownTypeSkipped(t *testing.T) {
 
 	if len(fm) != 0 {
 		t.Errorf("expected empty frontmatter for unknown types, got %v", fm)
+	}
+}
+
+func TestFreezePage_DoesNotEmitFrozenAt(t *testing.T) {
+	// notion-frozen-at was removed because it added per-file diff churn on every
+	// refresh without driving any logic. The database-level lastSyncedAt in
+	// _database.json is the authoritative "when was this synced" record.
+	dir := t.TempDir()
+	page := testPage("page-id-frozen", "Frozen Test", "2025-01-01T00:00:00Z")
+	client := newMockClient()
+	client.pages["page-id-frozen"] = &page
+	client.blocks["page-id-frozen"] = []notion.Block{}
+
+	_, err := FreezePage(FreezePageOptions{
+		Client:       client,
+		NotionID:     "page-id-frozen",
+		OutputFolder: dir,
+		DatabaseID:   "db-1",
+		Page:         &page,
+	})
+	if err != nil {
+		t.Fatalf("FreezePage: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "page-id-frozen.md"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "notion-frozen-at") {
+		t.Errorf("freshly-written file should not contain notion-frozen-at:\n%s", data)
 	}
 }
 

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -165,7 +165,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 // buildPropertyPayload constructs the Notion API property update payload from frontmatter.
 // Uses the database schema to determine property types; skips read-only / Notion-native properties.
 var pushNotionKeys = map[string]bool{
-	"notion-id": true, "notion-url": true, "notion-frozen-at": true,
+	"notion-id": true, "notion-url": true,
 	"notion-last-edited": true, "notion-database-id": true,
 	"notion-deleted": true, "notion-last-pushed": true,
 }

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -15,7 +15,6 @@ func TestBuildPropertyPayload_SkipsNotionKeys(t *testing.T) {
 	fm := map[string]interface{}{
 		"notion-id":          "abc",
 		"notion-url":         "https://notion.so/abc",
-		"notion-frozen-at":   "2024-01-01T00:00:00Z",
 		"notion-last-edited": "2024-01-01T00:00:00Z",
 		"notion-database-id": "db1",
 		"notion-deleted":     false,
@@ -278,7 +277,6 @@ func TestPushDatabase_PushesProperties(t *testing.T) {
 	md := "---\n" +
 		"notion-id: page-001\n" +
 		"notion-url: https://notion.so/page-001\n" +
-		"notion-frozen-at: 2024-01-01T00:00:00Z\n" +
 		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
 		"notion-database-id: db-001\n" +
 		"Status: In Progress\n" +


### PR DESCRIPTION
## Context

- Addressess #54
- goal is to produce cleaner diffs and remuve churn from the refresh PRs

## Aciton Items

- [x] Issue eval
- [x] TDD
- [ ] Code Review
- [ ] E2E testing