### PR TITLE
feat(clean): normalize folderPath separator to forward slashes

### DIFF
--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -601,8 +601,8 @@ func runClean(args []string) error {
 		bumpLabel = "Would stamp"
 	}
 	fmt.Printf("Scanned: %d files\n", r.FilesScanned)
-	fmt.Printf("%s: %d files (%d URLs stripped, %d URLs canonicalized, %d trailing newlines added, %d notion-frozen-at lines stripped)\n",
-		label, r.FilesChanged, r.URLsStripped, r.URLsCanonicalized, r.NewlinesFixed, r.FrozenAtStripped)
+	fmt.Printf("%s: %d files (%d URLs stripped, %d URLs canonicalized, %d folderPaths normalized, %d trailing newlines added, %d notion-frozen-at lines stripped)\n",
+		label, r.FilesChanged, r.URLsStripped, r.URLsCanonicalized, r.FolderPathsNormalized, r.NewlinesFixed, r.FrozenAtStripped)
 	fmt.Printf("%s syncVersion in: %d folder(s)\n", bumpLabel, r.MetadataBumped)
 	if r.AgentsMDWritten > 0 {
 		agentsLabel := "Regenerated"

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -334,19 +334,21 @@ func countNonCanonicalNotionURLInJSON(s string) int {
 }
 
 // countNonCanonicalFolderPathInJSON returns the number of `"folderPath": "..."`
-// fields in the JSON content whose value contains a backslash separator. JSON
-// encodes a literal backslash as `\\`, so the captured raw bytes contain `\\`
-// for each separator — `strings.Contains(val, "\\")` matches that. folderPath
-// values are filesystem paths, which won't legitimately carry other escape
-// sequences, so any backslash means the path was serialized with the host's
-// native separator.
+// fields in the JSON content whose value contains a backslash separator. A
+// real backslash in the path is encoded by JSON as `\\` (two raw bytes in
+// the captured value), so we check for two consecutive backslashes.
+//
+// Checking for a single backslash would over-count: Go's json.Marshal runs
+// with HTML escape enabled, so paths containing `&`, `<`, or `>` are emitted
+// as `\u0026`, `\u003c`, `\u003e` — escape sequences that contain
+// a single backslash but are not path separators.
 func countNonCanonicalFolderPathInJSON(s string) int {
 	count := 0
 	for _, m := range jsonFolderPathValuePattern.FindAllStringSubmatch(s, -1) {
 		if len(m) < 2 {
 			continue
 		}
-		if strings.Contains(m[1], `\`) {
+		if strings.Contains(m[1], `\\`) {
 			count++
 		}
 	}

--- a/internal/clean/clean.go
+++ b/internal/clean/clean.go
@@ -14,6 +14,9 @@
 //     in metadata JSON to the `app.notion.com/p/{id}` form, so legacy
 //     `www.notion.so/Title-{id}` URLs from earlier syncs stop drifting against
 //     newly emitted ones.
+//   - Normalizes `folderPath` values in metadata JSON to forward slashes, so
+//     workspaces synced on Windows stop leaking host-native backslashes into
+//     version-controlled snapshots.
 //   - Ensures .md and .json files end with a trailing newline.
 //
 // For each folder it modifies, the corresponding _database.json or _page.json
@@ -48,15 +51,16 @@ var presignedURLPattern = regexp.MustCompile(
 
 // Result summarizes a clean run.
 type Result struct {
-	FilesScanned      int
-	FilesChanged      int
-	URLsStripped      int
-	NewlinesFixed     int
-	FrozenAtStripped  int
-	URLsCanonicalized int
-	MetadataBumped    int
-	AgentsMDWritten   int
-	DryRun            bool
+	FilesScanned          int
+	FilesChanged          int
+	URLsStripped          int
+	NewlinesFixed         int
+	FrozenAtStripped      int
+	URLsCanonicalized     int
+	FolderPathsNormalized int
+	MetadataBumped        int
+	AgentsMDWritten       int
+	DryRun                bool
 }
 
 // Folder walks `root` recursively and applies cleanups to eligible files:
@@ -64,6 +68,8 @@ type Result struct {
 //   - removes `notion-frozen-at:` lines from `.md` frontmatter
 //   - canonicalizes `notion-url:` values in `.md` frontmatter and `"url"`
 //     fields in `_database.json` / `_page.json`
+//   - normalizes `folderPath` separators in `_database.json` / `_page.json`
+//     to forward slashes
 //   - appends a trailing newline to `.md` and `.json` files that are missing one
 //
 // After the walk, any folder whose files were modified has its `_database.json`
@@ -93,6 +99,11 @@ func Folder(root string, dryRun bool) (*Result, error) {
 	// succeed) — otherwise the user-visible counter would lie when
 	// sync.Version is unset or the metadata file fails to round-trip.
 	jsonURLCounts := make(map[string]int)
+	// Per-folder count of "folderPath" values that contain a host-native
+	// backslash separator. Same deferred-count discipline as jsonURLCounts —
+	// the rewrite happens inside WriteDatabaseMetadata / WritePageMetadata,
+	// so the counter is only folded in once the bump is confirmed.
+	jsonFolderPathCounts := make(map[string]int)
 
 	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -163,6 +174,11 @@ func Folder(root string, dryRun bool) (*Result, error) {
 				jsonURLCounts[filepath.Dir(path)] += ucount
 				dirtyDirs[filepath.Dir(path)] = true
 			}
+			fpcount := countNonCanonicalFolderPathInJSON(out)
+			if fpcount > 0 {
+				jsonFolderPathCounts[filepath.Dir(path)] += fpcount
+				dirtyDirs[filepath.Dir(path)] = true
+			}
 		}
 
 		if !changed {
@@ -204,6 +220,7 @@ func Folder(root string, dryRun bool) (*Result, error) {
 			if bumped {
 				r.MetadataBumped++
 				r.URLsCanonicalized += jsonURLCounts[dir]
+				r.FolderPathsNormalized += jsonFolderPathCounts[dir]
 			}
 		}
 	} else if sync.Version != "" {
@@ -211,6 +228,7 @@ func Folder(root string, dryRun bool) (*Result, error) {
 			if folderHasMetadata(dir) {
 				r.MetadataBumped++
 				r.URLsCanonicalized += jsonURLCounts[dir]
+				r.FolderPathsNormalized += jsonFolderPathCounts[dir]
 			}
 		}
 	}
@@ -283,6 +301,11 @@ var notionURLLinePattern = regexp.MustCompile(`(?m)^([ \t]*notion-url[ \t]*:[ \t
 // Used to detect non-canonical Notion URLs in _database.json / _page.json.
 var jsonURLValuePattern = regexp.MustCompile(`"url"\s*:\s*"([^"]*)"`)
 
+// jsonFolderPathValuePattern matches a JSON `"folderPath": "..."` field and
+// captures the raw (still-JSON-escaped) value. Used to detect host-native
+// backslash separators leaked into metadata by Windows-side syncs.
+var jsonFolderPathValuePattern = regexp.MustCompile(`"folderPath"\s*:\s*"([^"]*)"`)
+
 // isMetadataFileName reports whether the given basename is one of the
 // notion-sync metadata files (case-insensitive on the file's lowercase form).
 func isMetadataFileName(name string) bool {
@@ -304,6 +327,26 @@ func countNonCanonicalNotionURLInJSON(s string) int {
 			continue
 		}
 		if notion.CanonicalizeNotionURL(val) != val {
+			count++
+		}
+	}
+	return count
+}
+
+// countNonCanonicalFolderPathInJSON returns the number of `"folderPath": "..."`
+// fields in the JSON content whose value contains a backslash separator. JSON
+// encodes a literal backslash as `\\`, so the captured raw bytes contain `\\`
+// for each separator — `strings.Contains(val, "\\")` matches that. folderPath
+// values are filesystem paths, which won't legitimately carry other escape
+// sequences, so any backslash means the path was serialized with the host's
+// native separator.
+func countNonCanonicalFolderPathInJSON(s string) int {
+	count := 0
+	for _, m := range jsonFolderPathValuePattern.FindAllStringSubmatch(s, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		if strings.Contains(m[1], `\`) {
 			count++
 		}
 	}

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -1112,6 +1112,11 @@ func TestFolder_NormalizeFolderPath_Idempotent(t *testing.T) {
 	t.Cleanup(func() { sync.Version = prev })
 
 	dir := t.TempDir()
+	// Seed with a stale syncVersion that differs from sync.Version. If the
+	// folder ever gets falsely flagged as dirty, the bump pass will overwrite
+	// this with "v0.99.0-test" and the byte-equality check at the end will
+	// catch it. Seeding with the current version would mask a false bump,
+	// since rewriting an already-current file produces identical bytes.
 	dbContent := `{
   "databaseId": "db-1",
   "title": "Test",
@@ -1119,7 +1124,7 @@ func TestFolder_NormalizeFolderPath_Idempotent(t *testing.T) {
   "folderPath": "_etl/notion-sync/v1/Foo",
   "lastSyncedAt": "2024-01-01T00:00:00Z",
   "entryCount": 1,
-  "syncVersion": "v0.99.0-test"
+  "syncVersion": "v0.5.0"
 }
 `
 	dbPath := filepath.Join(dir, "_database.json")

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -948,6 +948,194 @@ body
 	}
 }
 
+func TestCountNonCanonicalFolderPathInJSON(t *testing.T) {
+	// `\\` in a Go raw string is two literal backslash characters, which is
+	// exactly how JSON encodes a single backslash on disk.
+	tests := []struct {
+		name string
+		json string
+		want int
+	}{
+		{
+			name: "windows separator",
+			json: `{"folderPath": "_etl\\notion-sync\\v1\\Foo"}`,
+			want: 1,
+		},
+		{
+			name: "forward slash",
+			json: `{"folderPath": "_etl/notion-sync/v1/Foo"}`,
+			want: 0,
+		},
+		{
+			name: "missing field",
+			json: `{"databaseId": "abc"}`,
+			want: 0,
+		},
+		{
+			name: "empty value",
+			json: `{"folderPath": ""}`,
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countNonCanonicalFolderPathInJSON(tc.json)
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFolder_NormalizesFolderPathInDatabaseJSON(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	dbJSON := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+  "folderPath": "_etl\\notion-sync\\v1\\Foo",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.5.0"
+}
+`
+	dbPath := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(dbPath, []byte(dbJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FolderPathsNormalized != 1 {
+		t.Errorf("FolderPathsNormalized = %d, want 1", r.FolderPathsNormalized)
+	}
+	if r.MetadataBumped != 1 {
+		t.Errorf("MetadataBumped = %d, want 1 (folderPath-only change must trigger bump)", r.MetadataBumped)
+	}
+
+	got, _ := os.ReadFile(dbPath)
+	if !strings.Contains(string(got), `"folderPath": "_etl/notion-sync/v1/Foo"`) {
+		t.Errorf("_database.json folderPath not normalized:\n%s", got)
+	}
+	if strings.Contains(string(got), `\\`) {
+		t.Errorf("_database.json still contains backslashes:\n%s", got)
+	}
+}
+
+func TestFolder_NormalizesFolderPathInPageJSON(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	root := t.TempDir()
+	pageDir := filepath.Join(root, "pages", "MyPage_abc12345")
+	if err := os.MkdirAll(pageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pageJSON := `{
+  "pageId": "page-1",
+  "title": "MyPage",
+  "url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+  "folderPath": "pages\\MyPage_abc12345",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "syncVersion": "v0.5.0"
+}
+`
+	pagePath := filepath.Join(pageDir, "_page.json")
+	if err := os.WriteFile(pagePath, []byte(pageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FolderPathsNormalized != 1 {
+		t.Errorf("FolderPathsNormalized = %d, want 1", r.FolderPathsNormalized)
+	}
+
+	got, _ := os.ReadFile(pagePath)
+	if !strings.Contains(string(got), `"folderPath": "pages/MyPage_abc12345"`) {
+		t.Errorf("_page.json folderPath not normalized:\n%s", got)
+	}
+}
+
+func TestFolder_NormalizeFolderPath_DryRun(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	dbOriginal := `{
+  "databaseId": "db-1",
+  "url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+  "folderPath": "_etl\\notion-sync\\v1\\Foo",
+  "syncVersion": "v0.5.0"
+}
+`
+	dbPath := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(dbPath, []byte(dbOriginal), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FolderPathsNormalized != 1 {
+		t.Errorf("dry-run FolderPathsNormalized = %d, want 1", r.FolderPathsNormalized)
+	}
+
+	got, _ := os.ReadFile(dbPath)
+	if string(got) != dbOriginal {
+		t.Errorf("dry-run mutated _database.json:\n%s", got)
+	}
+}
+
+func TestFolder_NormalizeFolderPath_Idempotent(t *testing.T) {
+	prev := sync.Version
+	sync.Version = "v0.99.0-test"
+	t.Cleanup(func() { sync.Version = prev })
+
+	dir := t.TempDir()
+	dbContent := `{
+  "databaseId": "db-1",
+  "title": "Test",
+  "url": "https://app.notion.com/p/1234567890abcdef1234567890abcdef",
+  "folderPath": "_etl/notion-sync/v1/Foo",
+  "lastSyncedAt": "2024-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.99.0-test"
+}
+`
+	dbPath := filepath.Join(dir, "_database.json")
+	if err := os.WriteFile(dbPath, []byte(dbContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Folder(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FolderPathsNormalized != 0 {
+		t.Errorf("FolderPathsNormalized = %d, want 0 (already canonical)", r.FolderPathsNormalized)
+	}
+	if r.MetadataBumped != 0 {
+		t.Errorf("MetadataBumped = %d, want 0 (no changes ⇒ no bump)", r.MetadataBumped)
+	}
+
+	got, _ := os.ReadFile(dbPath)
+	if string(got) != dbContent {
+		t.Errorf("_database.json was mutated:\n%s", got)
+	}
+}
+
 func TestFolder_RegeneratesStaleAgentsMD(t *testing.T) {
 	prev := sync.Version
 	sync.Version = "v9.9.9-test"

--- a/internal/clean/clean_test.go
+++ b/internal/clean/clean_test.go
@@ -976,6 +976,14 @@ func TestCountNonCanonicalFolderPathInJSON(t *testing.T) {
 			json: `{"folderPath": ""}`,
 			want: 0,
 		},
+		{
+			// Go's json.Marshal escapes `&` as `\u0026` (HTML-escape on by
+			// default), which contains a single backslash but is not a path
+			// separator. The detector must not treat this as non-canonical.
+			name: "ampersand HTML-escape is not a separator",
+			json: `{"folderPath": "Foo \u0026 Bar"}`,
+			want: 0,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/sync/metadata.go
+++ b/internal/sync/metadata.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ran-codes/notion-sync/internal/notion"
 )
@@ -40,7 +41,13 @@ func WriteDatabaseMetadata(folderPath string, metadata *FrozenDatabase) error {
 		metadata.SyncVersion = Version
 	}
 	metadata.URL = notion.CanonicalizeNotionURL(metadata.URL)
-	metadata.FolderPath = filepath.ToSlash(metadata.FolderPath)
+	// Replace backslashes unconditionally rather than using filepath.ToSlash —
+	// ToSlash only converts on Windows, but a Linux user running `clean` on a
+	// Windows-synced workspace also needs to canonicalize the backslashes that
+	// the Windows binary previously wrote. The whole point of the migration is
+	// to make folderPath host-invariant in the snapshot, so the rewrite must
+	// not depend on the host that's doing the rewriting.
+	metadata.FolderPath = strings.ReplaceAll(metadata.FolderPath, `\`, "/")
 
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
@@ -79,7 +86,13 @@ func WritePageMetadata(folderPath string, metadata *FrozenPage) error {
 		metadata.SyncVersion = Version
 	}
 	metadata.URL = notion.CanonicalizeNotionURL(metadata.URL)
-	metadata.FolderPath = filepath.ToSlash(metadata.FolderPath)
+	// Replace backslashes unconditionally rather than using filepath.ToSlash —
+	// ToSlash only converts on Windows, but a Linux user running `clean` on a
+	// Windows-synced workspace also needs to canonicalize the backslashes that
+	// the Windows binary previously wrote. The whole point of the migration is
+	// to make folderPath host-invariant in the snapshot, so the rewrite must
+	// not depend on the host that's doing the rewriting.
+	metadata.FolderPath = strings.ReplaceAll(metadata.FolderPath, `\`, "/")
 
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {

--- a/internal/sync/metadata.go
+++ b/internal/sync/metadata.go
@@ -40,6 +40,7 @@ func WriteDatabaseMetadata(folderPath string, metadata *FrozenDatabase) error {
 		metadata.SyncVersion = Version
 	}
 	metadata.URL = notion.CanonicalizeNotionURL(metadata.URL)
+	metadata.FolderPath = filepath.ToSlash(metadata.FolderPath)
 
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
@@ -78,6 +79,7 @@ func WritePageMetadata(folderPath string, metadata *FrozenPage) error {
 		metadata.SyncVersion = Version
 	}
 	metadata.URL = notion.CanonicalizeNotionURL(metadata.URL)
+	metadata.FolderPath = filepath.ToSlash(metadata.FolderPath)
 
 	data, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {

--- a/internal/sync/metadata_test.go
+++ b/internal/sync/metadata_test.go
@@ -159,6 +159,47 @@ func TestWritePageMetadata_CanonicalizesURL(t *testing.T) {
 	}
 }
 
+func TestWriteDatabaseMetadata_NormalizesFolderPathSeparator(t *testing.T) {
+	dir := t.TempDir()
+	meta := &FrozenDatabase{
+		DatabaseID: "abc",
+		Title:      "T",
+		FolderPath: `_etl\notion-sync\v1\Foo`,
+		EntryCount: 1,
+	}
+	if err := WriteDatabaseMetadata(dir, meta); err != nil {
+		t.Fatalf("WriteDatabaseMetadata: %v", err)
+	}
+	got, err := ReadDatabaseMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadDatabaseMetadata: %v", err)
+	}
+	want := "_etl/notion-sync/v1/Foo"
+	if got.FolderPath != want {
+		t.Errorf("FolderPath = %q, want %q", got.FolderPath, want)
+	}
+}
+
+func TestWritePageMetadata_NormalizesFolderPathSeparator(t *testing.T) {
+	dir := t.TempDir()
+	meta := &FrozenPage{
+		PageID:     "abc",
+		Title:      "T",
+		FolderPath: `pages\MyPage_abc`,
+	}
+	if err := WritePageMetadata(dir, meta); err != nil {
+		t.Fatalf("WritePageMetadata: %v", err)
+	}
+	got, err := ReadPageMetadata(dir)
+	if err != nil {
+		t.Fatalf("ReadPageMetadata: %v", err)
+	}
+	want := "pages/MyPage_abc"
+	if got.FolderPath != want {
+		t.Errorf("FolderPath = %q, want %q", got.FolderPath, want)
+	}
+}
+
 func TestWritePageMetadata_TrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 	meta := &FrozenPage{PageID: "abc", Title: "T"}


### PR DESCRIPTION
## Context
- Windows-side syncs were leaking host-native backslashes into `folderPath` in `_database.json` / `_page.json`. When a teammate refreshed the same workspace on macOS/Linux, every metadata file flipped its `folderPath` line — pure-noise diffs in PRs and Git history.
- Same shape as the v1.3.0 URL canonicalization migration (#63) and the dry-run reporting fix (#69): metadata that should be host-invariant must not carry host-specific state.
- Concretely surfaced as a follow-up to issue #70.

## Changes
- [`internal/sync/metadata.go`](https://github.com/Drexel-UHC/notion-sync/blob/24ea4089cd68fcedb5e9ef7074e53ff5268a138d/internal/sync/metadata.go) — `WriteDatabaseMetadata` and `WritePageMetadata` now run `strings.ReplaceAll(folderPath, "\\", "/")` next to the existing `CanonicalizeNotionURL` call, so newly written metadata is host-independent.
  - Note: deliberately NOT `filepath.ToSlash`, which is a no-op on Linux. The migration must work on a Linux teammate who runs `clean` on a Windows-synced workspace, so the rewrite must not depend on the host doing it.
- [`internal/clean/clean.go`](https://github.com/Drexel-UHC/notion-sync/blob/24ea4089cd68fcedb5e9ef7074e53ff5268a138d/internal/clean/clean.go) — clean walk gains a one-time migration:
  - new `FolderPathsNormalized` field on `Result`
  - new `jsonFolderPathValuePattern` + `countNonCanonicalFolderPathInJSON` helper that detects backslash-bearing `folderPath` values in metadata JSON (a literal `\` survives JSON quoting as `\`)
  - walk now marks a metadata folder dirty on either non-canonical URL **or** backslash `folderPath`; the actual rewrite happens for free inside `WriteDatabaseMetadata` / `WritePageMetadata` during the existing bump pass
  - same deferred-counter discipline as the URL counter — only folded into the result once `MetadataBumped` is confirmed (or in dry-run, would be confirmed). Honest in `sync.Version=""` and corrupt-metadata cases.
- [`cmd/notion-sync/main.go`](https://github.com/Drexel-UHC/notion-sync/blob/24ea4089cd68fcedb5e9ef7074e53ff5268a138d/cmd/notion-sync/main.go) — `clean` summary line now includes `%d folderPaths normalized` for both real-run and dry-run.
- [`internal/sync/metadata_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/24ea4089cd68fcedb5e9ef7074e53ff5268a138d/internal/sync/metadata_test.go) — `TestWriteDatabaseMetadata_NormalizesFolderPathSeparator`, `TestWritePageMetadata_NormalizesFolderPathSeparator`.
- [`internal/clean/clean_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/24ea4089cd68fcedb5e9ef7074e53ff5268a138d/internal/clean/clean_test.go) — `TestCountNonCanonicalFolderPathInJSON` (table-driven), `TestFolder_NormalizesFolderPathInDatabaseJSON`, `TestFolder_NormalizesFolderPathInPageJSON`, `TestFolder_NormalizeFolderPath_DryRun`, `TestFolder_NormalizeFolderPath_Idempotent`.

Related to #70

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)