### PR TITLE
feat: regenerate AGENTS.md without sync (agents-md command)

### DIFF
--- a/.claude/skills/test-double-datasource-db/SKILL.md
+++ b/.claude/skills/test-double-datasource-db/SKILL.md
@@ -69,6 +69,15 @@ Checks:
 
 - **Pass criteria:** All 6 checks pass.
 
+### Step 3b: Verify AGENTS.md is emitted with a version stamp
+The `import` command must drop a stamped `AGENTS.md` at the workspace root so downstream agents can interpret the synced files (regression guard — ref #62: AGENTS.md emission used to lack a version stamp, which prevented `clean` from detecting drift).
+
+Check `./test-output/AGENTS.md`:
+- File exists
+- Contains a line matching `^<!-- notion-sync-version: \S+ -->` near the top of the file
+
+- **Pass criteria:** File exists and the stamp line is present.
+
 ### Step 4: Verify Projects markdown files
 Check the `.md` files in `Projects/` subfolder:
 

--- a/.claude/skills/test-single-datasource-db/SKILL.md
+++ b/.claude/skills/test-single-datasource-db/SKILL.md
@@ -53,6 +53,15 @@ Since PR #43, all synced files are named by UUID (e.g., `<notion-id>.md`), not b
 - All files have `notion-database-id: 2fe57008-e885-8003-b1f3-cc05981dc6b0`
 - **Pass criteria:** All checks pass.
 
+### Step 2c: Verify AGENTS.md is emitted with a version stamp
+The `import` command must drop a stamped `AGENTS.md` at the workspace root so downstream agents can interpret the synced files (regression guard — ref #62: AGENTS.md emission used to lack a version stamp, which prevented `clean` from detecting drift).
+
+Check `./test-output/AGENTS.md`:
+- File exists
+- Contains a line matching `^<!-- notion-sync-version: \S+ -->` near the top of the file
+
+- **Pass criteria:** File exists and the stamp line is present.
+
 ### Step 3: No-op refresh
 Run: `./notion-sync.exe refresh "./test-output/test database obsdiain complex"`
 - **Pass criteria:** updated = 0, skipped = total, deleted = 0.

--- a/.claude/skills/test-standalone-page/SKILL.md
+++ b/.claude/skills/test-standalone-page/SKILL.md
@@ -53,6 +53,15 @@ Check that the import created the correct structure:
 - The `.md` file contains expected content (at least a heading and a code block)
 - **Pass criteria:** All checks pass.
 
+### Step 3b: Verify AGENTS.md is emitted with a version stamp
+The `import` command must drop a stamped `AGENTS.md` at the workspace root so downstream agents can interpret the synced files (regression guard — ref #62: AGENTS.md emission used to lack a version stamp, which prevented `clean` from detecting drift).
+
+Check `./test-output/AGENTS.md`:
+- File exists
+- Contains a line matching `^<!-- notion-sync-version: \S+ -->` near the top of the file
+
+- **Pass criteria:** File exists and the stamp line is present.
+
 ### Step 4: No-op refresh
 Run: `./notion-sync.exe refresh "test-output/pages/Test - Notion sync - single page_31357008"`
 - **Pass criteria:** Output shows `Status: skipped`.

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -63,6 +63,7 @@ Usage:
   notion-sync push <folder> [--force] [--dry-run] [--api-key <key>]
   notion-sync list [<output-folder>]
   notion-sync clean <folder> [--dry-run]
+  notion-sync agents-md <folder>
   notion-sync config set <key> <value>
 
 Commands:
@@ -81,7 +82,11 @@ Commands:
   list      List all synced databases and pages in a folder
   clean     Strip AWS S3 pre-signed query strings from existing .md files in a folder.
             Useful one-time backfill after upgrading. No API calls.
+            Also regenerates AGENTS.md if its version stamp is older than this binary.
             --dry-run  Show what would change without writing
+  agents-md Regenerate AGENTS.md in a workspace from the running binary.
+            Always overwrites any existing AGENTS.md (the command name is the consent).
+            No API calls.
   config    Manage configuration (apiKey, defaultOutputFolder)
 
 Examples:
@@ -139,6 +144,8 @@ func main() {
 		err = runList(args)
 	case "clean":
 		err = runClean(args)
+	case "agents-md":
+		err = runAgentsMD(args)
 	case "config":
 		err = runConfig(args)
 	default:
@@ -597,10 +604,40 @@ func runClean(args []string) error {
 	fmt.Printf("%s: %d files (%d URLs stripped, %d trailing newlines added, %d notion-frozen-at lines stripped)\n",
 		label, r.FilesChanged, r.URLsStripped, r.NewlinesFixed, r.FrozenAtStripped)
 	fmt.Printf("%s syncVersion in: %d folder(s)\n", bumpLabel, r.MetadataBumped)
+	if r.AgentsMDWritten > 0 {
+		agentsLabel := "Regenerated"
+		if *dryRun {
+			agentsLabel = "Would regenerate"
+		}
+		fmt.Printf("%s AGENTS.md (stamp out of date)\n", agentsLabel)
+	}
 	return nil
 }
 
-//// 2.7 Config ----
+//// 2.7 AgentsMD ----
+
+func runAgentsMD(args []string) error {
+	fs := flag.NewFlagSet("agents-md", flag.ExitOnError)
+
+	if err := fs.Parse(reorderArgs(args)); err != nil {
+		return err
+	}
+
+	if fs.NArg() == 0 {
+		return fmt.Errorf("missing folder path\n" +
+			"Usage: notion-sync agents-md <folder>\n" +
+			"Example: notion-sync agents-md ./notion")
+	}
+
+	folder := fs.Arg(0)
+	if err := sync.RegenerateAgentsMD(folder); err != nil {
+		return err
+	}
+	fmt.Printf("Wrote AGENTS.md in %s (notion-sync %s)\n", folder, version)
+	return nil
+}
+
+//// 2.8 Config ----
 
 func runConfig(args []string) error {
 	if len(args) == 0 {

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -609,7 +609,7 @@ func runClean(args []string) error {
 		if *dryRun {
 			agentsLabel = "Would regenerate"
 		}
-		fmt.Printf("%s AGENTS.md (stamp out of date)\n", agentsLabel)
+		fmt.Printf("%s AGENTS.md\n", agentsLabel)
 	}
 	return nil
 }

--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -100,6 +100,10 @@ func TestCLI_AgentsMD_OverwritesExisting(t *testing.T) {
 		t.Fatalf("agents-md failed: %v\n%s", err, out)
 	}
 
+	if !strings.Contains(string(out), "Wrote AGENTS.md") {
+		t.Errorf("expected confirmation message in stdout, got:\n%s", out)
+	}
+
 	got, err := os.ReadFile(dest)
 	if err != nil {
 		t.Fatalf("read: %v", err)

--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +85,30 @@ func TestCLI_UnknownCommand_ExitOne(t *testing.T) {
 	err := cmd.Run()
 	if err == nil {
 		t.Error("expected non-zero exit for unknown command")
+	}
+}
+
+func TestCLI_AgentsMD_OverwritesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+	if err := os.WriteFile(dest, []byte("# old\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("go", "run", ".", "agents-md", tmp).CombinedOutput()
+	if err != nil {
+		t.Fatalf("agents-md failed: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "<!-- notion-sync-version:") {
+		t.Errorf("AGENTS.md missing version stamp:\n%s", got)
+	}
+	if strings.Contains(string(got), "# old") {
+		t.Errorf("AGENTS.md was not overwritten:\n%s", got)
 	}
 }
 

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -55,6 +55,7 @@ type Result struct {
 	FrozenAtStripped  int
 	URLsCanonicalized int
 	MetadataBumped    int
+	AgentsMDWritten   int
 	DryRun            bool
 }
 
@@ -72,6 +73,19 @@ type Result struct {
 // have changed.
 func Folder(root string, dryRun bool) (*Result, error) {
 	r := &Result{DryRun: dryRun}
+
+	// Refresh AGENTS.md at the workspace root if its embedded version stamp is
+	// missing or differs from the running binary. Conservative by design: if
+	// the stamp is current we leave the file alone, even if the user has
+	// hand-edited it. The dedicated `agents-md` subcommand exists for the
+	// always-overwrite case.
+	written, err := sync.EnsureAgentsMDCurrent(root, dryRun)
+	if err != nil {
+		return r, err
+	}
+	if written {
+		r.AgentsMDWritten++
+	}
 	dirtyDirs := make(map[string]bool)
 	// Per-folder count of non-canonical "url" values found in metadata JSON.
 	// Counted at walk time but only added to URLsCanonicalized once the
@@ -80,7 +94,7 @@ func Folder(root string, dryRun bool) (*Result, error) {
 	// sync.Version is unset or the metadata file fails to round-trip.
 	jsonURLCounts := make(map[string]int)
 
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -948,6 +948,64 @@ body
 	}
 }
 
+func TestFolder_RegeneratesStaleAgentsMD(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v9.9.9-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	stale := "<!-- notion-sync-version: v0.0.1 -->\n# stale agents doc\n"
+	dest := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(dest, []byte(stale), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.AgentsMDWritten != 1 {
+		t.Errorf("AgentsMDWritten = %d, want 1", r.AgentsMDWritten)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "<!-- notion-sync-version: v9.9.9-test -->") {
+		t.Errorf("AGENTS.md not regenerated:\n%s", got)
+	}
+}
+
+func TestFolder_LeavesCurrentAgentsMDAlone(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v9.9.9-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	current := "<!-- notion-sync-version: v9.9.9-test -->\n# current agents doc, possibly user-edited\n"
+	dest := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(dest, []byte(current), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.AgentsMDWritten != 0 {
+		t.Errorf("AgentsMDWritten = %d, want 0 (stamp matches)", r.AgentsMDWritten)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != current {
+		t.Errorf("AGENTS.md was overwritten despite matching stamp")
+	}
+}
+
 func TestFolder_RecursesIntoSubfolders(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")

--- a/internal/sync/agents.go
+++ b/internal/sync/agents.go
@@ -3,7 +3,30 @@ package sync
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 )
+
+// agentsMDVersionPattern matches the version-stamp HTML comment emitted at the
+// top of AGENTS.md. The captured group is the version string (e.g. "v1.2.0").
+var agentsMDVersionPattern = regexp.MustCompile(`<!--\s*notion-sync-version:\s*(\S.*?)\s*-->`)
+
+// ParseAgentsMDVersion extracts the notion-sync version stamped into an
+// AGENTS.md file's content, or "" if the stamp is missing or empty.
+func ParseAgentsMDVersion(content string) string {
+	m := agentsMDVersionPattern.FindStringSubmatch(content)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// renderAgentsMD returns the AGENTS.md content with the current binary's
+// Version interpolated into the version stamp. If Version is unset (e.g. in
+// tests that don't wire it), the stamp value is empty.
+func renderAgentsMD() string {
+	return strings.Replace(agentsMDTemplate, "{{VERSION}}", Version, 1)
+}
 
 // agentsMDContent is written to the workspace root as AGENTS.md so that any
 // downstream LLM/agent that lands in a notion-sync output folder understands
@@ -12,7 +35,8 @@ import (
 // AGENTS.md is the cross-vendor convention (Cursor, OpenAI's agents.md spec,
 // and others) for provider-neutral agent instructions. Claude Code reads it
 // alongside CLAUDE.md.
-const agentsMDContent = `# notion-sync workspace
+const agentsMDTemplate = `<!-- notion-sync-version: {{VERSION}} -->
+# notion-sync workspace
 
 This folder contains data synced from Notion using [notion-sync](https://github.com/ran-codes/notion-sync).
 This file (AGENTS.md) tells downstream LLM/agent tools how to interpret the contents.
@@ -149,7 +173,8 @@ For multi-source databases, the **top-level** ` + "`_database.json`" + ` has no 
 - Default ` + "`refresh`" + ` is incremental: entries whose ` + "`notion-last-edited`" + ` matches the local copy are skipped.
 - ` + "`refresh --force`" + ` resyncs every entry regardless of timestamp.
 - ` + "`refresh --ids id1,id2`" + ` resyncs specific pages by ID.
-- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call — strips presigned URLs, removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line, and ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files. Any folder it modifies has its ` + "`_database.json`" + ` or ` + "`_page.json`" + ` re-stamped with the current ` + "`syncVersion`" + ` so the workspace records which binary last touched it. Used as a one-time backfill after upgrading.
+- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call — strips presigned URLs, removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line, and ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files. Any folder it modifies has its ` + "`_database.json`" + ` or ` + "`_page.json`" + ` re-stamped with the current ` + "`syncVersion`" + ` so the workspace records which binary last touched it. Also regenerates ` + "`AGENTS.md`" + ` (this file) when its version stamp is older than the running binary. Used as a one-time backfill after upgrading.
+- ` + "`agents-md <folder>`" + ` regenerates ` + "`AGENTS.md`" + ` from the running binary, **always overwriting** any existing copy. Use this when you want the latest doc unconditionally; ` + "`clean`" + ` is the safer default that only rewrites on stamp drift.
 
 ## Push semantics (writing local changes back to Notion)
 
@@ -172,5 +197,44 @@ func WriteAgentsMD(workspacePath string) error {
 	if _, err := os.Stat(dest); err == nil {
 		return nil // file exists, don't overwrite
 	}
-	return os.WriteFile(dest, []byte(agentsMDContent), 0644)
+	return os.WriteFile(dest, []byte(renderAgentsMD()), 0644)
+}
+
+// RegenerateAgentsMD writes AGENTS.md to the workspace root, overwriting any
+// existing file. Used by `notion-sync agents-md` for explicit user-driven
+// refreshes — the command name is the consent.
+func RegenerateAgentsMD(workspacePath string) error {
+	dest := filepath.Join(workspacePath, "AGENTS.md")
+	return os.WriteFile(dest, []byte(renderAgentsMD()), 0644)
+}
+
+// EnsureAgentsMDCurrent writes AGENTS.md to the workspace root if it is
+// missing, or if its embedded version stamp does not match the current
+// binary's Version. Used by `clean` to keep the doc in sync with the binary
+// post-upgrade without clobbering an already-current file.
+//
+// Returns true if a write happened (or, in dryRun, would have happened).
+//
+// If Version is unset (build-time -ldflags not wired), this is a no-op — we
+// have nothing meaningful to stamp. Mirrors the guard in bumpFolderMetadata.
+func EnsureAgentsMDCurrent(workspacePath string, dryRun bool) (bool, error) {
+	if Version == "" {
+		return false, nil
+	}
+	dest := filepath.Join(workspacePath, "AGENTS.md")
+	existing, err := os.ReadFile(dest)
+	if err == nil {
+		if ParseAgentsMDVersion(string(existing)) == Version {
+			return false, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if dryRun {
+		return true, nil
+	}
+	if err := os.WriteFile(dest, []byte(renderAgentsMD()), 0644); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/sync/agents_test.go
+++ b/internal/sync/agents_test.go
@@ -70,7 +70,7 @@ func TestEnsureAgentsMDCurrent_LeavesAloneIfCurrent(t *testing.T) {
 	}
 }
 
-func TestEnsureAgentsMDCurrent_DryRun(t *testing.T) {
+func TestEnsureAgentsMDCurrent_DryRunMissing(t *testing.T) {
 	tmp := t.TempDir()
 	dest := filepath.Join(tmp, "AGENTS.md")
 
@@ -87,6 +87,58 @@ func TestEnsureAgentsMDCurrent_DryRun(t *testing.T) {
 	}
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
 		t.Errorf("dry-run wrote a file (or stat err = %v)", err)
+	}
+}
+
+func TestEnsureAgentsMDCurrent_DryRunStale(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "v4.0.0"
+	defer func() { Version = prev }()
+
+	stale := "<!-- notion-sync-version: v1.0.0 -->\n# stale content\n"
+	if err := os.WriteFile(dest, []byte(stale), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	written, err := EnsureAgentsMDCurrent(tmp, true)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMDCurrent: %v", err)
+	}
+	if !written {
+		t.Errorf("written = false, want true (dry-run with stale stamp should report)")
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != stale {
+		t.Errorf("dry-run modified file on disk:\nwant: %q\ngot:  %q", stale, got)
+	}
+}
+
+func TestEnsureAgentsMDCurrent_DryRunCurrent(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "v4.0.0"
+	defer func() { Version = prev }()
+
+	current := "<!-- notion-sync-version: v4.0.0 -->\n# current content\n"
+	if err := os.WriteFile(dest, []byte(current), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	written, err := EnsureAgentsMDCurrent(tmp, true)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMDCurrent: %v", err)
+	}
+	if written {
+		t.Errorf("written = true, want false (dry-run with current stamp must not report a write)")
 	}
 }
 

--- a/internal/sync/agents_test.go
+++ b/internal/sync/agents_test.go
@@ -1,0 +1,222 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureAgentsMDCurrent_RewritesIfStaleStamp(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "v2.0.0"
+	defer func() { Version = prev }()
+
+	stale := "<!-- notion-sync-version: v1.0.0 -->\n# stale content\n"
+	if err := os.WriteFile(dest, []byte(stale), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	written, err := EnsureAgentsMDCurrent(tmp, false)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMDCurrent: %v", err)
+	}
+	if !written {
+		t.Errorf("written = false, want true")
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "<!-- notion-sync-version: v2.0.0 -->") {
+		t.Errorf("AGENTS.md was not rewritten with new stamp:\n%s", got)
+	}
+	if strings.Contains(string(got), "# stale content") {
+		t.Errorf("AGENTS.md still contains stale content:\n%s", got)
+	}
+}
+
+func TestEnsureAgentsMDCurrent_LeavesAloneIfCurrent(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "v3.0.0"
+	defer func() { Version = prev }()
+
+	current := "<!-- notion-sync-version: v3.0.0 -->\n# user-edited but stamp matches\n"
+	if err := os.WriteFile(dest, []byte(current), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	written, err := EnsureAgentsMDCurrent(tmp, false)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMDCurrent: %v", err)
+	}
+	if written {
+		t.Errorf("written = true, want false (stamp matches current)")
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != current {
+		t.Errorf("AGENTS.md was overwritten despite matching stamp")
+	}
+}
+
+func TestEnsureAgentsMDCurrent_DryRun(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "v4.0.0"
+	defer func() { Version = prev }()
+
+	written, err := EnsureAgentsMDCurrent(tmp, true)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMDCurrent: %v", err)
+	}
+	if !written {
+		t.Errorf("written = false, want true (dry-run should still report)")
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("dry-run wrote a file (or stat err = %v)", err)
+	}
+}
+
+func TestEnsureAgentsMDCurrent_NoVersion(t *testing.T) {
+	tmp := t.TempDir()
+
+	prev := Version
+	Version = ""
+	defer func() { Version = prev }()
+
+	written, err := EnsureAgentsMDCurrent(tmp, false)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMDCurrent: %v", err)
+	}
+	if written {
+		t.Errorf("written = true, want false (Version unset must skip)")
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Errorf("AGENTS.md was written despite Version unset")
+	}
+}
+
+func TestEnsureAgentsMDCurrent_WritesIfMissing(t *testing.T) {
+	tmp := t.TempDir()
+
+	prev := Version
+	Version = "v1.0.0"
+	defer func() { Version = prev }()
+
+	written, err := EnsureAgentsMDCurrent(tmp, false)
+	if err != nil {
+		t.Fatalf("EnsureAgentsMDCurrent: %v", err)
+	}
+	if !written {
+		t.Errorf("written = false, want true")
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("AGENTS.md not written: %v", err)
+	}
+	if !strings.Contains(string(got), "<!-- notion-sync-version: v1.0.0 -->") {
+		t.Errorf("missing version stamp:\n%s", got)
+	}
+}
+
+func TestRegenerateAgentsMD_OverwritesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "vREGEN"
+	defer func() { Version = prev }()
+
+	if err := os.WriteFile(dest, []byte("# old hand-edited content\n"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := RegenerateAgentsMD(tmp); err != nil {
+		t.Fatalf("RegenerateAgentsMD: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "<!-- notion-sync-version: vREGEN -->") {
+		t.Errorf("AGENTS.md was not regenerated:\n%s", got)
+	}
+}
+
+func TestParseAgentsMDVersion_Stamped(t *testing.T) {
+	in := "<!-- notion-sync-version: v1.2.3 -->\n# notion-sync workspace\n"
+	if got := ParseAgentsMDVersion(in); got != "v1.2.3" {
+		t.Errorf("ParseAgentsMDVersion = %q, want v1.2.3", got)
+	}
+}
+
+func TestParseAgentsMDVersion_Missing(t *testing.T) {
+	in := "# notion-sync workspace\n\nno stamp here.\n"
+	if got := ParseAgentsMDVersion(in); got != "" {
+		t.Errorf("ParseAgentsMDVersion = %q, want empty", got)
+	}
+}
+
+func TestParseAgentsMDVersion_EmptyValue(t *testing.T) {
+	// Stamp with empty version (e.g. binary built without -ldflags).
+	in := "<!-- notion-sync-version:  -->\n# notion-sync workspace\n"
+	if got := ParseAgentsMDVersion(in); got != "" {
+		t.Errorf("ParseAgentsMDVersion = %q, want empty", got)
+	}
+}
+
+func TestWriteAgentsMD_PreservesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+	custom := "# my hand-edited AGENTS.md\n"
+	if err := os.WriteFile(dest, []byte(custom), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := WriteAgentsMD(tmp); err != nil {
+		t.Fatalf("WriteAgentsMD: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != custom {
+		t.Errorf("WriteAgentsMD overwrote existing file:\nwant: %q\ngot:  %q", custom, got)
+	}
+}
+
+func TestWriteAgentsMD_StampsVersion(t *testing.T) {
+	tmp := t.TempDir()
+
+	prev := Version
+	Version = "vTEST"
+	defer func() { Version = prev }()
+
+	if err := WriteAgentsMD(tmp); err != nil {
+		t.Fatalf("WriteAgentsMD: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "<!-- notion-sync-version: vTEST -->") {
+		t.Errorf("AGENTS.md missing version stamp, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Context

- `AGENTS.md` is the downstream-consumer agent doc emitted into every notion-sync workspace. It's currently write-if-missing — once a workspace has the file, it never refreshes, even when notion-sync ships material updates (v1.1, v1.2 both did).
- The only workaround was `rm AGENTS.md && refresh`, which forces a Notion API call and resyncs every entry just to repopulate one doc.
- Resolves the gap raised in #62: a CLI path to regen AGENTS.md without API calls, plus an embedded version stamp so we can detect drift.

## Changes

- **Embed a version stamp** in AGENTS.md as `<!-- notion-sync-version: vX.Y.Z -->` at the top of the file ([`internal/sync/agents.go`](https://github.com/Drexel-UHC/notion-sync/blob/1f2341e5b52597d7086729035b9e178ab7bfe0ad/internal/sync/agents.go)). New helpers: `RegenerateAgentsMD` (always overwrites), `EnsureAgentsMDCurrent` (writes if missing or stamp drifts), `ParseAgentsMDVersion`. `EnsureAgentsMDCurrent` skips silently when `sync.Version` is unset (mirrors the `bumpFolderMetadata` guard); `RegenerateAgentsMD` and `WriteAgentsMD` still write since the explicit caller is the consent.
- **New `notion-sync agents-md <folder>` subcommand** ([`cmd/notion-sync/main.go`](https://github.com/Drexel-UHC/notion-sync/blob/1f2341e5b52597d7086729035b9e178ab7bfe0ad/cmd/notion-sync/main.go)) — always overwrites AGENTS.md from the running binary. No `--force` flag: the command name is the consent.
- **`clean` now also regenerates AGENTS.md** when its stamp is missing or differs from the running binary ([`internal/clean/clean.go`](https://github.com/Drexel-UHC/notion-sync/blob/1f2341e5b52597d7086729035b9e178ab7bfe0ad/internal/clean/clean.go)). No-op when current — preserves any user edits made behind a current stamp. Reports via new `Result.AgentsMDWritten` counter and a `Regenerated AGENTS.md` line in CLI output.
- **Doc body updated** to describe both `clean`'s new behavior and the `agents-md` command, so downstream agents reading the regenerated file know about both paths.
- **Tests**: 9 new unit tests in [`internal/sync/agents_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/1f2341e5b52597d7086729035b9e178ab7bfe0ad/internal/sync/agents_test.go) covering stamp emission/parsing, write-if-missing, regenerate-overwrites, ensure-current decision matrix (missing/stale/current/dry-run/no-version). 2 new end-to-end tests in [`internal/clean/clean_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/1f2341e5b52597d7086729035b9e178ab7bfe0ad/internal/clean/clean_test.go) for the `clean` integration. 1 CLI test in [`cmd/notion-sync/main_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/1f2341e5b52597d7086729035b9e178ab7bfe0ad/cmd/notion-sync/main_test.go).

### Behavioral matrix

| Trigger | AGENTS.md behavior |
|---|---|
| `import`, `refresh` | write only if missing (preserve user edits — unchanged) |
| `clean` | rewrite if missing OR stamp differs from current binary |
| `clean --dry-run` | report would-write, no write |
| `agents-md` | always overwrite |
| `Version == ""` (unwired build) | `EnsureAgentsMDCurrent` (used by `clean`) skips silently; `WriteAgentsMD` and `RegenerateAgentsMD` still write (explicit caller intent) |

Related to #62

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)