### PR TITLE
test(clean): CLI e2e test covering all 9 migrations budnled into `go test`

### DIFF
--- a/cmd/notion-sync/clean_e2e_test.go
+++ b/cmd/notion-sync/clean_e2e_test.go
@@ -224,10 +224,21 @@ func TestCLI_Clean_AppliesAllMigrations(t *testing.T) {
 	}
 
 	// Migration #4, #5, #7 — _database.json
-	expectMetadataMigrated(t, p.dbJSON, canonicalDBURL, "[db]")
+	expectMetadataMigrated(t, p.dbJSON, expectedMeta{
+		URL:          canonicalDBURL,
+		ID:           "abcdefabcdefabcdefabcdefabcdefab",
+		Title:        "My Database",
+		LastSyncedAt: "2026-01-01T00:00:00Z",
+		EntryCount:   1,
+	}, "[db]")
 
 	// Migration #4, #5, #8 — _page.json
-	expectMetadataMigrated(t, p.pageJSON, canonicalPageURL, "[page]")
+	expectMetadataMigrated(t, p.pageJSON, expectedMeta{
+		URL:          canonicalPageURL,
+		ID:           "fedcba9876543210fedcba9876543210",
+		Title:        "My Page",
+		LastSyncedAt: "2026-01-01T00:00:00Z",
+	}, "[page]")
 
 	// Migration #6 — page.md trailing newline added
 	pageAfter := readFile(t, p.pageMD)
@@ -235,13 +246,13 @@ func TestCLI_Clean_AppliesAllMigrations(t *testing.T) {
 		t.Errorf("[#6] page.md missing trailing newline:\n%q", pageAfter)
 	}
 
-	// Migration #9 — AGENTS.md regenerated with current stamp
+	// Migration #9 — AGENTS.md regenerated with current binary's version stamp.
+	// The TestMain build runs `go build` without -ldflags, so `version` stays at
+	// its source default ("dev"). Anchor on that exact stamp so a regression
+	// that writes the wrong version (e.g., a hardcoded constant) fails loudly.
 	agentsAfter := readFile(t, p.agentsMD)
-	if strings.Contains(agentsAfter, "v0.0.1") {
-		t.Errorf("[#9] AGENTS.md still has stale stamp:\n%s", agentsAfter)
-	}
-	if !strings.Contains(agentsAfter, "<!-- notion-sync-version:") {
-		t.Errorf("[#9] AGENTS.md missing version stamp:\n%s", agentsAfter)
+	if !strings.Contains(agentsAfter, "<!-- notion-sync-version: dev -->") {
+		t.Errorf("[#9] AGENTS.md missing expected version stamp '<!-- notion-sync-version: dev -->':\n%s", agentsAfter)
 	}
 
 	// Phase 3: idempotency — second run reports zero work for every counter.
@@ -306,21 +317,44 @@ func expectUnchanged(t *testing.T, path, original, label string) {
 	}
 }
 
+// expectedMeta captures both the migrated values (URL) and the round-trip
+// values that must survive the syncVersion bump. EntryCount is page-vs-db
+// asymmetric: _database.json carries it, _page.json does not — a zero value
+// is treated as "not part of this metadata type, skip the check."
+type expectedMeta struct {
+	URL          string
+	ID           string // databaseId or pageId
+	Title        string
+	LastSyncedAt string
+	EntryCount   int // 0 = skip (page metadata has no entryCount)
+}
+
 // expectMetadataMigrated asserts a metadata JSON file (_database.json or
 // _page.json) had its url canonicalized, folderPath de-backslashed, and
-// syncVersion bumped off the stale "v0.0.1" seed value.
-func expectMetadataMigrated(t *testing.T, path, wantURL, tag string) {
+// syncVersion bumped off the stale "v0.0.1" seed value. It also asserts that
+// the rest of the struct round-tripped unchanged through the bump — the bump
+// goes through Write{Database,Page}Metadata, so a regression that drops a
+// field (entryCount, lastSyncedAt, title, id) would be invisible if we only
+// asserted on the migrated fields.
+func expectMetadataMigrated(t *testing.T, path string, want expectedMeta, tag string) {
 	t.Helper()
 	var meta struct {
-		URL         string `json:"url"`
-		FolderPath  string `json:"folderPath"`
-		SyncVersion string `json:"syncVersion"`
+		DatabaseID   string `json:"databaseId"`
+		PageID       string `json:"pageId"`
+		Title        string `json:"title"`
+		URL          string `json:"url"`
+		FolderPath   string `json:"folderPath"`
+		LastSyncedAt string `json:"lastSyncedAt"`
+		EntryCount   int    `json:"entryCount"`
+		SyncVersion  string `json:"syncVersion"`
 	}
 	if err := json.Unmarshal([]byte(readFile(t, path)), &meta); err != nil {
 		t.Fatalf("%s unmarshal: %v", tag, err)
 	}
-	if meta.URL != wantURL {
-		t.Errorf("%s [#4] url: got %q, want %q", tag, meta.URL, wantURL)
+
+	// Migrations.
+	if meta.URL != want.URL {
+		t.Errorf("%s [#4] url: got %q, want %q", tag, meta.URL, want.URL)
 	}
 	if strings.Contains(meta.FolderPath, `\`) {
 		t.Errorf("%s [#5] folderPath still contains backslash: %q", tag, meta.FolderPath)
@@ -330,6 +364,24 @@ func expectMetadataMigrated(t *testing.T, path, wantURL, tag string) {
 	}
 	if meta.SyncVersion == "" || meta.SyncVersion == "v0.0.1" {
 		t.Errorf("%s [#7/#8] syncVersion not bumped: got %q", tag, meta.SyncVersion)
+	}
+
+	// Preservation: fields that must round-trip unchanged through the bump.
+	id := meta.DatabaseID
+	if id == "" {
+		id = meta.PageID
+	}
+	if id != want.ID {
+		t.Errorf("%s preservation: id got %q, want %q", tag, id, want.ID)
+	}
+	if meta.Title != want.Title {
+		t.Errorf("%s preservation: title got %q, want %q", tag, meta.Title, want.Title)
+	}
+	if meta.LastSyncedAt != want.LastSyncedAt {
+		t.Errorf("%s preservation: lastSyncedAt got %q, want %q", tag, meta.LastSyncedAt, want.LastSyncedAt)
+	}
+	if want.EntryCount > 0 && meta.EntryCount != want.EntryCount {
+		t.Errorf("%s preservation: entryCount got %d, want %d", tag, meta.EntryCount, want.EntryCount)
 	}
 }
 

--- a/cmd/notion-sync/clean_e2e_test.go
+++ b/cmd/notion-sync/clean_e2e_test.go
@@ -1,0 +1,301 @@
+package main
+
+// CLI-level e2e coverage for the `clean` command.
+//
+// `clean` exists to absorb one-time migrations after a binary upgrade. The
+// fixture below is a synthetic workspace that hits every migration the
+// `internal/clean` package doc lists. The test asserts both stdout summary
+// counts and post-state file contents, then re-runs `clean` to verify
+// idempotency.
+//
+// Migrations exercised by the seed:
+//
+//	| # | Migration                                       | Fixture                          |
+//	|---|-------------------------------------------------|----------------------------------|
+//	| 1 | Strip S3 presigned query strings from .md       | entry.md frontmatter (PDF field) |
+//	| 2 | Remove `notion-frozen-at:` from frontmatter     | entry.md                         |
+//	| 3 | Canonicalize `notion-url:` in .md               | entry.md                         |
+//	| 4 | Canonicalize `"url"` in metadata JSON           | _database.json + _page.json      |
+//	| 5 | Normalize `folderPath` separator (\ → /)        | _database.json + _page.json      |
+//	| 6 | Append trailing newline on .md/.json            | pages/.../My Page.md             |
+//	| 7 | Bump syncVersion in _database.json              | My Database/_database.json       |
+//	| 8 | Bump syncVersion in _page.json                  | pages/.../_page.json             |
+//	| 9 | Regenerate stale AGENTS.md                      | workspace AGENTS.md (v0.0.1)     |
+//
+// API-drift caveat: this seed encodes notion-sync's *historical* output
+// shapes — frozen-in-time legacy artifacts. It does NOT call the Notion API.
+// If the importer's output contract changes (frontmatter keys, _database.json
+// shape, AGENTS.md template, URL format), this fixture may need regeneration
+// so the test stays representative of real workspaces. See issue #66.
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	legacyEntryID     = "1234567890abcdef1234567890abcdef"
+	legacyEntryURL    = "https://www.notion.so/Title-1234567890abcdef1234567890abcdef"
+	canonicalEntryURL = "https://app.notion.com/p/1234567890abcdef1234567890abcdef"
+
+	legacyDBURL    = "https://www.notion.so/My-Database-abcdefabcdefabcdefabcdefabcdefab"
+	canonicalDBURL = "https://app.notion.com/p/abcdefabcdefabcdefabcdefabcdefab"
+
+	legacyPageURL    = "https://www.notion.so/My-Page-fedcba9876543210fedcba9876543210"
+	canonicalPageURL = "https://app.notion.com/p/fedcba9876543210fedcba9876543210"
+
+	presignedURL    = "https://prod-files-secure.s3.us-west-2.amazonaws.com/x/y/file.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc&X-Amz-Date=20260101T000000Z"
+	strippedFileURL = "https://prod-files-secure.s3.us-west-2.amazonaws.com/x/y/file.pdf"
+
+	staleAgentsMD = "<!-- notion-sync-version: v0.0.1 -->\n# stale\n"
+)
+
+type seedPaths struct {
+	workspace, entryMD, dbJSON, agentsMD, pageMD, pageJSON string
+}
+
+// writeSyntheticWorkspace lays out the fixture documented in the file header.
+// Returns absolute paths to every file the test asserts against.
+func writeSyntheticWorkspace(t *testing.T) seedPaths {
+	t.Helper()
+	p := seedPaths{workspace: t.TempDir()}
+
+	// --- Database folder: covers migrations #1, #2, #3, #4, #5, #7
+	dbDir := filepath.Join(p.workspace, "My Database")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	p.entryMD = filepath.Join(dbDir, legacyEntryID+".md")
+	entry := "---\n" +
+		`notion-id: "` + legacyEntryID + `"` + "\n" +
+		`notion-url: "` + legacyEntryURL + `"` + "\n" +
+		`notion-frozen-at: "2026-01-01T00:00:00Z"` + "\n" +
+		"PDF:\n" +
+		`  - "` + presignedURL + `"` + "\n" +
+		"---\n\nbody\n"
+	if err := os.WriteFile(p.entryMD, []byte(entry), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p.dbJSON = filepath.Join(dbDir, "_database.json")
+	dbJSON := `{
+  "databaseId": "abcdefabcdefabcdefabcdefabcdefab",
+  "title": "My Database",
+  "url": "` + legacyDBURL + `",
+  "folderPath": "test-output\\My Database",
+  "lastSyncedAt": "2026-01-01T00:00:00Z",
+  "entryCount": 1,
+  "syncVersion": "v0.0.1"
+}
+`
+	if err := os.WriteFile(p.dbJSON, []byte(dbJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- Standalone page folder: covers migrations #4, #5, #6, #8
+	pageDir := filepath.Join(p.workspace, "pages", "My Page_fedcba98")
+	if err := os.MkdirAll(pageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	p.pageMD = filepath.Join(pageDir, "My Page.md")
+	// No trailing newline — exercises migration #6.
+	pageMD := "---\n" +
+		`notion-id: "fedcba9876543210fedcba9876543210"` + "\n" +
+		"---\n\nstandalone body"
+	if err := os.WriteFile(p.pageMD, []byte(pageMD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p.pageJSON = filepath.Join(pageDir, "_page.json")
+	pageJSON := `{
+  "pageId": "fedcba9876543210fedcba9876543210",
+  "title": "My Page",
+  "url": "` + legacyPageURL + `",
+  "folderPath": "test-output\\pages\\My Page_fedcba98",
+  "lastSyncedAt": "2026-01-01T00:00:00Z",
+  "syncVersion": "v0.0.1"
+}
+`
+	if err := os.WriteFile(p.pageJSON, []byte(pageJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- Workspace root: covers migration #9
+	p.agentsMD = filepath.Join(p.workspace, "AGENTS.md")
+	if err := os.WriteFile(p.agentsMD, []byte(staleAgentsMD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestCLI_Clean_AppliesAllMigrations(t *testing.T) {
+	p := writeSyntheticWorkspace(t)
+
+	originalEntry := readFile(t, p.entryMD)
+	originalDB := readFile(t, p.dbJSON)
+	originalPageMD := readFile(t, p.pageMD)
+	originalPageJSON := readFile(t, p.pageJSON)
+	originalAgents := readFile(t, p.agentsMD)
+
+	// Counts the real run and the dry-run share. Derived from the seed:
+	//   1 S3 URL  · 3 notion URLs (1 .md + 2 .json) · 2 backslash folderPaths
+	//   1 frozen-at line · 1 file missing trailing newline
+	//   2 metadata folders bumped (My Database + pages/My Page_fedcba98)
+	expectedCounts := []string{
+		"1 URLs stripped",
+		"3 URLs canonicalized",
+		"2 folderPaths normalized",
+		"1 trailing newlines added",
+		"1 notion-frozen-at lines stripped",
+	}
+
+	// Phase 1: dry-run reports counts but does not mutate disk.
+	out := mustRunClean(t, p.workspace, true)
+	expectContains(t, out, append(expectedCounts,
+		"Would stamp syncVersion in: 2 folder(s)",
+		"Would regenerate AGENTS.md",
+	))
+	expectUnchanged(t, p.entryMD, originalEntry, "entry.md")
+	expectUnchanged(t, p.dbJSON, originalDB, "_database.json")
+	expectUnchanged(t, p.pageMD, originalPageMD, "page.md")
+	expectUnchanged(t, p.pageJSON, originalPageJSON, "_page.json")
+	expectUnchanged(t, p.agentsMD, originalAgents, "AGENTS.md")
+
+	// Phase 2: real run applies every migration.
+	out = mustRunClean(t, p.workspace, false)
+	expectContains(t, out, append(expectedCounts,
+		"Stamped syncVersion in: 2 folder(s)",
+		"Regenerated AGENTS.md",
+	))
+
+	// Migration #1, #2, #3 — entry.md
+	entryAfter := readFile(t, p.entryMD)
+	if !strings.Contains(entryAfter, strippedFileURL) {
+		t.Errorf("[#1] presigned URL not stripped:\n%s", entryAfter)
+	}
+	if strings.Contains(entryAfter, "X-Amz-Signature") {
+		t.Errorf("[#1] X-Amz-Signature still present:\n%s", entryAfter)
+	}
+	if strings.Contains(entryAfter, "notion-frozen-at") {
+		t.Errorf("[#2] notion-frozen-at line still present:\n%s", entryAfter)
+	}
+	if !strings.Contains(entryAfter, canonicalEntryURL) {
+		t.Errorf("[#3] notion-url not canonicalized:\n%s", entryAfter)
+	}
+	if strings.Contains(entryAfter, legacyEntryURL) {
+		t.Errorf("[#3] legacy notion-url still present:\n%s", entryAfter)
+	}
+
+	// Migration #4, #5, #7 — _database.json
+	expectMetadataMigrated(t, p.dbJSON, canonicalDBURL, "[db]")
+
+	// Migration #4, #5, #8 — _page.json
+	expectMetadataMigrated(t, p.pageJSON, canonicalPageURL, "[page]")
+
+	// Migration #6 — page.md trailing newline added
+	pageAfter := readFile(t, p.pageMD)
+	if !strings.HasSuffix(pageAfter, "\n") {
+		t.Errorf("[#6] page.md missing trailing newline:\n%q", pageAfter)
+	}
+
+	// Migration #9 — AGENTS.md regenerated with current stamp
+	agentsAfter := readFile(t, p.agentsMD)
+	if strings.Contains(agentsAfter, "v0.0.1") {
+		t.Errorf("[#9] AGENTS.md still has stale stamp:\n%s", agentsAfter)
+	}
+	if !strings.Contains(agentsAfter, "<!-- notion-sync-version:") {
+		t.Errorf("[#9] AGENTS.md missing version stamp:\n%s", agentsAfter)
+	}
+
+	// Phase 3: idempotency — second run reports zero work for every counter.
+	out = mustRunClean(t, p.workspace, false)
+	for _, want := range []string{
+		"Modified: 0 files",
+		"0 URLs stripped",
+		"0 URLs canonicalized",
+		"0 folderPaths normalized",
+		"0 trailing newlines added",
+		"0 notion-frozen-at lines stripped",
+		"Stamped syncVersion in: 0 folder(s)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("idempotent run missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Regenerated AGENTS.md") {
+		t.Errorf("AGENTS.md should not regenerate on second run, got:\n%s", out)
+	}
+}
+
+func TestCLI_Clean_MissingFolderArg_ExitOne(t *testing.T) {
+	if err := exec.Command("go", "run", ".", "clean").Run(); err == nil {
+		t.Error("expected non-zero exit when folder arg is missing")
+	}
+}
+
+func mustRunClean(t *testing.T, workspace string, dryRun bool) string {
+	t.Helper()
+	args := []string{"run", ".", "clean", workspace}
+	if dryRun {
+		args = append(args, "--dry-run")
+	}
+	out, err := exec.Command("go", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clean failed (dryRun=%v): %v\n%s", dryRun, err, out)
+	}
+	return string(out)
+}
+
+func expectContains(t *testing.T, out string, needles []string) {
+	t.Helper()
+	for _, n := range needles {
+		if !strings.Contains(out, n) {
+			t.Errorf("output missing %q\n--- output ---\n%s", n, out)
+		}
+	}
+}
+
+func expectUnchanged(t *testing.T, path, original, label string) {
+	t.Helper()
+	if readFile(t, path) != original {
+		t.Errorf("dry-run mutated %s", label)
+	}
+}
+
+// expectMetadataMigrated asserts a metadata JSON file (_database.json or
+// _page.json) had its url canonicalized, folderPath de-backslashed, and
+// syncVersion bumped off the stale "v0.0.1" seed value.
+func expectMetadataMigrated(t *testing.T, path, wantURL, tag string) {
+	t.Helper()
+	var meta struct {
+		URL         string `json:"url"`
+		FolderPath  string `json:"folderPath"`
+		SyncVersion string `json:"syncVersion"`
+	}
+	if err := json.Unmarshal([]byte(readFile(t, path)), &meta); err != nil {
+		t.Fatalf("%s unmarshal: %v", tag, err)
+	}
+	if meta.URL != wantURL {
+		t.Errorf("%s [#4] url: got %q, want %q", tag, meta.URL, wantURL)
+	}
+	if strings.Contains(meta.FolderPath, `\`) {
+		t.Errorf("%s [#5] folderPath still contains backslash: %q", tag, meta.FolderPath)
+	}
+	if !strings.Contains(meta.FolderPath, "/") {
+		t.Errorf("%s [#5] folderPath should contain forward slash: %q", tag, meta.FolderPath)
+	}
+	if meta.SyncVersion == "" || meta.SyncVersion == "v0.0.1" {
+		t.Errorf("%s [#7/#8] syncVersion not bumped: got %q", tag, meta.SyncVersion)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/cmd/notion-sync/clean_e2e_test.go
+++ b/cmd/notion-sync/clean_e2e_test.go
@@ -30,12 +30,42 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+// testBinaryPath is the absolute path to a notion-sync binary built once in
+// TestMain and reused across every test invocation in this package's e2e
+// tests. Building once instead of `go run`-ing per call keeps a 4-invocation
+// test from paying 4× the toolchain build cost.
+var testBinaryPath string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "notion-sync-e2e-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "test bin temp dir:", err)
+		os.Exit(2)
+	}
+	bin := "notion-sync-e2e"
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	testBinaryPath = filepath.Join(dir, bin)
+	if out, err := exec.Command("go", "build", "-o", testBinaryPath, ".").CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "test bin build failed: %v\n%s\n", err, out)
+		os.RemoveAll(dir)
+		os.Exit(2)
+	}
+
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 const (
 	legacyEntryID     = "1234567890abcdef1234567890abcdef"
@@ -143,12 +173,17 @@ func TestCLI_Clean_AppliesAllMigrations(t *testing.T) {
 	//   1 S3 URL  · 3 notion URLs (1 .md + 2 .json) · 2 backslash folderPaths
 	//   1 frozen-at line · 1 file missing trailing newline
 	//   2 metadata folders bumped (My Database + pages/My Page_fedcba98)
+	// Anchor each count with the literal punctuation that immediately precedes
+	// it in the summary line:
+	//   "Modified: N files (N URLs stripped, N URLs canonicalized, ...)"
+	// Without the leading "(" / ", " anchors, "1 URLs stripped" would also
+	// match "11 URLs stripped" and any future double-digit counts.
 	expectedCounts := []string{
-		"1 URLs stripped",
-		"3 URLs canonicalized",
-		"2 folderPaths normalized",
-		"1 trailing newlines added",
-		"1 notion-frozen-at lines stripped",
+		"(1 URLs stripped",
+		", 3 URLs canonicalized",
+		", 2 folderPaths normalized",
+		", 1 trailing newlines added",
+		", 1 notion-frozen-at lines stripped",
 	}
 
 	// Phase 1: dry-run reports counts but does not mutate disk.
@@ -213,11 +248,11 @@ func TestCLI_Clean_AppliesAllMigrations(t *testing.T) {
 	out = mustRunClean(t, p.workspace, false)
 	for _, want := range []string{
 		"Modified: 0 files",
-		"0 URLs stripped",
-		"0 URLs canonicalized",
-		"0 folderPaths normalized",
-		"0 trailing newlines added",
-		"0 notion-frozen-at lines stripped",
+		"(0 URLs stripped",
+		", 0 URLs canonicalized",
+		", 0 folderPaths normalized",
+		", 0 trailing newlines added",
+		", 0 notion-frozen-at lines stripped",
 		"Stamped syncVersion in: 0 folder(s)",
 	} {
 		if !strings.Contains(out, want) {
@@ -230,18 +265,25 @@ func TestCLI_Clean_AppliesAllMigrations(t *testing.T) {
 }
 
 func TestCLI_Clean_MissingFolderArg_ExitOne(t *testing.T) {
-	if err := exec.Command("go", "run", ".", "clean").Run(); err == nil {
-		t.Error("expected non-zero exit when folder arg is missing")
+	out, err := exec.Command(testBinaryPath, "clean").CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit when folder arg is missing\n--- output ---\n%s", out)
+	}
+	// Anchor on the actual error string from runClean so this test fails
+	// loudly if `clean` ever exits non-zero for an unrelated reason (build
+	// regression, panic, different validation path).
+	if !strings.Contains(string(out), "missing folder path") {
+		t.Errorf("expected 'missing folder path' in stderr, got:\n%s", out)
 	}
 }
 
 func mustRunClean(t *testing.T, workspace string, dryRun bool) string {
 	t.Helper()
-	args := []string{"run", ".", "clean", workspace}
+	args := []string{"clean", workspace}
 	if dryRun {
 		args = append(args, "--dry-run")
 	}
-	out, err := exec.Command("go", args...).CombinedOutput()
+	out, err := exec.Command(testBinaryPath, args...).CombinedOutput()
 	if err != nil {
 		t.Fatalf("clean failed (dryRun=%v): %v\n%s", dryRun, err, out)
 	}

--- a/scr-4.md
+++ b/scr-4.md
@@ -1,0 +1,74 @@
+# notion-sync gap: agent-driven edits silently skipped
+
+## The gap
+
+`notion-sync refresh` decides whether to re-fetch a page by comparing the page's Notion `last_edited_time` against the snapshot's `notion-last-edited`. Newer → re-fetch. Same/older → skip. That's the incremental optimization that keeps refresh cheap on large databases.
+
+**The problem:** Notion's API doesn't bump `last_edited_time` for every kind of property write. Empirically observed in this project:
+
+| Operation                                          | Bumps `last_edited_time`?            |
+| -------------------------------------------------- | ------------------------------------ |
+| Title text edit (e.g., `Name` typo fix)            | Yes                                  |
+| Rich-text property edit                            | Yes (assumed — same family as title) |
+| URL property cleared (e.g., `English Link → null`) | **No**                               |
+| Other property types via API                       | Unknown — not empirically tested     |
+| In-app human edits in Notion UI                    | Yes (always)                         |
+
+So when an agent (Claude, automation, MCP) clears a URL or makes a similar non-bumping write, the page silently looks "untouched" to notion-sync. Vanilla refresh skips it. The snapshot drifts from Notion. Nothing surfaces unless a human diffs carefully.
+
+This happened twice on PR #580: Figueroa + Unar Munguía `English Link` clears were missed by `refresh` and required `--ids` to force-fetch.
+
+## Why this gets worse with agents
+
+Same-session edit-then-sync is recoverable: the agent can track touched IDs and pass them to `refresh --ids`. Cross-session is the real hole:
+
+```
+Agent A (Mon)  → MCP write to page X       → timestamp doesn't bump → A's session ends
+Agent B (Wed)  → notion-sync refresh       → skips page X (timestamp says stale)
+                 → page X never lands in snapshot
+```
+
+Agent B has no view of what Agent A touched. There's no shared state. As agent edit volume grows, the probability of cross-session drift grows with it.
+
+## Options considered
+
+| #   | Option                                                                                                                                  | Effort                                         | Pros                                                                   | Cons                                                                                  |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | **Operational discipline:** every agent runs `--ids` for touched pages at end of session                                                | None                                           | Trivial to adopt                                                       | Only solves same-session. Cross-session still drifts. Easy to forget.                 |
+| 2   | **Upstream `--force-since <timestamp>` flag** in notion-sync — re-fetch any page with `last_synced_at < window` regardless of timestamp | Medium (file upstream issue, wait for release) | Cleanest fix. Cross-session safe. Cheap re-fetch (only recent subset). | Depends on maintainer. Not in our hands.                                              |
+| 3   | **Periodic `--no-incremental` full refresh** as a safety net (e.g., weekly cron)                                                        | Low                                            | Catches everything                                                     | Expensive on large DBs. Doesn't prevent drift between runs, just bounds it.           |
+| 4   | **Persistent `_pending-refresh.json` queue file** per database — agents append touched IDs, next sync drains                            | Medium                                         | Cross-session safe without upstream change                             | Extra failure modes (crash before append, concurrent writes, git churn on every edit) |
+| 5   | **Force-bump trick:** every agent write also re-writes a known-bumping property in the same atomic API call                             | Low                                            | Works without upstream change                                          | Ad-hoc per write, easy to miss, ugly                                                  |
+| 6   | **Notion webhooks → external queue** (Azure Function, drain on sync)                                                                    | High                                           | Most robust. Captures all edits agent or human.                        | Significant infra. Overkill until volume justifies.                                   |
+
+## My opinion: standardized `agent_log` column (variant of #5, but as a convention)
+
+Add an `agent_log` rich-text property to every notion-sync-managed database. Agents writing to Notion always append to this column in the same atomic `update_properties` call as their real edit (e.g., `"<ISO timestamp> <agent-id>: <short summary>"`).
+
+Why this is the easiest path:
+
+- Rich-text writes **do** bump `last_edited_time` (verified empirically). So pairing any property write with an `agent_log` append guarantees the timestamp bumps, regardless of what the primary property type is.
+- Notion's `update_properties` is atomic across multiple properties — the real edit and the log entry land in one API call. No race window.
+- No upstream notion-sync change needed. Works with vanilla incremental refresh today.
+- No cross-session coordination needed. The mechanism is "every agent edit bumps the timestamp" — sync correctness no longer depends on knowing who touched what.
+- Free audit log as a side effect. Useful for debugging, attribution, and noticing when an agent has been chatty on a page.
+- Simple convention to enforce: skill definitions and the `mcp__claude_ai_Notion__notion-update-page` wrapper require the `agent_log` field be set on every write. Lint-able.
+
+Tradeoffs honestly:
+
+- Schema change across every database (one rich-text property each — small but real).
+- Convention-bound: if an agent forgets the `agent_log` write, the bug recurs silently for that page. Mitigated by wrapping MCP writes in a helper that requires the field.
+- The `agent_log` column will accumulate entries over time. Set a convention to keep it short (last N entries, or rolling buffer) so it doesn't bloat.
+
+## Recommended sequence
+
+1. **Now** — add `agent_log` (rich-text) to every database in `_etl/_notion-sync/v1/`. Document the convention in `_etl/_notion-sync/CLAUDE.md`. Update agent skills (`/notion-sync` and any other Notion-writing skill) to require the field.
+2. **Also now** — file the upstream `--force-since` issue on `notion-sync`. The `agent_log` convention is local to us; the upstream fix benefits the whole notion-sync ecosystem and doesn't conflict.
+3. **Skip the queue file (#4) and webhook (#6) options** unless `agent_log` proves insufficient at higher edit volumes.
+4. **Run a periodic `--no-incremental` (option #3) as a belt-and-suspenders safety net** — quarterly is probably enough given `agent_log` should catch the bulk.
+
+## Open questions
+
+- Does Notion's API return the property write order in `update_properties`, or could the rich-text touch land in a way that doesn't bump the timestamp? Need to spot-check.
+- Are there any property types we use that _also_ don't bump `last_edited_time` even when paired with a rich-text write? Unlikely (the bump is page-level, not property-level), but worth confirming.
+- What's the right format for `agent_log` entries? Suggest: `<ISO timestamp>\t<agent-id>\t<one-line summary>`, newest line on top, capped at 20 entries.


### PR DESCRIPTION
## Context

- `notion-sync clean` is the post-upgrade migration command — it absorbs one-time fixes (S3 URL stripping, `notion-frozen-at` removal, URL canonicalization, folderPath normalization, syncVersion bumps, AGENTS.md regen) so routine refreshes produce focused diffs.
- Until now, `clean` had unit coverage in `internal/clean/clean_test.go` and a hand-run smoke test, but **no end-to-end coverage of the binary's CLI surface**: arg parsing, exit codes, the stdout summary text users grep against, or interaction effects across migration types in one pass. PR #71 was a recent example of that gap biting (the `URLs canonicalized` count was missing from dry-run output).
- The 3 existing system-test skills hit real Notion, so a network-free CLI test fits as a Go test rather than a skill — runs in `go test ./...` and CI for free, no manual invocation needed. Reframed accordingly in #66.

## Changes

- New file [`cmd/notion-sync/clean_e2e_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/46e5eaccba8625ca7f06e561ef5c07deadda2afe/cmd/notion-sync/clean_e2e_test.go) (~300 lines).
- Synthetic temp-dir seed encoding all 9 documented migrations from [`internal/clean/clean.go`](https://github.com/Drexel-UHC/notion-sync/blob/46e5eaccba8625ca7f06e561ef5c07deadda2afe/internal/clean/clean.go)'s package doc:
  | # | Migration | Fixture |
  |---|---|---|
  | 1 | Strip S3 presigned query strings (.md) | `entry.md` PDF field |
  | 2 | Remove `notion-frozen-at:` line | `entry.md` |
  | 3 | Canonicalize `notion-url:` (.md) | `entry.md` |
  | 4 | Canonicalize `"url"` (JSON) | `_database.json` + `_page.json` |
  | 5 | Normalize folderPath separator | `_database.json` + `_page.json` |
  | 6 | Append trailing newline | `pages/.../My Page.md` |
  | 7 | Bump syncVersion in `_database.json` | `My Database/_database.json` |
  | 8 | Bump syncVersion in `_page.json` | `pages/.../_page.json` |
  | 9 | Regenerate stale AGENTS.md | workspace `AGENTS.md` (v0.0.1) |
- Three phases asserted: dry-run is read-only (counts reported, files unchanged), real run applies every migration (count assertions + post-state byte checks), second run is idempotent.
- Top-of-file API-drift caveat: the seed encodes notion-sync's *historical* output shapes; if the importer's output contract changes meaningfully, the seed may need regeneration.
- Mutation pass at write-time: each of the 9 migrations was disabled one at a time and the test confirmed to fail on the matching assertion. Every migration is caught by ≥2 independent assertions (count + post-state, or two post-states).
- No production code changes — pure additive test file.

Related to #66.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)