### PR TITLE
fix(import): detect page-on-databases-endpoint 400 in auto-detect

### DIFF
--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -402,6 +402,9 @@ func (c *Client) QueryAllEntries(dataSourceID string) ([]Page, error) {
 func IsNotFoundError(err error) bool {
 	var apiErr *ErrorResponse
 	if errors.As(err, &apiErr) {
+		// Notion has no specific error code for the page-on-/databases/ mismatch
+		// as of 2026-05, so we substring-match the message. Revisit if they add
+		// a more specific code.
 		return apiErr.Status == 404 ||
 			apiErr.Code == "object_not_found" ||
 			(apiErr.Status == 401 && strings.Contains(apiErr.Message, "API token is invalid")) ||

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -395,14 +395,17 @@ func (c *Client) QueryAllEntries(dataSourceID string) ([]Page, error) {
 
 // IsNotFoundError returns true if the error indicates the requested
 // Notion object was not found or not accessible as the expected type.
-// Notion returns 404 for missing objects and 401 "API token is invalid"
-// when querying an ID against the wrong object type (e.g. page ID on /databases/).
+// Notion returns 404 for missing objects, 401 "API token is invalid"
+// when querying an ID against the wrong object type (e.g. page ID on /databases/),
+// and 400 validation_error "is a page, not a database" for the same mismatch
+// on the /databases/ endpoint.
 func IsNotFoundError(err error) bool {
 	var apiErr *ErrorResponse
 	if errors.As(err, &apiErr) {
 		return apiErr.Status == 404 ||
 			apiErr.Code == "object_not_found" ||
-			(apiErr.Status == 401 && strings.Contains(apiErr.Message, "API token is invalid"))
+			(apiErr.Status == 401 && strings.Contains(apiErr.Message, "API token is invalid")) ||
+			(apiErr.Status == 400 && apiErr.Code == "validation_error" && strings.Contains(apiErr.Message, "is a page, not a database"))
 	}
 	return false
 }

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -2,6 +2,59 @@ package notion
 
 import "testing"
 
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *ErrorResponse
+		want bool
+	}{
+		{
+			// Auto-detect: GET /databases/{page-id} returns 400 validation_error.
+			// runImport relies on this to fall back to page import.
+			name: "400 validation_error 'is a page, not a database'",
+			err: &ErrorResponse{
+				Status:  400,
+				Code:    "validation_error",
+				Message: "Provided database_id 31357008-e885-80c3-90f4-d148f0854bba is a page, not a database. Use the pages API instead, or pass the ID of the database itself.",
+			},
+			want: true,
+		},
+		{
+			name: "404 object_not_found",
+			err:  &ErrorResponse{Status: 404, Code: "object_not_found", Message: "Could not find database"},
+			want: true,
+		},
+		{
+			name: "401 API token is invalid (page ID on database endpoint)",
+			err:  &ErrorResponse{Status: 401, Code: "unauthorized", Message: "API token is invalid"},
+			want: true,
+		},
+		{
+			name: "400 validation_error unrelated message",
+			err:  &ErrorResponse{Status: 400, Code: "validation_error", Message: "body failed validation: body.properties is not a recognized property"},
+			want: false,
+		},
+		{
+			name: "401 unrelated unauthorized",
+			err:  &ErrorResponse{Status: 401, Code: "unauthorized", Message: "Insufficient permissions"},
+			want: false,
+		},
+		{
+			name: "500 internal error",
+			err:  &ErrorResponse{Status: 500, Code: "internal_server_error", Message: "Something went wrong"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFoundError(tt.err); got != tt.want {
+				t.Errorf("IsNotFoundError(%+v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeNotionID(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Context
- `notion-sync import <page-id>` was erroring out with `Provided database_id ... is a page, not a database. Use the pages API instead, or pass the ID of the database itself.` instead of importing the page.
- The auto-detect path in `runImport` calls `GetDatabase` first and falls back to `runImportPage` only when `IsNotFoundError` returns `true`. Notion now responds to a page ID against `/databases/{id}` with HTTP **400 `validation_error`**, but `IsNotFoundError` only recognized 404, `object_not_found`, and 401 token-mismatch — so the fallback never fired.
- Surfaced by `/test-standalone-page` failing at Step 2 during the `/test` run.

## Changes
- [`internal/notion/client.go`](https://github.com/Drexel-UHC/notion-sync/blob/2d09ed1c9f9da716e8d68e2aaf7cc788f4949297/internal/notion/client.go) — extend `IsNotFoundError` with a 4th OR clause: 400 `validation_error` whose message contains `"is a page, not a database"` (narrow — code + message both matched so unrelated 400s aren't swallowed).
- [`internal/notion/client_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/2d09ed1c9f9da716e8d68e2aaf7cc788f4949297/internal/notion/client_test.go) — add table-driven `TestIsNotFoundError` covering the new case plus regression guards for 404, 401-token, 401-unrelated, 400-unrelated, and 500.
- Verified end-to-end: `notion-sync import 31357008-e885-80c3-90f4-d148f0854bba` now reports `Status: created`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)