### PR TITLE
fix(push): refetch precise last_edited_time after UpdatePage

### DIFF
--- a/internal/sync/mock_client_test.go
+++ b/internal/sync/mock_client_test.go
@@ -14,6 +14,15 @@ type mockNotionClient struct {
 	pages          map[string]*notion.Page
 	blocks         map[string][]notion.Block // keyed by blockID
 	updateRequests []updateRequest           // recorded UpdatePage calls
+	// updatePageReturns, when set for a page ID, is what UpdatePage returns
+	// for that ID instead of pages[id]. Simulates Notion's real behavior
+	// where UpdatePage echoes a minute-quantized last_edited_time while the
+	// stored value (returned by GetPage / QueryDataSource) is precise.
+	updatePageReturns map[string]*notion.Page
+	// postUpdatePages, when set for a page ID, replaces pages[id] after a
+	// successful UpdatePage call. Simulates Notion's stored state advancing
+	// to a precise post-edit timestamp that subsequent GetPage calls see.
+	postUpdatePages map[string]*notion.Page
 }
 
 type updateRequest struct {
@@ -23,11 +32,13 @@ type updateRequest struct {
 
 func newMockClient() *mockNotionClient {
 	return &mockNotionClient{
-		databases:   make(map[string]*notion.Database),
-		dataSources: make(map[string]*notion.DataSourceDetail),
-		entries:     make(map[string][]notion.Page),
-		pages:       make(map[string]*notion.Page),
-		blocks:      make(map[string][]notion.Block),
+		databases:         make(map[string]*notion.Database),
+		dataSources:       make(map[string]*notion.DataSourceDetail),
+		entries:           make(map[string][]notion.Page),
+		pages:             make(map[string]*notion.Page),
+		blocks:            make(map[string][]notion.Block),
+		updatePageReturns: make(map[string]*notion.Page),
+		postUpdatePages:   make(map[string]*notion.Page),
 	}
 }
 
@@ -65,11 +76,24 @@ func (m *mockNotionClient) GetPage(pageID string) (*notion.Page, error) {
 
 func (m *mockNotionClient) UpdatePage(pageID string, properties map[string]interface{}) (*notion.Page, error) {
 	m.updateRequests = append(m.updateRequests, updateRequest{PageID: pageID, Properties: properties})
-	page, ok := m.pages[pageID]
-	if !ok {
-		return nil, fmt.Errorf("page %s not found", pageID)
+
+	var response *notion.Page
+	if override, ok := m.updatePageReturns[pageID]; ok {
+		response = override
+	} else {
+		page, ok := m.pages[pageID]
+		if !ok {
+			return nil, fmt.Errorf("page %s not found", pageID)
+		}
+		response = page
 	}
-	return page, nil
+
+	// Simulate Notion's stored state advancing after a successful update.
+	if post, ok := m.postUpdatePages[pageID]; ok {
+		m.pages[pageID] = post
+	}
+
+	return response, nil
 }
 
 func (m *mockNotionClient) FetchAllBlocks(blockID string) ([]notion.Block, error) {

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -142,12 +142,21 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		// is precise. Re-fetch so the local frontmatter holds the precise value
 		// and the next refresh doesn't see the page as stale. See issue #57.
 		newLastEdited := ""
-		if refetched, err := opts.Client.GetPage(notionID); err == nil && refetched != nil {
+		refetched, refetchErr := opts.Client.GetPage(notionID)
+		if refetchErr == nil && refetched != nil {
 			newLastEdited = refetched.LastEditedTime
-		} else if updated != nil && updated.LastEditedTime != "" {
-			newLastEdited = updated.LastEditedTime
-		} else if notionPage != nil {
-			newLastEdited = notionPage.LastEditedTime
+		} else {
+			if refetchErr != nil {
+				// Non-fatal: push succeeded; we just couldn't refetch the precise
+				// timestamp. Surface it so silent failures don't quietly reintroduce
+				// the quantized-timestamp bug this code exists to avoid.
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: refetch precise timestamp: %v", filepath.Base(f.path), refetchErr))
+			}
+			if updated != nil && updated.LastEditedTime != "" {
+				newLastEdited = updated.LastEditedTime
+			} else if notionPage != nil {
+				newLastEdited = notionPage.LastEditedTime
+			}
 		}
 
 		pushedAt := time.Now().UTC().Format(time.RFC3339)

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -137,10 +137,14 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 			continue
 		}
 
-		// Use the returned last_edited_time if available, otherwise fall back to the
-		// value we already fetched during conflict check.
+		// UpdatePage's response echoes last_edited_time quantized to whole
+		// minutes, but Notion's stored value (returned by GetPage / QueryDataSource)
+		// is precise. Re-fetch so the local frontmatter holds the precise value
+		// and the next refresh doesn't see the page as stale. See issue #57.
 		newLastEdited := ""
-		if updated != nil && updated.LastEditedTime != "" {
+		if refetched, err := opts.Client.GetPage(notionID); err == nil && refetched != nil {
+			newLastEdited = refetched.LastEditedTime
+		} else if updated != nil && updated.LastEditedTime != "" {
 			newLastEdited = updated.LastEditedTime
 		} else if notionPage != nil {
 			newLastEdited = notionPage.LastEditedTime

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -618,6 +618,64 @@ func TestPushDatabase_WritesLastPushed(t *testing.T) {
 	}
 }
 
+// Notion's UpdatePage response echoes last_edited_time quantized to whole
+// minutes, while the value Notion stores (and that QueryDataSource / GetPage
+// return) is precise. If push wrote the quantized value to local frontmatter,
+// the next refresh would see local != remote and re-fetch the page block tree
+// for nothing. Push must therefore reconcile by re-fetching the precise
+// timestamp via GetPage after UpdatePage and writing that to the file.
+func TestPushDatabase_WritesPreciseLastEditedAfterUpdate(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2026-04-30T22:00:00Z\n" +
+		"notion-database-id: db-001\n" +
+		"Status: Done\n" +
+		"---\n"
+	filePath := filepath.Join(dir, "page-001.md")
+	if err := os.WriteFile(filePath, []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+	// Pre-update GetPage (conflict check) returns the local timestamp.
+	client.pages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2026-04-30T22:00:00Z",
+	}
+	// UpdatePage echoes a minute-quantized timestamp (Notion's API behavior).
+	client.updatePageReturns["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2026-04-30T22:43:00.000Z",
+	}
+	// After UpdatePage, Notion's stored state has the precise timestamp,
+	// which is what subsequent GetPage / QueryDataSource calls would see.
+	preciseTime := "2026-04-30T22:43:25.123Z"
+	client.postUpdatePages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: preciseTime,
+	}
+
+	if _, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(filePath)
+	s := string(got)
+	if !strings.Contains(s, "notion-last-edited: "+preciseTime) {
+		t.Errorf("expected frontmatter to contain precise timestamp %q (from post-update GetPage), got:\n%s", preciseTime, s)
+	}
+	if strings.Contains(s, "notion-last-edited: 2026-04-30T22:43:00.000Z") {
+		t.Error("frontmatter still has the quantized timestamp from UpdatePage's response")
+	}
+}
+
 func TestUpdateAfterPush_DoesNotCorruptValueContainingKey(t *testing.T) {
 	dir := t.TempDir()
 	// A property value contains the substring "notion-last-edited:" — the function

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -676,6 +676,65 @@ func TestPushDatabase_WritesPreciseLastEditedAfterUpdate(t *testing.T) {
 	}
 }
 
+// When the post-update GetPage refetch fails (rate limit, network blip, etc.),
+// push must still succeed (UpdatePage already committed) but the failure must
+// be surfaced as a non-fatal warning in result.Errors. Silent fallback to the
+// quantized timestamp would defeat the precise-timestamp fix without any signal
+// to the caller — they'd silently get the bug back.
+func TestPushDatabase_RefetchFailure_RecordsNonFatalWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2026-04-30T22:00:00Z\n" +
+		"notion-database-id: db-001\n" +
+		"Status: Done\n" +
+		"---\n"
+	filePath := filepath.Join(dir, "page-001.md")
+	if err := os.WriteFile(filePath, []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+	// UpdatePage succeeds and returns the quantized timestamp.
+	client.updatePageReturns["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2026-04-30T22:43:00.000Z",
+	}
+	// pages["page-001"] is intentionally NOT set so the post-update GetPage
+	// refetch returns "page not found". Force=true skips the pre-update
+	// conflict-check GetPage, so the only GetPage call in this run is the
+	// post-update refetch — guaranteed to fail.
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, Force: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Pushed != 1 {
+		t.Errorf("expected Pushed=1 (push should succeed despite refetch failure), got %d", result.Pushed)
+	}
+	if result.Failed != 0 {
+		t.Errorf("expected Failed=0 (refetch failure is non-fatal), got %d", result.Failed)
+	}
+
+	var foundRefetchErr bool
+	for _, e := range result.Errors {
+		if strings.Contains(e, "page-001.md") && strings.Contains(strings.ToLower(e), "refetch") {
+			foundRefetchErr = true
+			break
+		}
+	}
+	if !foundRefetchErr {
+		t.Errorf("expected result.Errors to contain a refetch warning for page-001.md, got: %v", result.Errors)
+	}
+}
+
 func TestUpdateAfterPush_DoesNotCorruptValueContainingKey(t *testing.T) {
 	dir := t.TempDir()
 	// A property value contains the substring "notion-last-edited:" — the function


### PR DESCRIPTION
## Context

- Addresess #57 

## Changes
- After a successful `UpdatePage`, push now calls `GetPage` to refetch the precise `last_edited_time` and writes that to local `notion-last-edited` — instead of writing the minute-quantized echo from `UpdatePage`'s response. ([internal/sync/push.go](https://github.com/Drexel-UHC/notion-sync/blob/2af95b19e3226c96005f27e7ab72c6c217590f23/internal/sync/push.go))
- Falls back to the `UpdatePage` response, then to the pre-update `notionPage`, if the post-update `GetPage` errors — same non-fatal philosophy as the existing timestamp-write path.
- Adds `TestPushDatabase_WritesPreciseLastEditedAfterUpdate` ([internal/sync/push_test.go](https://github.com/Drexel-UHC/notion-sync/blob/2af95b19e3226c96005f27e7ab72c6c217590f23/internal/sync/push_test.go)) — fails on the old code, passes on the new.
- Extends the test mock ([internal/sync/mock_client_test.go](https://github.com/Drexel-UHC/notion-sync/blob/2af95b19e3226c96005f27e7ab72c6c217590f23/internal/sync/mock_client_test.go)) with `updatePageReturns` (override `UpdatePage`'s echo) and `postUpdatePages` (advance stored state after `UpdatePage`), mirroring Notion's real API divergence.

Related to #57

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)