### PR TITLE
fix(sync): stop pinning file mtime to Notion last_edited_time

### DIFF
--- a/.claude/reference/testing/README.md
+++ b/.claude/reference/testing/README.md
@@ -9,7 +9,7 @@
 │                                                         │
 │  /test-single-datasource-db  /test-double-datasource-db │
 │  - import → refresh → --ids  - multi-source subfolders  │
-│  - --force, mtime, props     - cross-source relations   │
+│  - --force, no-pin, props    - cross-source relations   │
 │  - SQLite verification       - edge cases (nulls, 0,    │
 │  - scoped cleanup per DB       unicode, negative nums)  │
 │                                                         │

--- a/.claude/skills/test-double-datasource-db/SKILL.md
+++ b/.claude/skills/test-double-datasource-db/SKILL.md
@@ -148,9 +148,9 @@ Run: `./notion-sync.exe refresh "./test-output/test database - double data sourc
 Run: `./notion-sync.exe refresh "./test-output/test database - double data source" --force`
 - **Pass criteria:** updated = total (>= 14), skipped = 0.
 
-### Step 11: Verify file mtime preservation
+### Step 11: Verify file mtime is not pinned to Notion's last_edited_time
 For each synced `.md` file in both `Projects/` and `Clients/`, compare the file's modification time (via `stat`) against the `notion-last-edited` value in its frontmatter.
-- **Pass criteria:** File mtime matches `notion-last-edited` timestamp (within 1-second tolerance).
+- **Pass criteria:** File mtime is **not** within 1 second of `notion-last-edited` for any file (regression guard — ref PR #75: pinning mtime backwards to Notion's timestamp defeated git's stat-cache and caused silent loss on same-length rewrites; mtime must reflect actual write time so `git status` invalidates correctly. The authoritative timestamp lives in `notion-last-edited` frontmatter).
 
 ### Step 12: Revert Notion changes
 Use Notion MCP tools to restore the page edited in Step 8 back to its original property values and content. This keeps the test database clean for the next run.

--- a/.claude/skills/test-single-datasource-db/SKILL.md
+++ b/.claude/skills/test-single-datasource-db/SKILL.md
@@ -99,9 +99,9 @@ Also check `_database.json` in the synced folder: its `"url"` line must match `"
 
 - **Pass criteria:** First 3 keys found with valid non-null values; `notion-frozen-at` produces zero matches across all `.md` files; every `.md` file has a `notion-url` line matching the anchored canonical pattern, and `_database.json`'s `"url"` matches the anchored canonical pattern.
 
-### Step 9: Verify file mtime preservation
+### Step 9: Verify file mtime is not pinned to Notion's last_edited_time
 For each synced `.md` file, compare the file's modification time (via `stat`) against the `notion-last-edited` value in its frontmatter.
-- **Pass criteria:** File mtime matches `notion-last-edited` timestamp (within 1-second tolerance).
+- **Pass criteria:** File mtime is **not** within 1 second of `notion-last-edited` for any file (regression guard — ref PR #75: pinning mtime backwards to Notion's timestamp defeated git's stat-cache and caused silent loss on same-length rewrites; mtime must reflect actual write time so `git status` invalidates correctly. The authoritative timestamp lives in `notion-last-edited` frontmatter).
 
 ### Step 9b: Pick a push test page and snapshot originals
 Pick a page **other than the one edited in Step 4** (call it page B). Read its local `.md` file and record the original values for these properties (you'll need them for Step 9d):

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -132,10 +132,6 @@ func FreezePage(opts FreezePageOptions) (*PageFreezeResult, error) {
 	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 		return nil, fmt.Errorf("write file: %w", err)
 	}
-	// Preserve file mtime from Notion's last_edited_time
-	if lastEdited, err := time.Parse(time.RFC3339, page.LastEditedTime); err == nil {
-		os.Chtimes(filePath, lastEdited, lastEdited)
-	}
 
 	status := "created"
 	if exists {

--- a/internal/sync/page_test.go
+++ b/internal/sync/page_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ran-codes/notion-sync/internal/notion"
 )
@@ -514,6 +515,46 @@ func TestFreezePage_CanonicalizesNotionURLInFrontmatter(t *testing.T) {
 	}
 	if strings.Contains(string(data), "https://www.notion.so/") {
 		t.Errorf("frontmatter still contains legacy notion.so URL:\n%s", data)
+	}
+}
+
+func TestFreezePage_DoesNotPinMtimeToNotionTimestamp(t *testing.T) {
+	// Pinning the file's mtime to Notion's last_edited_time defeats git's
+	// stat-cache: a same-length rewrite where Notion's timestamp also did not
+	// move forward leaves (size, mtime, inode) unchanged, so `git status`
+	// reports the file clean even though its content changed on disk. The
+	// authoritative timestamp lives in `notion-last-edited` frontmatter; the
+	// filesystem mtime must reflect actual write time so git invalidates its
+	// stat-cache. See scr.md / salurbal.org PR #580 for the silent-loss repro.
+	dir := t.TempDir()
+	pastNotionTime := "2020-01-01T00:00:00Z"
+	page := testPage("page-mtime-test", "Mtime Test", pastNotionTime)
+	client := newMockClient()
+	client.pages[page.ID] = &page
+	client.blocks[page.ID] = []notion.Block{}
+
+	// Capture wall-clock floor with margin for filesystem mtime resolution
+	// (Windows FAT/NTFS can quantize to ~1s/2s).
+	before := time.Now().Add(-2 * time.Second)
+
+	_, err := FreezePage(FreezePageOptions{
+		Client:       client,
+		NotionID:     page.ID,
+		OutputFolder: dir,
+		DatabaseID:   "db-1",
+		Page:         &page,
+	})
+	if err != nil {
+		t.Fatalf("FreezePage: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, page.ID+".md"))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.ModTime().Before(before) {
+		t.Errorf("file mtime = %s is before test start %s — looks pinned to Notion's last_edited_time (%s); this defeats git's stat-cache",
+			info.ModTime().Format(time.RFC3339Nano), before.Format(time.RFC3339Nano), pastNotionTime)
 	}
 }
 

--- a/scr.md
+++ b/scr.md
@@ -1,0 +1,101 @@
+---
+title: 'notion-sync: drop filesystem mtime pinning to Notion last_edited_time'
+status: proposal
+target_repo: https://github.com/Drexel-UHC/notion-sync
+discovered_in: salurbal.org PR #580 (2026-05-05)
+---
+
+# Bug: notion-sync silently drops content updates from `git status` on same-length edits
+
+## TL;DR
+
+After every write, notion-sync calls `os.utime()` (or equivalent) to set the local file's `mtime` backwards to match Notion's `last_edited_time`. This actively defeats git's stat-cache: when a refresh produces a content change of the same byte length AND the Notion timestamp didn't bump, `git status` reports the file as clean despite the content having changed on disk. Git workflows then commit the unchanged file, and the update is silently lost.
+
+The Notion timestamp is already preserved in the file's YAML frontmatter (`notion-last-edited:`). Duplicating it as filesystem `mtime` adds no functional value and is the sole source of this bug. **Drop the `os.utime()` call.**
+
+## The bug, demonstrated
+
+Repro: take any Notion entry, change a property to a same-length string via the API (e.g. fix a typo `Calors → Carlos`, both 6 chars), then run `notion-sync refresh --ids "<id>"`.
+
+Stat output of the refreshed file, before and after the refresh:
+
+```
+                Before refresh                       After refresh
+Size:           1770                                 1770              ← unchanged
+Modify (mtime): 2026-04-30 14:29:00.000              2026-04-30 14:29:00.000  ← pinned back
+Change (ctime): 2026-05-05 10:41:42                  2026-05-05 11:06:31      ← bumped (write happened)
+```
+
+`Change` confirms notion-sync did rewrite the file (inode metadata updated). `Modify` is identical to the second between before and after — pinned to Notion's `last_edited_time` of `2026-04-30T18:29:00 UTC`.
+
+`git status` after the refresh: empty. GitHub Desktop: zero changes shown. The corrected content is on disk; git is blind to it.
+
+Side-by-side with Notion's authoritative timestamp inside the file:
+
+```yaml
+---
+notion-last-edited: "2026-04-30T18:29:00.000Z"   ← matches the pinned mtime exactly
+---
+```
+
+## Root cause
+
+Git's stat-cache (the mechanism that makes `git status` fast on large repos) skips re-hashing a file when `(size, mtime, inode)` are all unchanged from the cached entry. By pinning `mtime` to a value that does not move forward, notion-sync ensures the stat-cache stays valid even after a content rewrite. The two conditions for silent loss:
+
+1. Notion's `last_edited_time` did not bump between syncs (e.g. URL-property clears via the Notion API do not bump it; some title-property edits also do not, observed empirically).
+2. The new content has the same byte length as the old content.
+
+Both conditions hold for any same-length API-driven correction (typo fixes, equal-length renames, certain property toggles). It is not a rare corner — it is the standard shape of "fix a typo and re-sync."
+
+The condition table:
+
+| Notion `last_edited_time` bumped? | Content size changed? | Git sees the rewrite? |
+| --------------------------------- | --------------------- | --------------------- |
+| Yes                               | Yes                   | yes                   |
+| Yes                               | No                    | yes (mtime delta)     |
+| No                                | Yes                   | yes (size delta)      |
+| **No**                            | **No**                | **no — silent loss**  |
+
+## Proposed fix
+
+Remove the `os.utime()` (or analogous timestamp-pin) call that runs after writing each file. Let the OS set `mtime` naturally to wall-clock-now at write time, like every other file-writing tool on the system.
+
+Suggested replacement comment in code:
+
+> `mtime` is intentionally left at write-time-now so git's stat-cache correctly invalidates on rewrites. Notion's authoritative timestamp is preserved in the file's `notion-last-edited` frontmatter field, which is git-tracked and human-readable.
+
+## Why removing the pin is safe
+
+The justification for the `utime` pin is presumably "preserve Notion's timestamp on disk for audit/reproducibility." That justification does not survive scrutiny:
+
+- **The timestamp is already preserved.** Every entry file carries `notion-last-edited: "<ISO-8601>"` in YAML frontmatter. That field is the durable, content-level, git-tracked, human-readable source of truth for "when did Notion last touch this entry." Filesystem `mtime` is a redundant copy.
+- **Filesystem `mtime` is a poor place for authoritative metadata.** It does not survive `cp`, many editors' save-cycles, `rsync` without `-t`, archive extraction, OS-level backups, or simply being read by a stat-aware indexer. Anything that depends on `mtime` for correctness is fragile.
+- **"Two refreshes produce byte-identical metadata" is a fake benefit.** Git tracks content, not metadata. Two refreshes already produce byte-identical _commits_ whether or not the working-tree mtimes match. There is no downstream consumer that benefits from matching mtimes that wouldn't be better served by reading `notion-last-edited` from frontmatter.
+- **The current behavior produces a silent-loss bug, observed in production** (salurbal.org PR #580: a typo correction `Juan Calors → Juan Carlos` was issued via the Notion API and `notion-sync refresh --ids` was run, but git did not detect the on-disk change; the commit captured the pre-fix state and the typo persisted to a downstream products catalog).
+
+Cost of removing the pin: none observed. Benefit: `git status` becomes trustworthy after every refresh.
+
+## Impact
+
+Anyone using notion-sync with git as the version-control / QC layer (which is the documented use case in `_etl/_notion-sync/CLAUDE.md` of the salurbal.org repo) is exposed. The exposure surface is every same-length edit on a property whose Notion `last_edited_time` does not advance — a non-trivial fraction of routine Notion operations.
+
+The downstream consequence is that automated agents running `notion-sync refresh` followed by `git add -A && git commit` will produce false-clean commits when the trigger conditions hold. Reviewers cannot catch this from the diff alone (there is no diff), only by independently verifying file content against Notion.
+
+## Where the fix likely lives
+
+Best guess based on behavior: a write-helper inside whatever module performs page-to-markdown materialization. Look for `os.utime` or a wrapper that takes a `last_edited_time` parameter alongside a path. Removing the timestamp-pin call (and the parameter, if present) is the entire change.
+
+## Workaround until upstream fix lands
+
+Force-rehash after every refresh:
+
+```bash
+notion-sync refresh "<path>" --ids "<id>" --api-key "$NOTION_API_KEY"
+# Then one of:
+git add -A                           # forces re-hash on stage (may still miss with stat-cache)
+# or, more reliably on Windows:
+find <path> -type f -exec touch {} + # bumps mtimes so git invalidates the cache
+git status                           # now reports the actual changes
+```
+
+Critical reviewers of any notion-sync PR should not trust `git status` until this is fixed upstream.


### PR DESCRIPTION
## Context

- Production silent-loss observed in salurbal.org PR #580: a typo fix issued via the Notion API + `notion-sync refresh --ids` left the corrected content on disk, but `git status` reported the file clean and the commit captured the pre-fix state.
- Root cause: `FreezePage` called `os.Chtimes` after every write to set the file's mtime backwards to Notion's `last_edited_time`. Git's stat-cache skips re-hashing when `(size, mtime, inode)` are unchanged from the cached entry, so a same-length rewrite where Notion's timestamp also did not advance is invisible to `git status`.
- Both trigger conditions hold for routine same-length API edits (typo corrections, equal-length renames, certain property toggles whose `last_edited_time` does not bump) — not a rare corner.
- The Notion timestamp is already preserved in YAML frontmatter (`notion-last-edited`), which is git-tracked and human-readable. Filesystem mtime was a redundant copy, and no internal caller reads `ModTime()` for any decision.

## Changes

- Drop the `os.Chtimes` mtime-pin block in [`internal/sync/page.go`](https://github.com/Drexel-UHC/notion-sync/blob/9e8cf937ad47e6333629f3486c1d5c1cc6eb91be/internal/sync/page.go) so the OS sets mtime to wall-clock-now at write time. Git's stat-cache then invalidates correctly on every rewrite.
- Add `TestFreezePage_DoesNotPinMtimeToNotionTimestamp` in [`internal/sync/page_test.go`](https://github.com/Drexel-UHC/notion-sync/blob/9e8cf937ad47e6333629f3486c1d5c1cc6eb91be/internal/sync/page_test.go) — freezes a page with a 2020 `last_edited_time` and asserts the resulting file's mtime is not in the past. Encodes the contract so the pin cannot silently regress.
- `notion-last-edited` frontmatter remains the authoritative source of truth for "when did Notion last touch this entry"; behavior of skip-if-unchanged checks (which read frontmatter, not mtime) is unaffected.
- Full test suite (`go test ./...`) passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)