### PR TITLE
feat: canonicalize Notion page URLs to app.notion.com/p/{id}

### DIFF
--- a/.claude/skills/test-single-datasource-db/SKILL.md
+++ b/.claude/skills/test-single-datasource-db/SKILL.md
@@ -84,11 +84,11 @@ Grep the synced `.md` files in `./test-output/test database obsdiain complex/` f
 | `created_by` | Present in at least one file, value is a non-empty string (user name or ID) |
 | `last_edited_by` | Present in at least one file, value is a non-empty string (user name or ID) |
 | `notion-frozen-at` | **Absent from every file** (regression guard — ref #54: the field was removed because it churned every entry's diff on every refresh) |
-| `notion-url` | Every file's value matches `https://app.notion.com/p/[a-f0-9]{32}` (regression guard — ref #63: legacy `www.notion.so/...` URLs must not leak through; helper canonicalizes on every write) |
+| `notion-url` | **Present in every file**, and the line matches `^notion-url:[ \t]*"?https://app\.notion\.com/p/[a-f0-9]{32}"?[ \t]*$` (regression guard — ref #63: legacy `www.notion.so/...` URLs must not leak through; the anchored pattern also catches a future writer that appends a query/fragment or drops the field entirely) |
 
-Also check `_database.json` in the synced folder: its `"url"` field must match `https://app.notion.com/p/[a-f0-9]{32}` (same regression guard, applied to the metadata writer's chokepoint).
+Also check `_database.json` in the synced folder: its `"url"` line must match `"url":[ \t]*"https://app\.notion\.com/p/[a-f0-9]{32}"` (same regression guard, applied to the metadata writer's chokepoint).
 
-- **Pass criteria:** First 3 keys found with valid non-null values; `notion-frozen-at` produces zero matches across all `.md` files; every `notion-url` in `.md` files and the `"url"` in `_database.json` matches the canonical pattern.
+- **Pass criteria:** First 3 keys found with valid non-null values; `notion-frozen-at` produces zero matches across all `.md` files; every `.md` file has a `notion-url` line matching the anchored canonical pattern, and `_database.json`'s `"url"` matches the anchored canonical pattern.
 
 ### Step 9: Verify file mtime preservation
 For each synced `.md` file, compare the file's modification time (via `stat`) against the `notion-last-edited` value in its frontmatter.

--- a/.claude/skills/test-single-datasource-db/SKILL.md
+++ b/.claude/skills/test-single-datasource-db/SKILL.md
@@ -84,8 +84,11 @@ Grep the synced `.md` files in `./test-output/test database obsdiain complex/` f
 | `created_by` | Present in at least one file, value is a non-empty string (user name or ID) |
 | `last_edited_by` | Present in at least one file, value is a non-empty string (user name or ID) |
 | `notion-frozen-at` | **Absent from every file** (regression guard — ref #54: the field was removed because it churned every entry's diff on every refresh) |
+| `notion-url` | Every file's value matches `https://app.notion.com/p/[a-f0-9]{32}` (regression guard — ref #63: legacy `www.notion.so/...` URLs must not leak through; helper canonicalizes on every write) |
 
-- **Pass criteria:** First 3 keys found with valid non-null values; `notion-frozen-at` produces zero matches across all `.md` files.
+Also check `_database.json` in the synced folder: its `"url"` field must match `https://app.notion.com/p/[a-f0-9]{32}` (same regression guard, applied to the metadata writer's chokepoint).
+
+- **Pass criteria:** First 3 keys found with valid non-null values; `notion-frozen-at` produces zero matches across all `.md` files; every `notion-url` in `.md` files and the `"url"` in `_database.json` matches the canonical pattern.
 
 ### Step 9: Verify file mtime preservation
 For each synced `.md` file, compare the file's modification time (via `stat`) against the `notion-last-edited` value in its frontmatter.

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -10,6 +10,10 @@
 //   - Removes the deprecated `notion-frozen-at` line from YAML frontmatter. The
 //     field used to be written on every freeze, which churned every entry's
 //     diff even when content was byte-identical.
+//   - Canonicalizes `notion-url:` values in .md frontmatter and `"url"` fields
+//     in metadata JSON to the `app.notion.com/p/{id}` form, so legacy
+//     `www.notion.so/Title-{id}` URLs from earlier syncs stop drifting against
+//     newly emitted ones.
 //   - Ensures .md and .json files end with a trailing newline.
 //
 // For each folder it modifies, the corresponding _database.json or _page.json
@@ -57,6 +61,8 @@ type Result struct {
 // Folder walks `root` recursively and applies cleanups to eligible files:
 //   - strips pre-signed S3 query strings from `.md` files
 //   - removes `notion-frozen-at:` lines from `.md` frontmatter
+//   - canonicalizes `notion-url:` values in `.md` frontmatter and `"url"`
+//     fields in `_database.json` / `_page.json`
 //   - appends a trailing newline to `.md` and `.json` files that are missing one
 //
 // After the walk, any folder whose files were modified has its `_database.json`
@@ -67,6 +73,12 @@ type Result struct {
 func Folder(root string, dryRun bool) (*Result, error) {
 	r := &Result{DryRun: dryRun}
 	dirtyDirs := make(map[string]bool)
+	// Per-folder count of non-canonical "url" values found in metadata JSON.
+	// Counted at walk time but only added to URLsCanonicalized once the
+	// corresponding bumpFolderMetadata succeeds (or, in dry-run, would
+	// succeed) — otherwise the user-visible counter would lie when
+	// sync.Version is unset or the metadata file fails to round-trip.
+	jsonURLCounts := make(map[string]int)
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -123,15 +135,18 @@ func Folder(root string, dryRun bool) (*Result, error) {
 			changed = true
 		}
 
-		// For metadata JSON, detect non-canonical Notion URLs and mark the
+		// For metadata JSON, record non-canonical Notion URLs and mark the
 		// folder dirty. The actual rewrite happens in bumpFolderMetadata, which
 		// goes through WriteDatabaseMetadata / WritePageMetadata — both
-		// canonicalize URLs as part of the write. Counting here gives users an
-		// accurate URLsCanonicalized total without duplicating rewrite logic.
+		// canonicalize URLs as part of the write. The count is held in
+		// jsonURLCounts and only folded into r.URLsCanonicalized after the
+		// rewrite is confirmed (or in dry-run, would be confirmed) — otherwise
+		// a missing sync.Version or an unparseable metadata file would leave
+		// the URL on disk while inflating the user-visible counter.
 		if isJSON && isMetadataFileName(d.Name()) {
 			ucount := countNonCanonicalNotionURLInJSON(out)
 			if ucount > 0 {
-				r.URLsCanonicalized += ucount
+				jsonURLCounts[filepath.Dir(path)] += ucount
 				dirtyDirs[filepath.Dir(path)] = true
 			}
 		}
@@ -174,12 +189,14 @@ func Folder(root string, dryRun bool) (*Result, error) {
 			}
 			if bumped {
 				r.MetadataBumped++
+				r.URLsCanonicalized += jsonURLCounts[dir]
 			}
 		}
 	} else if sync.Version != "" {
 		for dir := range dirtyDirs {
 			if folderHasMetadata(dir) {
 				r.MetadataBumped++
+				r.URLsCanonicalized += jsonURLCounts[dir]
 			}
 		}
 	}

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -226,15 +226,29 @@ func bumpFolderMetadata(dir string) (bool, error) {
 	if sync.Version == "" {
 		return false, nil
 	}
-	if dbMeta, err := sync.ReadDatabaseMetadata(dir); err == nil && dbMeta != nil {
+	// Read errors here mean the metadata file exists but is unreadable —
+	// permission denied, partial truncation, malformed JSON. ReadDatabaseMetadata
+	// and ReadPageMetadata return (nil, nil) for missing files, so a non-nil
+	// error always means real corruption that the user needs to see. Surface it
+	// instead of silently falling through, otherwise a broken _database.json
+	// would survive every clean run with no signal to the user.
+	dbMeta, err := sync.ReadDatabaseMetadata(dir)
+	if err != nil {
+		return false, fmt.Errorf("read %s in %s: %w", sync.DatabaseMetadataFile, dir, err)
+	}
+	if dbMeta != nil {
 		if err := sync.WriteDatabaseMetadata(dir, dbMeta); err != nil {
-			return false, fmt.Errorf("rewrite %s: %w", sync.DatabaseMetadataFile, err)
+			return false, fmt.Errorf("rewrite %s in %s: %w", sync.DatabaseMetadataFile, dir, err)
 		}
 		return true, nil
 	}
-	if pageMeta, err := sync.ReadPageMetadata(dir); err == nil && pageMeta != nil {
+	pageMeta, err := sync.ReadPageMetadata(dir)
+	if err != nil {
+		return false, fmt.Errorf("read %s in %s: %w", sync.PageMetadataFile, dir, err)
+	}
+	if pageMeta != nil {
 		if err := sync.WritePageMetadata(dir, pageMeta); err != nil {
-			return false, fmt.Errorf("rewrite %s: %w", sync.PageMetadataFile, err)
+			return false, fmt.Errorf("rewrite %s in %s: %w", sync.PageMetadataFile, dir, err)
 		}
 		return true, nil
 	}

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ran-codes/notion-sync/internal/notion"
 	"github.com/ran-codes/notion-sync/internal/sync"
 )
 
@@ -43,13 +44,14 @@ var presignedURLPattern = regexp.MustCompile(
 
 // Result summarizes a clean run.
 type Result struct {
-	FilesScanned     int
-	FilesChanged     int
-	URLsStripped     int
-	NewlinesFixed    int
-	FrozenAtStripped int
-	MetadataBumped   int
-	DryRun           bool
+	FilesScanned      int
+	FilesChanged      int
+	URLsStripped      int
+	NewlinesFixed     int
+	FrozenAtStripped  int
+	URLsCanonicalized int
+	MetadataBumped    int
+	DryRun            bool
 }
 
 // Folder walks `root` recursively and applies cleanups to eligible files:
@@ -106,12 +108,32 @@ func Folder(root string, dryRun bool) (*Result, error) {
 				r.FrozenAtStripped += fcount
 				changed = true
 			}
+
+			canonical, ucount := canonicalizeFrontmatterURL(out)
+			if ucount > 0 {
+				out = canonical
+				r.URLsCanonicalized += ucount
+				changed = true
+			}
 		}
 
 		if len(out) > 0 && out[len(out)-1] != '\n' {
 			out += "\n"
 			r.NewlinesFixed++
 			changed = true
+		}
+
+		// For metadata JSON, detect non-canonical Notion URLs and mark the
+		// folder dirty. The actual rewrite happens in bumpFolderMetadata, which
+		// goes through WriteDatabaseMetadata / WritePageMetadata — both
+		// canonicalize URLs as part of the write. Counting here gives users an
+		// accurate URLsCanonicalized total without duplicating rewrite logic.
+		if isJSON && isMetadataFileName(d.Name()) {
+			ucount := countNonCanonicalNotionURLInJSON(out)
+			if ucount > 0 {
+				r.URLsCanonicalized += ucount
+				dirtyDirs[filepath.Dir(path)] = true
+			}
 		}
 
 		if !changed {
@@ -207,6 +229,42 @@ func bumpFolderMetadata(dir string) (bool, error) {
 // won't match the substring inside another property's value.
 var frozenAtKeyPattern = regexp.MustCompile(`(?m)^[ \t]*notion-frozen-at[ \t]*:.*\r?\n?`)
 
+// notionURLLinePattern matches a `notion-url:` line in YAML frontmatter and
+// captures the URL value. The value may be quoted ("...") or bare; we keep
+// it tight by stopping at the line end.
+var notionURLLinePattern = regexp.MustCompile(`(?m)^([ \t]*notion-url[ \t]*:[ \t]*"?)([^"\r\n]*)("?[ \t]*\r?)$`)
+
+// jsonURLValuePattern matches a JSON `"url": "..."` field and captures the value.
+// Used to detect non-canonical Notion URLs in _database.json / _page.json.
+var jsonURLValuePattern = regexp.MustCompile(`"url"\s*:\s*"([^"]*)"`)
+
+// isMetadataFileName reports whether the given basename is one of the
+// notion-sync metadata files (case-insensitive on the file's lowercase form).
+func isMetadataFileName(name string) bool {
+	return name == sync.DatabaseMetadataFile || name == sync.PageMetadataFile
+}
+
+// countNonCanonicalNotionURLInJSON returns the number of `"url": "..."` fields
+// in the JSON content whose value is a Notion URL not in canonical form.
+// Used by the clean walk to decide whether a metadata folder is "dirty" because
+// its URL needs canonicalization.
+func countNonCanonicalNotionURLInJSON(s string) int {
+	count := 0
+	for _, m := range jsonURLValuePattern.FindAllStringSubmatch(s, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		val := m[1]
+		if val == "" {
+			continue
+		}
+		if notion.CanonicalizeNotionURL(val) != val {
+			count++
+		}
+	}
+	return count
+}
+
 // stripFrozenAt removes any `notion-frozen-at:` line from the YAML frontmatter
 // of a Markdown file. Body content is not touched. Returns the modified content
 // and the number of lines stripped.
@@ -259,6 +317,46 @@ func indexOfFrontmatterClose(rest string) int {
 		i += nl + 1
 	}
 	return -1
+}
+
+// canonicalizeFrontmatterURL rewrites the value of `notion-url:` inside YAML
+// frontmatter to the canonical app.notion.com/p/{id} form. Body content is not
+// touched. Returns the modified content and the number of URLs that were
+// changed (0 if the URL was already canonical or had no extractable Notion ID).
+func canonicalizeFrontmatterURL(s string) (string, int) {
+	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
+		return s, 0
+	}
+	openLen := 4
+	if strings.HasPrefix(s, "---\r\n") {
+		openLen = 5
+	}
+
+	rest := s[openLen:]
+	closeIdx := indexOfFrontmatterClose(rest)
+	if closeIdx < 0 {
+		return s, 0
+	}
+
+	count := 0
+	fmRegion := rest[:closeIdx]
+	rewritten := notionURLLinePattern.ReplaceAllStringFunc(fmRegion, func(match string) string {
+		groups := notionURLLinePattern.FindStringSubmatch(match)
+		if len(groups) != 4 {
+			return match
+		}
+		prefix, value, suffix := groups[1], groups[2], groups[3]
+		canonical := notion.CanonicalizeNotionURL(value)
+		if canonical == value {
+			return match
+		}
+		count++
+		return prefix + canonical + suffix
+	})
+	if count == 0 {
+		return s, 0
+	}
+	return s[:openLen] + rewritten + rest[closeIdx:], count
 }
 
 // stripContent returns the input with all S3 pre-signed query strings removed,

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -910,6 +910,44 @@ body
 	}
 }
 
+func TestFolder_SurfacesCorruptMetadataReadError(t *testing.T) {
+	// A corrupt _database.json (exists but malformed) used to be silently
+	// swallowed by bumpFolderMetadata, leaving the user with no signal that
+	// their workspace is broken. The clean walk must now surface the read
+	// error instead of returning success.
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "_database.json"), []byte("{ this is not valid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// A .md file with notion-frozen-at so the folder gets marked dirty and
+	// bumpFolderMetadata is reached.
+	md := `---
+notion-id: abc
+notion-frozen-at: "2024-01-01T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, "abc.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Folder(dir, false)
+	if err == nil {
+		t.Fatal("expected error from corrupt _database.json, got nil")
+	}
+	if !strings.Contains(err.Error(), "_database.json") {
+		t.Errorf("error should name the broken file, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Errorf("error should include the folder path, got: %v", err)
+	}
+}
+
 func TestFolder_RecursesIntoSubfolders(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -383,6 +383,307 @@ This page documents the deprecated notion-frozen-at: "2024-01-01" key.
 	}
 }
 
+func TestFolder_CanonicalizesNotionURLInFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	original := `---
+notion-id: 1234567890abcdef1234567890abcdef
+notion-url: "https://www.notion.so/Title-1234567890abcdef1234567890abcdef"
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsCanonicalized != 1 {
+		t.Errorf("URLsCanonicalized = %d, want 1", r.URLsCanonicalized)
+	}
+	if r.FilesChanged != 1 {
+		t.Errorf("FilesChanged = %d, want 1", r.FilesChanged)
+	}
+
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "https://app.notion.com/p/1234567890abcdef1234567890abcdef") {
+		t.Errorf("file missing canonical URL:\n%s", got)
+	}
+	if strings.Contains(string(got), "https://www.notion.so/") {
+		t.Errorf("file still contains legacy notion.so URL:\n%s", got)
+	}
+}
+
+func TestFolder_CanonicalizesURLInDatabaseJSON(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	dbJSON := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://www.notion.so/Title-1234567890abcdef1234567890abcdef",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.5.0"
+}
+`
+	dbPath := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(dbPath, []byte(dbJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsCanonicalized != 1 {
+		t.Errorf("URLsCanonicalized = %d, want 1", r.URLsCanonicalized)
+	}
+
+	got, _ := os.ReadFile(dbPath)
+	if !strings.Contains(string(got), `"url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef"`) {
+		t.Errorf("_database.json missing canonical url:\n%s", got)
+	}
+	if strings.Contains(string(got), "https://www.notion.so/") {
+		t.Errorf("_database.json still contains legacy notion.so URL:\n%s", got)
+	}
+}
+
+func TestFolder_BumpsMetadata_OnURLOnlyCanonicalization(t *testing.T) {
+	// Folder where the ONLY thing wrong is a non-canonical URL in _database.json.
+	// No .md changes, no presigned URLs, no frozen-at lines. The clean step
+	// must still mark the folder dirty and bump syncVersion + canonicalize URL
+	// in _database.json — otherwise legacy URLs in metadata files would silently
+	// survive every clean run.
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	dbJSON := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://www.notion.so/Title-1234567890abcdef1234567890abcdef",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.5.0"
+}
+`
+	dbPath := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(dbPath, []byte(dbJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanMd := `---
+notion-id: 1234567890abcdef1234567890abcdef
+notion-url: "https://app.notion.com/p/1234567890abcdef1234567890abcdef"
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, "entry.md"), []byte(cleanMd), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsCanonicalized != 1 {
+		t.Errorf("URLsCanonicalized = %d, want 1", r.URLsCanonicalized)
+	}
+	if r.MetadataBumped != 1 {
+		t.Errorf("MetadataBumped = %d, want 1 (URL-only change must trigger bump)", r.MetadataBumped)
+	}
+
+	got, _ := os.ReadFile(dbPath)
+	if !strings.Contains(string(got), `"url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef"`) {
+		t.Errorf("_database.json url not canonicalized:\n%s", got)
+	}
+	if !strings.Contains(string(got), `"syncVersion": "v0.99.0-test"`) {
+		t.Errorf("syncVersion not bumped:\n%s", got)
+	}
+}
+
+func TestFolder_CanonicalizeURL_DryRun(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "entry.md")
+	mdOriginal := `---
+notion-id: 1234567890abcdef1234567890abcdef
+notion-url: "https://www.notion.so/Title-1234567890abcdef1234567890abcdef"
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(mdPath, []byte(mdOriginal), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "_database.json")
+	dbOriginal := `{
+  "databaseId": "db-1",
+  "url": "https://www.notion.so/Title-1234567890abcdef1234567890abcdef",
+  "syncVersion": "v0.5.0"
+}
+`
+	if err := os.WriteFile(dbPath, []byte(dbOriginal), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsCanonicalized != 2 {
+		t.Errorf("dry-run URLsCanonicalized = %d, want 2 (1 .md + 1 .json)", r.URLsCanonicalized)
+	}
+
+	gotMd, _ := os.ReadFile(mdPath)
+	if string(gotMd) != mdOriginal {
+		t.Errorf("dry-run mutated .md:\n%s", gotMd)
+	}
+	gotDb, _ := os.ReadFile(dbPath)
+	if string(gotDb) != dbOriginal {
+		t.Errorf("dry-run mutated _database.json:\n%s", gotDb)
+	}
+}
+
+func TestFolder_CanonicalizeURL_OnlyInFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entry.md")
+	original := `---
+notion-id: 1234567890abcdef1234567890abcdef
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+This page documents the legacy notion-url: "https://www.notion.so/Title-1234567890abcdef1234567890abcdef" key from before normalization.
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsCanonicalized != 0 {
+		t.Errorf("URLsCanonicalized = %d, want 0 (body should not be touched)", r.URLsCanonicalized)
+	}
+
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), `legacy notion-url: "https://www.notion.so/Title-1234567890abcdef1234567890abcdef" key`) {
+		t.Errorf("body line was modified — should only canonicalize in frontmatter:\n%s", got)
+	}
+}
+
+func TestFolder_CanonicalizeURL_Idempotent(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	mdPath := filepath.Join(dir, "entry.md")
+	mdContent := `---
+notion-id: 1234567890abcdef1234567890abcdef
+notion-url: "https://app.notion.com/p/1234567890abcdef1234567890abcdef"
+notion-last-edited: "2024-01-02T00:00:00Z"
+---
+
+body
+`
+	if err := os.WriteFile(mdPath, []byte(mdContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "_database.json")
+	dbContent := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.99.0-test"
+}
+`
+	if err := os.WriteFile(dbPath, []byte(dbContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsCanonicalized != 0 {
+		t.Errorf("URLsCanonicalized = %d, want 0 (already canonical)", r.URLsCanonicalized)
+	}
+	if r.FilesChanged != 0 {
+		t.Errorf("FilesChanged = %d, want 0", r.FilesChanged)
+	}
+	if r.MetadataBumped != 0 {
+		t.Errorf("MetadataBumped = %d, want 0 (no changes ⇒ no bump)", r.MetadataBumped)
+	}
+
+	gotMd, _ := os.ReadFile(mdPath)
+	if string(gotMd) != mdContent {
+		t.Errorf(".md was mutated:\n%s", gotMd)
+	}
+	gotDb, _ := os.ReadFile(dbPath)
+	if string(gotDb) != dbContent {
+		t.Errorf("_database.json was mutated:\n%s", gotDb)
+	}
+}
+
+func TestFolder_CanonicalizesURLInPageJSON(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	root := t.TempDir()
+	pageDir := filepath.Join(root, "pages", "MyPage_abc12345")
+	if err := os.MkdirAll(pageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pageJSON := `{
+  "pageId": "page-1",
+  "title": "MyPage",
+  "url": "https://www.notion.so/Title-1234567890abcdef1234567890abcdef",
+  "folderPath": "/tmp",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "syncVersion": "v0.5.0"
+}
+`
+	pagePath := filepath.Join(pageDir, "_page.json")
+	if err := os.WriteFile(pagePath, []byte(pageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.URLsCanonicalized != 1 {
+		t.Errorf("URLsCanonicalized = %d, want 1", r.URLsCanonicalized)
+	}
+
+	got, _ := os.ReadFile(pagePath)
+	if !strings.Contains(string(got), `"url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef"`) {
+		t.Errorf("_page.json missing canonical url:\n%s", got)
+	}
+}
+
 func TestFolder_BumpsSyncVersionInDirtyDatabaseFolder(t *testing.T) {
 	prev := sync.Version
 	sync.Version = "v0.99.0-test"

--- a/internal/notion/url.go
+++ b/internal/notion/url.go
@@ -7,10 +7,19 @@ import (
 )
 
 // notionIDRe matches a Notion page ID in either 32-hex or UUID-with-dashes form.
-// Used by CanonicalizeNotionURL so URLs containing the dashed UUID variant
-// (e.g. legacy `notion.so/Title-12345678-90ab-...`) collapse to the same
-// canonical no-dashes output.
-var notionIDRe = regexp.MustCompile(`[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12}`)
+// The trailing `(?:[^a-f0-9]|$)` boundary prevents the regex from matching the
+// first 32 chars of a longer hex run (e.g. a 40-char git SHA) and silently
+// truncating the rest. The ID itself is captured in group 1.
+var notionIDRe = regexp.MustCompile(`([a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12})(?:[^a-f0-9]|$)`)
+
+// notionHosts is the set of first-party Notion hosts that CanonicalizeNotionURL
+// will rewrite. URLs on any other host pass through unchanged so non-Notion
+// inputs (S3 file URLs, GitHub commit URLs, etc.) are never corrupted.
+var notionHosts = map[string]bool{
+	"notion.so":      true,
+	"www.notion.so":  true,
+	"app.notion.com": true,
+}
 
 // StripPresignedParams removes the AWS S3 pre-signed query string from a URL.
 //
@@ -45,15 +54,30 @@ func StripPresignedParams(u string) string {
 // CanonicalizeNotionURL rewrites any first-party Notion page URL to the
 // canonical form `https://app.notion.com/p/{32-hex-no-dashes}`.
 //
-// Returns the input unchanged for non-Notion URLs, malformed inputs, or
-// strings without an extractable 32-hex Notion ID. Pure pass-through on
-// miss — never errors — so callers can wrap arbitrary strings without
-// risk of corrupting non-URL values.
+// Returns the input unchanged for non-Notion URLs (host check), malformed
+// inputs, or Notion URLs without an extractable 32-hex page ID in the path.
+// Pure pass-through on miss — never errors — so callers can wrap arbitrary
+// strings without risk of corrupting non-URL values.
+//
+// The page ID is taken from the URL path only; query parameters (e.g. `?v=`
+// view IDs on database links) and fragments (e.g. `#blockId` anchors) are
+// ignored, so a database-view link still canonicalizes to the page itself
+// rather than the view ID.
 func CanonicalizeNotionURL(s string) string {
-	matches := notionIDRe.FindAllString(strings.ToLower(s), -1)
+	if s == "" {
+		return s
+	}
+	parsed, err := url.Parse(s)
+	if err != nil {
+		return s
+	}
+	if !notionHosts[strings.ToLower(parsed.Host)] {
+		return s
+	}
+	matches := notionIDRe.FindAllStringSubmatch(strings.ToLower(parsed.Path), -1)
 	if len(matches) == 0 {
 		return s
 	}
-	id := strings.ReplaceAll(matches[len(matches)-1], "-", "")
+	id := strings.ReplaceAll(matches[len(matches)-1][1], "-", "")
 	return "https://app.notion.com/p/" + id
 }

--- a/internal/notion/url.go
+++ b/internal/notion/url.go
@@ -2,8 +2,15 @@ package notion
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 )
+
+// notionIDRe matches a Notion page ID in either 32-hex or UUID-with-dashes form.
+// Used by CanonicalizeNotionURL so URLs containing the dashed UUID variant
+// (e.g. legacy `notion.so/Title-12345678-90ab-...`) collapse to the same
+// canonical no-dashes output.
+var notionIDRe = regexp.MustCompile(`[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12}`)
 
 // StripPresignedParams removes the AWS S3 pre-signed query string from a URL.
 //
@@ -33,4 +40,20 @@ func StripPresignedParams(u string) string {
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return parsed.String()
+}
+
+// CanonicalizeNotionURL rewrites any first-party Notion page URL to the
+// canonical form `https://app.notion.com/p/{32-hex-no-dashes}`.
+//
+// Returns the input unchanged for non-Notion URLs, malformed inputs, or
+// strings without an extractable 32-hex Notion ID. Pure pass-through on
+// miss — never errors — so callers can wrap arbitrary strings without
+// risk of corrupting non-URL values.
+func CanonicalizeNotionURL(s string) string {
+	matches := notionIDRe.FindAllString(strings.ToLower(s), -1)
+	if len(matches) == 0 {
+		return s
+	}
+	id := strings.ReplaceAll(matches[len(matches)-1], "-", "")
+	return "https://app.notion.com/p/" + id
 }

--- a/internal/notion/url_test.go
+++ b/internal/notion/url_test.go
@@ -97,6 +97,31 @@ func TestCanonicalizeNotionURL(t *testing.T) {
 			want: "https://example.com/some/path",
 		},
 		{
+			name: "non-Notion URL with embedded 32-hex passes through (host gate)",
+			in:   "https://example.com/file/1234567890abcdef1234567890abcdef.png",
+			want: "https://example.com/file/1234567890abcdef1234567890abcdef.png",
+		},
+		{
+			name: "github 40-hex commit SHA — not truncated to 32",
+			in:   "https://github.com/repo/commit/abcdef0123456789abcdef0123456789abcdef01",
+			want: "https://github.com/repo/commit/abcdef0123456789abcdef0123456789abcdef01",
+		},
+		{
+			name: "notion view URL with ?v= — uses page ID, not view ID",
+			in:   "https://www.notion.so/Title-1234567890abcdef1234567890abcdef?v=fedcba0987654321fedcba0987654321",
+			want: "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+		},
+		{
+			name: "notion URL with #blockId fragment — uses page ID, not block ID",
+			in:   "https://www.notion.so/Title-1234567890abcdef1234567890abcdef#fedcba0987654321fedcba0987654321",
+			want: "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+		},
+		{
+			name: "look-alike host evil-notion.so passes through",
+			in:   "https://evil-notion.so/Title-1234567890abcdef1234567890abcdef",
+			want: "https://evil-notion.so/Title-1234567890abcdef1234567890abcdef",
+		},
+		{
 			name: "empty string",
 			in:   "",
 			want: "",

--- a/internal/notion/url_test.go
+++ b/internal/notion/url_test.go
@@ -64,3 +64,55 @@ func TestStripPresignedParams(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalizeNotionURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "legacy notion.so with title slug",
+			in:   "https://www.notion.so/Title-1234567890abcdef1234567890abcdef",
+			want: "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+		},
+		{
+			name: "already canonical — idempotent",
+			in:   "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+			want: "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+		},
+		{
+			name: "bare notion.so without title slug",
+			in:   "https://notion.so/1234567890abcdef1234567890abcdef",
+			want: "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+		},
+		{
+			name: "uuid-with-dashes in path — collapses to no-dashes",
+			in:   "https://www.notion.so/Title-12345678-90ab-cdef-1234-567890abcdef",
+			want: "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+		},
+		{
+			name: "non-Notion URL passes through unchanged",
+			in:   "https://example.com/some/path",
+			want: "https://example.com/some/path",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "notion URL without an extractable hex ID",
+			in:   "https://www.notion.so/Some-Workspace/SettingsPage",
+			want: "https://www.notion.so/Some-Workspace/SettingsPage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalizeNotionURL(tt.in); got != tt.want {
+				t.Errorf("CanonicalizeNotionURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sync/agents.go
+++ b/internal/sync/agents.go
@@ -53,7 +53,7 @@ Every ` + "`.md`" + ` file starts with YAML frontmatter. The first block is alwa
 ` + "```" + `yaml
 ---
 notion-id: "<page-uuid>"
-notion-url: "https://www.notion.so/..."
+notion-url: "https://app.notion.com/p/<page-id-32-hex>"
 notion-last-edited: "<RFC 3339 — Notion's last_edited_time>"
 notion-database-id: "<database-uuid>"   # only present for database entries
 # notion-deleted: true                  # only present if the entry was removed in Notion (soft delete)

--- a/internal/sync/metadata.go
+++ b/internal/sync/metadata.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/ran-codes/notion-sync/internal/notion"
 )
 
 const DatabaseMetadataFile = "_database.json"
@@ -37,6 +39,7 @@ func WriteDatabaseMetadata(folderPath string, metadata *FrozenDatabase) error {
 	if Version != "" {
 		metadata.SyncVersion = Version
 	}
+	metadata.URL = notion.CanonicalizeNotionURL(metadata.URL)
 
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
@@ -74,6 +77,7 @@ func WritePageMetadata(folderPath string, metadata *FrozenPage) error {
 	if Version != "" {
 		metadata.SyncVersion = Version
 	}
+	metadata.URL = notion.CanonicalizeNotionURL(metadata.URL)
 
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {

--- a/internal/sync/metadata_test.go
+++ b/internal/sync/metadata_test.go
@@ -118,6 +118,47 @@ func TestWriteDatabaseMetadata_TrailingNewline(t *testing.T) {
 	}
 }
 
+func TestWriteDatabaseMetadata_CanonicalizesURL(t *testing.T) {
+	dir := t.TempDir()
+	meta := &FrozenDatabase{
+		DatabaseID: "abc",
+		Title:      "T",
+		URL:        "https://www.notion.so/Title-1234567890abcdef1234567890abcdef",
+		EntryCount: 1,
+	}
+	if err := WriteDatabaseMetadata(dir, meta); err != nil {
+		t.Fatalf("WriteDatabaseMetadata: %v", err)
+	}
+	got, err := ReadDatabaseMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadDatabaseMetadata: %v", err)
+	}
+	want := "https://app.notion.com/p/1234567890abcdef1234567890abcdef"
+	if got.URL != want {
+		t.Errorf("URL = %q, want %q", got.URL, want)
+	}
+}
+
+func TestWritePageMetadata_CanonicalizesURL(t *testing.T) {
+	dir := t.TempDir()
+	meta := &FrozenPage{
+		PageID: "abc",
+		Title:  "T",
+		URL:    "https://www.notion.so/Title-1234567890abcdef1234567890abcdef",
+	}
+	if err := WritePageMetadata(dir, meta); err != nil {
+		t.Fatalf("WritePageMetadata: %v", err)
+	}
+	got, err := ReadPageMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadPageMetadata: %v", err)
+	}
+	want := "https://app.notion.com/p/1234567890abcdef1234567890abcdef"
+	if got.URL != want {
+		t.Errorf("URL = %q, want %q", got.URL, want)
+	}
+}
+
 func TestWritePageMetadata_TrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 	meta := &FrozenPage{PageID: "abc", Title: "T"}

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -100,7 +100,7 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 	// Build frontmatter
 	fm := map[string]interface{}{
 		"notion-id":          opts.NotionID,
-		"notion-url":         page.URL,
+		"notion-url":         notion.CanonicalizeNotionURL(page.URL),
 		"notion-last-edited": page.LastEditedTime,
 	}
 	if opts.DatabaseID != "" {

--- a/internal/sync/page_test.go
+++ b/internal/sync/page_test.go
@@ -485,6 +485,38 @@ func TestFreezePage_DoesNotEmitFrozenAt(t *testing.T) {
 	}
 }
 
+func TestFreezePage_CanonicalizesNotionURLInFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	page := testPage("1234567890abcdef1234567890abcdef", "Url Test", "2025-01-01T00:00:00Z")
+	page.URL = "https://www.notion.so/Url-Test-1234567890abcdef1234567890abcdef"
+	client := newMockClient()
+	client.pages[page.ID] = &page
+	client.blocks[page.ID] = []notion.Block{}
+
+	_, err := FreezePage(FreezePageOptions{
+		Client:       client,
+		NotionID:     page.ID,
+		OutputFolder: dir,
+		DatabaseID:   "db-1",
+		Page:         &page,
+	})
+	if err != nil {
+		t.Fatalf("FreezePage: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, page.ID+".md"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	want := "https://app.notion.com/p/1234567890abcdef1234567890abcdef"
+	if !strings.Contains(string(data), want) {
+		t.Errorf("frontmatter missing canonical URL %q:\n%s", want, data)
+	}
+	if strings.Contains(string(data), "https://www.notion.so/") {
+		t.Errorf("frontmatter still contains legacy notion.so URL:\n%s", data)
+	}
+}
+
 func TestFreezePage_TrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 	page := testPage("page-id-001", "My Page", "2025-01-01T00:00:00Z")


### PR DESCRIPTION


## Context

- The Notion API has begun emitting `https://app.notion.com/p/{id}` for some page URLs, while older synced data and docs still reference the legacy `https://www.notion.so/Title-{id}` form. Both resolve to the same page, but the inconsistency leaks into every downstream consumer of the snapshot.
- Without normalization, every API drift becomes a noisy diff across hundreds of files: `notion-url:` values differ across databases, `_database.json` `url` fields disagree with the AGENTS.md template, and downstream ETL built against the old shape silently sees a "different" URL even though the page is identical.
- Stable URLs are the contract between the snapshot and downstream consumers — pinning a canonical form removes that drift class entirely.
- Canonical form chosen: `https://app.notion.com/p/{32-hex-no-dashes}` — matches what the API emits today and what [issue #63](https://github.com/Drexel-UHC/notion-sync/issues/63) cites as the example. No title slug ⇒ renames don't drift the URL.
- Out of scope (deferred): rewriting Notion page links inside markdown body content; the `urlNormalization` config knob (YAGNI until someone needs the legacy form).

Related to #63

## Action Items

- [x] Issue eval
- [x] TDD
- [x] Code review
- [x] E2E testing

## Changes

- **New helper** [`internal/notion/url.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/notion/url.go): `CanonicalizeNotionURL(s string) string`. Pure pass-through on miss (non-Notion URL, no extractable hex ID, empty string) — never errors, so callers can wrap arbitrary strings without risk of corrupting non-URL values. Handles both 32-hex and UUID-with-dashes ID forms; collapses to no-dashes output.
- **Write-time wiring** — single chokepoint, mirrors how `SyncVersion` is stamped:
  - [`internal/sync/metadata.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/sync/metadata.go) — `WriteDatabaseMetadata` and `WritePageMetadata` canonicalize `metadata.URL` on every write.
  - [`internal/sync/page.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/sync/page.go) — `FreezePage` canonicalizes `page.URL` before stuffing into `notion-url:` frontmatter.
- **Clean-time wiring** [`internal/clean/clean.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/clean/clean.go):
  - New `canonicalizeFrontmatterURL` step rewrites `notion-url:` only inside the YAML frontmatter region — body text is preserved (mirrors the `notion-frozen-at` body-protection design).
  - Non-canonical URLs in `_database.json` / `_page.json` are detected and counted; the existing dirty-folder bump path performs the rewrite via the canonicalizing metadata writer, so JSON canonicalization logic lives in one place.
  - New `Result.URLsCanonicalized` counter exposed to callers.
- **AGENTS.md template** [`internal/sync/agents.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/sync/agents.go): example `notion-url:` line updated from `www.notion.so/...` to `app.notion.com/p/<page-id-32-hex>` so downstream agent docs match what sync emits.
- **Tests** — 16 new tests added across [`internal/notion/url_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/notion/url_test.go), [`internal/sync/metadata_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/sync/metadata_test.go), [`internal/sync/page_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/sync/page_test.go), [`internal/clean/clean_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/0b902203777d3aaa099e04244184858b6d9744d2/internal/clean/clean_test.go). Built TDD vertical-slice (red→green per behavior). Covers: helper edge cases (empty string, non-Notion URL, UUID dashes, idempotent canonical input), write-time canonicalization in both metadata writers and `FreezePage`, clean-time rewrites in `.md` frontmatter and metadata JSON, idempotency, frontmatter-only protection (body untouched), dry-run, and `MetadataBumped` firing on URL-only changes. All existing tests still pass (`go test ./...` green).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)