### PR TITLE
fix(clean): surface URLs canonicalized in dry-run summary

### DIFF
--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -601,8 +601,8 @@ func runClean(args []string) error {
 		bumpLabel = "Would stamp"
 	}
 	fmt.Printf("Scanned: %d files\n", r.FilesScanned)
-	fmt.Printf("%s: %d files (%d URLs stripped, %d trailing newlines added, %d notion-frozen-at lines stripped)\n",
-		label, r.FilesChanged, r.URLsStripped, r.NewlinesFixed, r.FrozenAtStripped)
+	fmt.Printf("%s: %d files (%d URLs stripped, %d URLs canonicalized, %d trailing newlines added, %d notion-frozen-at lines stripped)\n",
+		label, r.FilesChanged, r.URLsStripped, r.URLsCanonicalized, r.NewlinesFixed, r.FrozenAtStripped)
 	fmt.Printf("%s syncVersion in: %d folder(s)\n", bumpLabel, r.MetadataBumped)
 	if r.AgentsMDWritten > 0 {
 		agentsLabel := "Regenerated"


### PR DESCRIPTION
## Context

- `notion-sync clean --dry-run` was under-reporting what a real run would change. On folders with legacy `notion.so/Title-{id}` URLs, users saw the total file count climb but every itemized operation in the breakdown showed `0` — making the dry-run look cosmetic when it was actually the most impactful mutation in the run.
- Root cause: PR #64 added `Result.URLsCanonicalized` to the clean pipeline and covered it with unit tests, but the CLI summary line in `runClean` was never updated to print it. The counter has been silently populated for the entire v1.3.x line.
- Why this matters: dry-run is the user's pre-flight check before a multi-folder write. A breakdown that omits the dominant operation defeats the purpose. Concretely caused real confusion debugging 1,264 "would modify" files across a 13-folder snapshot.
- Related to #69 (issue), #64 (where canonicalization shipped without reporting).

## Changes

- [`cmd/notion-sync/main.go`](https://github.com/Drexel-UHC/notion-sync/blob/264fe811c44b7a5ab0bb619757f0f3aa166fac1a/cmd/notion-sync/main.go#L604-L605) — add `%d URLs canonicalized` segment to the clean summary line, sourced from the existing `r.URLsCanonicalized` counter. New format:
  ```
  Would modify: 5 files (0 URLs stripped, 5 URLs canonicalized, 0 trailing newlines added, 0 notion-frozen-at lines stripped)
  ```
- No counter logic changed — the field has been correctly populated since #64; this PR only surfaces it.
- `go test ./...` green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)