### PR TITLE
docs(agents): align AGENTS.md template with canonical URL behavior

### DIFF
--- a/internal/sync/agents.go
+++ b/internal/sync/agents.go
@@ -145,7 +145,7 @@ Pages removed from Notion are **not** deleted from disk on refresh. Instead, ` +
   "databaseId": "<uuid>",
   "dataSourceId": "<uuid>",
   "title": "Human Title",
-  "url": "https://app.notion.com/p/<page-id-32-hex>",
+  "url": "https://app.notion.com/p/<database-id-32-hex>",
   "folderPath": "<absolute path>",
   "lastSyncedAt": "<RFC 3339>",
   "entryCount": 42,
@@ -173,7 +173,13 @@ For multi-source databases, the **top-level** ` + "`_database.json`" + ` has no 
 - Default ` + "`refresh`" + ` is incremental: entries whose ` + "`notion-last-edited`" + ` matches the local copy are skipped.
 - ` + "`refresh --force`" + ` resyncs every entry regardless of timestamp.
 - ` + "`refresh --ids id1,id2`" + ` resyncs specific pages by ID.
-- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call — strips presigned URLs, removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line, canonicalizes legacy ` + "`www.notion.so/Title-{id}`" + ` URLs to ` + "`app.notion.com/p/{id}`" + ` in ` + "`.md`" + ` frontmatter and metadata JSON, and ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files. Any folder it modifies has its ` + "`_database.json`" + ` or ` + "`_page.json`" + ` re-stamped with the current ` + "`syncVersion`" + ` so the workspace records which binary last touched it. Also regenerates ` + "`AGENTS.md`" + ` (this file) when its version stamp is older than the running binary. Used as a one-time backfill after upgrading.
+- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call. Used as a one-time backfill after upgrading. Cleanups applied:
+  - strips Notion S3 presigned query strings from file URLs in ` + "`.md`" + ` content
+  - removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line
+  - canonicalizes legacy ` + "`www.notion.so/Title-{id}`" + ` URLs to ` + "`app.notion.com/p/{id}`" + ` in ` + "`.md`" + ` frontmatter and metadata JSON
+  - ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files
+  - re-stamps ` + "`_database.json`" + ` / ` + "`_page.json`" + ` with the current ` + "`syncVersion`" + ` for any folder it modified
+  - regenerates ` + "`AGENTS.md`" + ` (this file) when its version stamp is older than the running binary
 - ` + "`agents-md <folder>`" + ` regenerates ` + "`AGENTS.md`" + ` from the running binary, **always overwriting** any existing copy. Use this when you want the latest doc unconditionally; ` + "`clean`" + ` is the safer default that only rewrites on stamp drift.
 
 ## Push semantics (writing local changes back to Notion)

--- a/internal/sync/agents.go
+++ b/internal/sync/agents.go
@@ -145,7 +145,7 @@ Pages removed from Notion are **not** deleted from disk on refresh. Instead, ` +
   "databaseId": "<uuid>",
   "dataSourceId": "<uuid>",
   "title": "Human Title",
-  "url": "https://www.notion.so/...",
+  "url": "https://app.notion.com/p/<page-id-32-hex>",
   "folderPath": "<absolute path>",
   "lastSyncedAt": "<RFC 3339>",
   "entryCount": 42,
@@ -161,7 +161,7 @@ For multi-source databases, the **top-level** ` + "`_database.json`" + ` has no 
 {
   "pageId": "<uuid>",
   "title": "Page Title",
-  "url": "https://www.notion.so/...",
+  "url": "https://app.notion.com/p/<page-id-32-hex>",
   "folderPath": "<absolute path>",
   "lastSyncedAt": "<RFC 3339>",
   "syncVersion": "v0.5.0"
@@ -173,7 +173,7 @@ For multi-source databases, the **top-level** ` + "`_database.json`" + ` has no 
 - Default ` + "`refresh`" + ` is incremental: entries whose ` + "`notion-last-edited`" + ` matches the local copy are skipped.
 - ` + "`refresh --force`" + ` resyncs every entry regardless of timestamp.
 - ` + "`refresh --ids id1,id2`" + ` resyncs specific pages by ID.
-- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call — strips presigned URLs, removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line, and ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files. Any folder it modifies has its ` + "`_database.json`" + ` or ` + "`_page.json`" + ` re-stamped with the current ` + "`syncVersion`" + ` so the workspace records which binary last touched it. Also regenerates ` + "`AGENTS.md`" + ` (this file) when its version stamp is older than the running binary. Used as a one-time backfill after upgrading.
+- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call — strips presigned URLs, removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line, canonicalizes legacy ` + "`www.notion.so/Title-{id}`" + ` URLs to ` + "`app.notion.com/p/{id}`" + ` in ` + "`.md`" + ` frontmatter and metadata JSON, and ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files. Any folder it modifies has its ` + "`_database.json`" + ` or ` + "`_page.json`" + ` re-stamped with the current ` + "`syncVersion`" + ` so the workspace records which binary last touched it. Also regenerates ` + "`AGENTS.md`" + ` (this file) when its version stamp is older than the running binary. Used as a one-time backfill after upgrading.
 - ` + "`agents-md <folder>`" + ` regenerates ` + "`AGENTS.md`" + ` from the running binary, **always overwriting** any existing copy. Use this when you want the latest doc unconditionally; ` + "`clean`" + ` is the safer default that only rewrites on stamp drift.
 
 ## Push semantics (writing local changes back to Notion)


### PR DESCRIPTION
## Context

- PR #64 wired URL canonicalization (`app.notion.com/p/{id}`) into `FreezePage`, `WriteDatabaseMetadata`, and `WritePageMetadata`, and `internal/clean` migrates legacy URLs in existing snapshots.
- The AGENTS.md template in [`internal/sync/agents.go`](https://github.com/Drexel-UHC/notion-sync/blob/b3e040ce51d23e8612dbc25a2b1a085a1edc475d/internal/sync/agents.go) wasn't fully updated to match: metadata JSON examples still showed legacy `www.notion.so/...` URLs, and the `clean` description omitted URL canonicalization from its cleanup list.
- Downstream agents reading AGENTS.md would see stale guidance that contradicts what `notion-sync` actually emits and what `clean` actually does.

## Changes

- `_database.json` example URL: `https://www.notion.so/...` → `https://app.notion.com/p/<page-id-32-hex>`
- `_page.json` example URL: same fix
- `clean <folder>` description now lists URL canonicalization alongside presigned-URL stripping, `notion-frozen-at` removal, and trailing-newline enforcement — matching the package doc in [`internal/clean/clean.go`](https://github.com/Drexel-UHC/notion-sync/blob/b3e040ce51d23e8612dbc25a2b1a085a1edc475d/internal/clean/clean.go)

Related to #63, #64

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)