### PR TITLE
design of v1.4 push feature

### DIFF
--- a/.context/features/push/backlog/auth-failure-run-halt.md
+++ b/.context/features/push/backlog/auth-failure-run-halt.md
@@ -1,0 +1,35 @@
+# Halt run on auth failure (401 / 403)
+
+**Status:** backlog (v1.4.1 hardening)
+**DAG node:** `n34h`
+**Tier:** edge-case protection
+
+## What
+
+Today's design treats every non-2xx push response as a per-row failure (`n34c`). But auth failures (401, 403) are run-wide — every subsequent row will fail for the same reason.
+
+Split the 4xx branch:
+
+- **Per-row 4xx (400, 422)** → continue at `n34c` (LOUD failure, queue continues).
+- **Run-wide 4xx (401, 403)** → halt at `n34h` (stop the queue, report once, exit 1).
+
+Subsequent rows skip the API call entirely; the credential, not the row, is the failure.
+
+## Why
+
+Without it: a bad token produces N noisy per-row failures instead of one clean halt. Burns API quota, pollutes the JSON summary, makes it harder to see what actually broke.
+
+## Why deferred
+
+Annoying, not destructive. The tool still terminates and surfaces the error; users can read past the noise. Land after the cell-diff core works.
+
+## Acceptance
+
+- Push run with an invalid token → first API call returns 401, run halts immediately, no further rows attempted.
+- `halted[]` contains one entry with `phase: "auth"`.
+- Exit code `1`.
+- API call count = 1 (not N).
+
+## Coupled to
+
+`halt-schema-with-phase.md` — the schema rename is required to land this.

--- a/.context/features/push/backlog/cancelled-status.md
+++ b/.context/features/push/backlog/cancelled-status.md
@@ -1,0 +1,32 @@
+# Add `status: "cancelled"` for user-declined runs
+
+**Status:** backlog (v1.4.1 polish)
+**DAG node:** `n13a` → `n41`
+**Tier:** semantic clarity
+
+## What
+
+Add a fourth value to the run-summary `status` field: `cancelled`. Emitted when the user declines at the `n13` confirmation prompt (or `--yes` is missing in non-interactive mode).
+
+```json
+{ "status": "cancelled", "pushed": [], "skippedNoOp": [], ... }
+```
+
+## Why
+
+Today, a cancelled run would emit `status: "clean"` (nothing failed, nothing halted). That's technically true but semantically misleading — agents can't distinguish "ran successfully and had nothing to push" from "user said no."
+
+## Why deferred
+
+Agents that read the JSON can already disambiguate by checking `pushed[]` length and exit code. This is a clarity polish, not a correctness fix.
+
+## Acceptance
+
+- User answers `n` at the prompt → JSON has `"status": "cancelled"`.
+- Non-interactive run without `--yes` → JSON has `"status": "cancelled"`.
+- Exit code `0` (cancellation is not a failure — see `exit-code-cancelled.md`).
+
+## Coupled to
+
+- `status-rules-explicit.md` — adds `cancelled` to the rule table.
+- `exit-code-cancelled.md` — defines exit code for the new status.

--- a/.context/features/push/backlog/exit-code-cancelled.md
+++ b/.context/features/push/backlog/exit-code-cancelled.md
@@ -1,0 +1,28 @@
+# Exit code 0 for `cancelled` status
+
+**Status:** backlog (v1.4.1 polish)
+**Tier:** behavioral spec
+**Coupled to:** `cancelled-status.md`
+
+## What
+
+Define the exit code for a cancelled run as `0` (success). Update the rule:
+
+| Status                      | Exit code |
+|-----------------------------|-----------|
+| `clean`, `cancelled`        | `0`       |
+| `partial`, `halted`         | `1`       |
+
+## Why
+
+The user explicitly chose not to push. That is the correct outcome for the command they ran. Exit `0` lets shell pipelines treat `push` as a no-op when declined, without needing to special-case the JSON.
+
+## Why deferred
+
+Only meaningful once `cancelled-status.md` lands. Ship together.
+
+## Acceptance
+
+- Decline at TTY prompt → `$? == 0`.
+- Non-interactive without `--yes` → `$? == 0`, but stderr explains how to opt in.
+- Any actual failure (`partial`, `halted`) → `$? == 1`, unchanged.

--- a/.context/features/push/backlog/halt-schema-with-phase.md
+++ b/.context/features/push/backlog/halt-schema-with-phase.md
@@ -1,0 +1,34 @@
+# Unify halt schema with `phase` field
+
+**Status:** backlog (v1.4.1 hardening)
+**Tier:** schema cleanup
+**Coupled to:** `auth-failure-run-halt.md`
+
+## What
+
+Rename the run-summary key `haltedInValidation` → `halted`, and add a `phase` field per entry indicating where the halt originated:
+
+```json
+"halted": [
+  {"file": "...", "reason": "...", "fix": "...", "phase": "validation" | "auth"}
+]
+```
+
+## Why
+
+Today's schema only models validation halts. Adding auth halts (`auth-failure-run-halt.md`) introduces a second halt source. Rather than create a parallel `haltedAtAuth` key, fold both under one `halted[]` array discriminated by `phase`.
+
+## Why deferred
+
+Pure schema refactor. Only meaningful once auth halts exist. Ship together with `auth-failure-run-halt.md` as one PR.
+
+## Acceptance
+
+- Validation halts emit `phase: "validation"`.
+- Auth halts emit `phase: "auth"`.
+- Old key `haltedInValidation` is removed (clean break — push JSON is not yet stable).
+- Status rule: `status: "halted"` iff `halted[]` is non-empty (regardless of phase).
+
+## Migration
+
+None — push command is pre-1.0 in terms of stable JSON contract; we change the schema cleanly.

--- a/.context/features/push/backlog/network-blip-validation-halt.md
+++ b/.context/features/push/backlog/network-blip-validation-halt.md
@@ -1,0 +1,24 @@
+# Halt validation when Notion is unreachable
+
+**Status:** backlog (v1.4.1 hardening)
+**DAG node:** `n21f`
+**Tier:** edge-case protection
+
+## What
+
+During phase 2 validation, the tool reads each row's `last_edited_time` from Notion to compare against `local notion-last-edited`. If that read fails (network error, timeout, 5xx with retries exhausted), the row cannot be safely classified as ready-to-push.
+
+Add a halt branch (`n21f`) that stops the run when validation can't reach Notion. Surface the affected file(s) and the network error.
+
+## Why
+
+Without it, a transient network failure during the validation window could let a row fall through to "ready" or get silently skipped — pushing against potentially stale local state.
+
+## Why deferred
+
+Real risk but narrow: only fires on network failure *during the validation read specifically*, not during the push itself. Rare in practice. The confirmation gate (v1.4.0) gives the user a chance to abort; this is belt-and-suspenders for unattended runs.
+
+## Acceptance
+
+- Simulated network failure on a single row's `last_edited_time` read → run halts, no rows pushed, that row appears in `halted[]` with `phase: "validation"`.
+- Other rows in the same batch are not pushed (validation is all-or-nothing — see `n22`).

--- a/.context/features/push/backlog/status-rules-explicit.md
+++ b/.context/features/push/backlog/status-rules-explicit.md
@@ -1,0 +1,28 @@
+# Document explicit status rules in run summary
+
+**Status:** backlog (v1.4.1 polish)
+**Tier:** documentation
+
+## What
+
+Add an explicit rule table (in DAG header and CLI docs) defining how `status` is computed from `failed[]` and `halted[]`:
+
+| Status      | Condition                                                  |
+|-------------|------------------------------------------------------------|
+| `clean`     | `failed[]` empty AND `halted[]` empty                      |
+| `partial`   | `failed[]` non-empty AND `halted[]` empty                  |
+| `halted`    | `halted[]` non-empty (validation halt OR auth halt)        |
+| `cancelled` | user declined at `n13` confirm prompt                      |
+
+## Why
+
+Implementers (and downstream agents parsing the JSON) shouldn't have to derive these rules from scattered diagram nodes. One source of truth.
+
+## Why deferred
+
+Pure docs. Rules are derivable from the existing schema. Land alongside `cancelled-status.md` so the table includes all four values.
+
+## Acceptance
+
+- Rule table appears in DAG header comments AND in user-facing docs (CLI `--help` or AGENTS.md push section).
+- Test cases cover each status rule transition explicitly.

--- a/.context/features/push/dag-v1.4.0.mmd
+++ b/.context/features/push/dag-v1.4.0.mmd
@@ -2,6 +2,12 @@
 %% ELI-PM: ideal flow after the push redesign epic lands.
 %% Four phases — user call (once), validation gate (all files first), push (per row), run summary.
 %% Numbering: phase.step[branch-letter]. Use these IDs to refer to specific substeps.
+%% --- Confirmation gate (n12b → n13 → n13a) ---
+%%   Push is the only command that writes to a shared system (Notion).
+%%   n12b shows the user the queue (file paths + count) before any API write.
+%%   n13 requires explicit consent: y/N in TTY; --yes flag non-interactive.
+%%   Decline / missing flag → n13a (cancelled, exit 0, nothing sent).
+%%   See .context/features/push/features/confirmation-gate.md
 %% --- Glossary (frontmatter fields referenced below) ---
 %%   local notion-last-edited : ISO timestamp in the local file's frontmatter
 %%                              recording Notion's last_edited_time at last sync.

--- a/.context/features/push/dag-v1.4.0.mmd
+++ b/.context/features/push/dag-v1.4.0.mmd
@@ -1,0 +1,43 @@
+%% Push workflow — v1.4.0 (proposed: cell-level diff + strict validation gate)
+%% ELI-PM: ideal flow after the push redesign epic lands.
+%% Three phases — user call (once), validation gate (all files first), push (per row, field-by-field).
+%% Numbering: phase.step[branch-letter]. Use these IDs to refer to specific substeps.
+flowchart LR
+    subgraph Call[1\. User call]
+        direction LR
+        n11([1.1 — User runs push]) --> n12[1.2 — Find which Notion database<br/>this folder syncs with]
+        n12 --> n13{1.3 — Are local edits<br/>saved/committed first?}
+        n13 -->|no| n13a[1.3a — Stop — save your<br/>local edits first]
+        n13 -->|yes| n14[1.4 — Make a list of local<br/>files to push]
+    end
+
+    subgraph Validate[2\. Validation — classify every file, then gate]
+        direction LR
+        n21{2.1 — Classify each file}
+        n21 -->|AGENTS.md| n21a[2.1a — Skip — generated guide,<br/>not a synced row]
+        n21 -->|marked deleted| n21b[2.1b — Skip — already deleted]
+        n21 -->|linked to Notion AND<br/>Notion's last-edited time<br/>== our last-sync stamp| n21c[2.1c — Mark ready to push]
+        n21 -->|linked to Notion BUT<br/>Notion's last-edited time<br/>≠ our last-sync stamp| n21d[2.1d — HALT — conflict<br/>Notion's row has changed<br/>since we last synced]
+        n21 -->|not linked to Notion<br/>and not AGENTS.md| n21e[2.1e — HALT — unexpected file<br/>doesn't belong in synced folder]
+
+        n21c --> n22{2.2 — Any halts<br/>across all files?}
+        n21d --> n22
+        n21e --> n22
+
+        n22 -->|yes| n22a[2.2a — Stop the entire run.<br/>Show every halt reason.<br/>Nothing pushed to Notion.]
+        n22 -->|no| n22b([2.2b — All files cleared — proceed])
+    end
+
+    subgraph Push[3\. Push — per row, field-by-field]
+        direction LR
+        n31[3.1 — Look at each field:<br/>did the user actually change it?] --> n32{3.2 — Did any<br/>field change?}
+        n32 -->|no| n32a[3.2a — Skip — nothing to push]
+        n32 -->|yes| n33[3.3 — Send ONLY the changed<br/>fields to Notion]
+        n33 --> n34{3.4 — Notion accepts<br/>the push?}
+        n34 -->|no| n34a[3.4a — Record error for this row.<br/>Local file unchanged.<br/>Will retry next run.]
+        n34 -->|yes| n35[3.5 — Re-query Notion for this row<br/>to read back its authoritative<br/>new last-edited time]
+        n35 --> n36[3.6 — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
+    end
+
+    Call --> Validate
+    Validate --> Push

--- a/.context/features/push/dag-v1.4.0.mmd
+++ b/.context/features/push/dag-v1.4.0.mmd
@@ -1,6 +1,6 @@
-%% Push workflow — v1.4.0 (proposed: cell-level diff + strict validation gate)
+%% Push workflow — v1.4.0 (proposed: cell-level diff + strict validation gate + structured summary)
 %% ELI-PM: ideal flow after the push redesign epic lands.
-%% Three phases — user call (once), validation gate (all files first), push (per row, field-by-field).
+%% Four phases — user call (once), validation gate (all files first), push (per row), run summary.
 %% Numbering: phase.step[branch-letter]. Use these IDs to refer to specific substeps.
 flowchart LR
     subgraph Call[1\. User call]
@@ -49,5 +49,11 @@ flowchart LR
         n35b --> n36b[3.6b — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
     end
 
+    subgraph Report[4\. Run summary — agent-readable structured output]
+        direction LR
+        n41[4.1 — Print structured summary:<br/>• run status: clean / partial / halted<br/>• pushed count<br/>• skipped no-op count<br/>• skipped non-row count AGENTS.md / deleted<br/>• failed count + per-row file path + reason + fix<br/>• halted-in-validation count + per-row file path + reason + fix<br/><br/>Agents parse this to decide next action.]
+    end
+
     Call --> Validate
     Validate --> Push
+    Push --> Report

--- a/.context/features/push/dag-v1.4.0.mmd
+++ b/.context/features/push/dag-v1.4.0.mmd
@@ -12,23 +12,30 @@
 %%   1. write a structured failure line to stderr (file path + reason + fix)
 %%   2. append entry to JSON `failed[]` (see schema below)
 %%   3. continue the row queue — do NOT abort the run
-%%   Run-level exit code: 0 if status==clean ; 1 if status==partial or halted.
+%%   Per-row only (400 / 422). 401 / 403 is run-wide → see n34h (halts run).
+%% --- Status rules (emitted at n41) ---
+%%   clean     : failed[] empty AND halted[] empty
+%%   partial   : failed[] non-empty AND halted[] empty
+%%   halted    : halted[] non-empty (n22a validation halt OR n34h auth halt)
+%%   cancelled : user declined at n13 confirm prompt
+%%   Exit code: 0 if status==clean OR cancelled ; 1 if status==partial OR halted.
 %% --- Run summary JSON schema (emitted at n41) ---
 %%   {
-%%     "status":             "clean" | "partial" | "halted",
+%%     "status":             "clean" | "partial" | "halted" | "cancelled",
 %%     "pushed":             [{"file": "...", "fields": ["title", ...]}],
 %%     "skippedNoOp":        ["..."],
 %%     "skippedNonRow":      [{"file": "...", "reason": "AGENTS.md" | "notion-deleted"}],
 %%     "failed":             [{"file": "...", "reason": "...", "fix": "..."}],
-%%     "haltedInValidation": [{"file": "...", "reason": "...", "fix": "..."}]
+%%     "halted":             [{"file": "...", "reason": "...", "fix": "...", "phase": "validation" | "auth"}]
 %%   }
 flowchart LR
     subgraph Call[1\. User call]
         direction LR
         n11([1.1 — User runs push]) --> n12[1.2 — Find which Notion database<br/>this folder syncs with]
-        n12 --> n13{1.3 — Are local edits<br/>saved to disk?}
-        n13 -->|no| n13a[1.3a — Stop — save your<br/>local edits first]
-        n13 -->|yes| n14[1.4 — Make a list of local<br/>files to push]
+        n12 --> n12b[1.2b — Build push queue from local files<br/>and show it to the user]
+        n12b --> n13{1.3 — Confirm: proceed with push?<br/>interactive: prompt y/N<br/>non-interactive: require --yes flag}
+        n13 -->|no / declined / no --yes flag| n13a[1.3a — Cancelled —<br/>nothing pushed to Notion]
+        n13 -->|yes| n14[1.4 — Hand the push queue<br/>to validation]
     end
 
     subgraph Validate[2\. Validation — classify every file, then gate]
@@ -39,10 +46,12 @@ flowchart LR
         n21 -->|linked to Notion AND<br/>Notion last_edited_time<br/>== local notion-last-edited| n21c[2.1c — Mark ready to push]
         n21 -->|linked to Notion BUT<br/>Notion last_edited_time<br/>≠ local notion-last-edited| n21d[2.1d — HALT — conflict<br/>Notion's row has changed<br/>since we last synced]
         n21 -->|not linked to Notion<br/>and not AGENTS.md| n21e[2.1e — HALT — unexpected file<br/>doesn't belong in synced folder]
+        n21 -->|could not reach Notion<br/>during last_edited_time read| n21f[2.1f — HALT — Notion unreachable<br/>during validation. Cannot classify<br/>file safely.]
 
         n21c --> n22{2.2 — Any halts<br/>across all files?}
         n21d --> n22
         n21e --> n22
+        n21f --> n22
 
         n22 -->|yes| n22a[2.2a — Stop the entire run.<br/>Show every halt reason.<br/>Nothing pushed to Notion.]
         n22 -->|no| n22b([2.2b — All files cleared — proceed])
@@ -61,7 +70,8 @@ flowchart LR
         n35a --> n36a[3.6a — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
 
         n34 -->|no, transient<br/>429 / 5xx / network| n34a[3.4a — Transient failure detected]
-        n34 -->|no, permanent<br/>4xx auth / schema / validation| n34c[3.4c — LOUD failure:<br/>show file path + Notion's error +<br/>what user/agent must fix<br/>before the next push run]
+        n34 -->|no, per-row 4xx<br/>schema / validation<br/>400 or 422| n34c[3.4c — LOUD failure:<br/>show file path + Notion's error +<br/>what user/agent must fix<br/>before the next push run]
+        n34 -->|no, run-wide 4xx<br/>auth — 401 or 403| n34h[3.4h — HALT run — auth failed.<br/>Show error + fix.<br/>Subsequent rows skip the API call;<br/>the credential, not the row,<br/>is the failure.]
         n34a --> n34b{3.4b — Retry 2 more times<br/>with delays<br/>e.g. 5s then 15s}
         n34b -->|still failing| n34c
         n34b -->|succeeds on retry| n34f{3.4f — Verify pushed fields<br/>were stored correctly<br/>same check as 3.4d}
@@ -80,7 +90,7 @@ flowchart LR
 
     subgraph Report[4\. Run summary — agent-readable structured output]
         direction LR
-        n41[4.1 — Emit run summary as JSON<br/>per schema in header comment.<br/>Status: clean / partial / halted.<br/>Per-row entries for pushed,<br/>skipped no-op, skipped non-row,<br/>failed, halted-in-validation.<br/><br/>Agents parse this to decide next action.]
+        n41[4.1 — Emit run summary as JSON<br/>per schema in header comment.<br/>Status: clean / partial / halted / cancelled<br/>per status rules in header.<br/>Per-row entries for pushed,<br/>skipped no-op, skipped non-row,<br/>failed, halted (validation or auth).<br/><br/>Agents parse this to decide next action.]
     end
 
     %% Phase handoffs (explicit node-to-node)
@@ -93,3 +103,4 @@ flowchart LR
     n21a --> n41
     n21b --> n41
     n22a --> n41
+    n34h --> n41

--- a/.context/features/push/dag-v1.4.0.mmd
+++ b/.context/features/push/dag-v1.4.0.mmd
@@ -2,11 +2,34 @@
 %% ELI-PM: ideal flow after the push redesign epic lands.
 %% Four phases — user call (once), validation gate (all files first), push (per row), run summary.
 %% Numbering: phase.step[branch-letter]. Use these IDs to refer to specific substeps.
+%%
+%% ─── Glossary (frontmatter fields referenced below) ──────────────────────────
+%%   local notion-last-edited : ISO timestamp in the local file's frontmatter
+%%                              recording Notion's last_edited_time at last sync.
+%%   notion-deleted: true     : frontmatter flag marking a soft-deleted row.
+%%   linked to Notion         : local file has a `notion-id` in frontmatter.
+%%   AGENTS.md                : generated downstream-agent guide; never a Notion row.
+%%
+%% ─── LOUD failure semantics (used at n34c, n34e, n34g) ───────────────────────
+%%   1. write a structured failure line to stderr (file path + reason + fix)
+%%   2. append entry to JSON `failed[]` (see schema below)
+%%   3. continue the row queue — do NOT abort the run
+%%   Run-level exit code: 0 if status==clean ; 1 if status==partial or halted.
+%%
+%% ─── Run summary JSON schema (emitted at n41) ────────────────────────────────
+%%   {
+%%     "status":             "clean" | "partial" | "halted",
+%%     "pushed":             [{"file": "...", "fields": ["title", ...]}],
+%%     "skippedNoOp":        ["..."],
+%%     "skippedNonRow":      [{"file": "...", "reason": "AGENTS.md" | "notion-deleted"}],
+%%     "failed":             [{"file": "...", "reason": "...", "fix": "..."}],
+%%     "haltedInValidation": [{"file": "...", "reason": "...", "fix": "..."}]
+%%   }
 flowchart LR
     subgraph Call[1\. User call]
         direction LR
         n11([1.1 — User runs push]) --> n12[1.2 — Find which Notion database<br/>this folder syncs with]
-        n12 --> n13{1.3 — Are local edits<br/>saved/committed first?}
+        n12 --> n13{1.3 — Are local edits<br/>saved to disk?}
         n13 -->|no| n13a[1.3a — Stop — save your<br/>local edits first]
         n13 -->|yes| n14[1.4 — Make a list of local<br/>files to push]
     end
@@ -15,9 +38,9 @@ flowchart LR
         direction LR
         n21{2.1 — Classify each file}
         n21 -->|AGENTS.md| n21a[2.1a — Skip — generated guide,<br/>not a synced row]
-        n21 -->|marked deleted| n21b[2.1b — Skip — already deleted]
-        n21 -->|linked to Notion AND<br/>Notion's last-edited time<br/>== our last-sync stamp| n21c[2.1c — Mark ready to push]
-        n21 -->|linked to Notion BUT<br/>Notion's last-edited time<br/>≠ our last-sync stamp| n21d[2.1d — HALT — conflict<br/>Notion's row has changed<br/>since we last synced]
+        n21 -->|notion-deleted: true| n21b[2.1b — Skip — already soft-deleted]
+        n21 -->|linked to Notion AND<br/>Notion last_edited_time<br/>== local notion-last-edited| n21c[2.1c — Mark ready to push]
+        n21 -->|linked to Notion BUT<br/>Notion last_edited_time<br/>≠ local notion-last-edited| n21d[2.1d — HALT — conflict<br/>Notion's row has changed<br/>since we last synced]
         n21 -->|not linked to Notion<br/>and not AGENTS.md| n21e[2.1e — HALT — unexpected file<br/>doesn't belong in synced folder]
 
         n21c --> n22{2.2 — Any halts<br/>across all files?}
@@ -36,24 +59,40 @@ flowchart LR
         n33 --> n34{3.4 — Notion accepts<br/>the push?}
 
         n34 -->|yes| n34d{3.4d — Verify pushed fields<br/>were stored correctly<br/>Notion's response value ==<br/>what we sent re-encoded}
-        n34d -->|mismatch on a pushed field| n34e[3.4e — LOUD failure message:<br/>Notion stored value differently<br/>than we sent. Show field name +<br/>sent vs stored. Investigate before<br/>next push.]
+        n34d -->|mismatch on a pushed field| n34e[3.4e — LOUD failure:<br/>Notion stored value differently<br/>than we sent. Show field name +<br/>sent vs stored. Investigate before<br/>next push.]
         n34d -->|all pushed fields match| n35a[3.5a — Re-query Notion for this row<br/>to read back its authoritative<br/>new last-edited time]
         n35a --> n36a[3.6a — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
 
-        n34 -->|no| n34a[3.4a — First failure detected]
+        n34 -->|no, transient<br/>429 / 5xx / network| n34a[3.4a — Transient failure detected]
+        n34 -->|no, permanent<br/>4xx auth / schema / validation| n34c[3.4c — LOUD failure:<br/>show file path + Notion's error +<br/>what user/agent must fix<br/>before the next push run]
         n34a --> n34b{3.4b — Retry 2 more times<br/>with delays<br/>e.g. 5s then 15s}
-        n34b -->|still failing| n34c[3.4c — LOUD failure message:<br/>show file path + Notion's error +<br/>what user/agent must fix<br/>before the next push run]
+        n34b -->|still failing| n34c
         n34b -->|succeeds on retry| n34f{3.4f — Verify pushed fields<br/>were stored correctly<br/>same check as 3.4d}
-        n34f -->|mismatch on a pushed field| n34g[3.4g — LOUD failure message:<br/>Notion stored value differently<br/>than we sent on retry. Show field +<br/>sent vs stored. Investigate before<br/>next push.]
+        n34f -->|mismatch on a pushed field| n34g[3.4g — LOUD failure:<br/>Notion stored value differently<br/>than we sent on retry. Show field +<br/>sent vs stored. Investigate before<br/>next push.]
         n34f -->|all pushed fields match| n35b[3.5b — Re-query Notion for this row<br/>to read back its authoritative<br/>new last-edited time]
         n35b --> n36b[3.6b — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
+
+        n32a --> n37{3.7 — More rows<br/>in queue?}
+        n34c --> n37
+        n34e --> n37
+        n34g --> n37
+        n36a --> n37
+        n36b --> n37
+        n37 -->|yes| n31
     end
 
     subgraph Report[4\. Run summary — agent-readable structured output]
         direction LR
-        n41[4.1 — Print structured summary:<br/>• run status: clean / partial / halted<br/>• pushed count<br/>• skipped no-op count<br/>• skipped non-row count AGENTS.md / deleted<br/>• failed count + per-row file path + reason + fix<br/>• halted-in-validation count + per-row file path + reason + fix<br/><br/>Agents parse this to decide next action.]
+        n41[4.1 — Emit run summary as JSON<br/>per schema in header comment.<br/>Status: clean / partial / halted.<br/>Per-row entries for pushed,<br/>skipped no-op, skipped non-row,<br/>failed, halted-in-validation.<br/><br/>Agents parse this to decide next action.]
     end
 
-    Call --> Validate
-    Validate --> Push
-    Push --> Report
+    %% ─── Phase handoffs (explicit node-to-node) ─────────────────────────────
+    n14 --> n21
+    n22b --> n31
+    n37 -->|no| n41
+
+    %% ─── Universal report sink (every terminal reaches n41) ─────────────────
+    n13a --> n41
+    n21a --> n41
+    n21b --> n41
+    n22a --> n41

--- a/.context/features/push/dag-v1.4.0.mmd
+++ b/.context/features/push/dag-v1.4.0.mmd
@@ -2,21 +2,18 @@
 %% ELI-PM: ideal flow after the push redesign epic lands.
 %% Four phases — user call (once), validation gate (all files first), push (per row), run summary.
 %% Numbering: phase.step[branch-letter]. Use these IDs to refer to specific substeps.
-%%
-%% ─── Glossary (frontmatter fields referenced below) ──────────────────────────
+%% --- Glossary (frontmatter fields referenced below) ---
 %%   local notion-last-edited : ISO timestamp in the local file's frontmatter
 %%                              recording Notion's last_edited_time at last sync.
 %%   notion-deleted: true     : frontmatter flag marking a soft-deleted row.
 %%   linked to Notion         : local file has a `notion-id` in frontmatter.
 %%   AGENTS.md                : generated downstream-agent guide; never a Notion row.
-%%
-%% ─── LOUD failure semantics (used at n34c, n34e, n34g) ───────────────────────
+%% --- LOUD failure semantics (used at n34c, n34e, n34g) ---
 %%   1. write a structured failure line to stderr (file path + reason + fix)
 %%   2. append entry to JSON `failed[]` (see schema below)
 %%   3. continue the row queue — do NOT abort the run
 %%   Run-level exit code: 0 if status==clean ; 1 if status==partial or halted.
-%%
-%% ─── Run summary JSON schema (emitted at n41) ────────────────────────────────
+%% --- Run summary JSON schema (emitted at n41) ---
 %%   {
 %%     "status":             "clean" | "partial" | "halted",
 %%     "pushed":             [{"file": "...", "fields": ["title", ...]}],
@@ -86,12 +83,12 @@ flowchart LR
         n41[4.1 — Emit run summary as JSON<br/>per schema in header comment.<br/>Status: clean / partial / halted.<br/>Per-row entries for pushed,<br/>skipped no-op, skipped non-row,<br/>failed, halted-in-validation.<br/><br/>Agents parse this to decide next action.]
     end
 
-    %% ─── Phase handoffs (explicit node-to-node) ─────────────────────────────
+    %% Phase handoffs (explicit node-to-node)
     n14 --> n21
     n22b --> n31
     n37 -->|no| n41
 
-    %% ─── Universal report sink (every terminal reaches n41) ─────────────────
+    %% Universal report sink (every terminal reaches n41)
     n13a --> n41
     n21a --> n41
     n21b --> n41

--- a/.context/features/push/dag-v1.4.0.mmd
+++ b/.context/features/push/dag-v1.4.0.mmd
@@ -34,9 +34,19 @@ flowchart LR
         n32 -->|no| n32a[3.2a — Skip — nothing to push]
         n32 -->|yes| n33[3.3 — Send ONLY the changed<br/>fields to Notion]
         n33 --> n34{3.4 — Notion accepts<br/>the push?}
-        n34 -->|no| n34a[3.4a — Record error for this row.<br/>Local file unchanged.<br/>Will retry next run.]
-        n34 -->|yes| n35[3.5 — Re-query Notion for this row<br/>to read back its authoritative<br/>new last-edited time]
-        n35 --> n36[3.6 — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
+
+        n34 -->|yes| n34d{3.4d — Verify pushed fields<br/>were stored correctly<br/>Notion's response value ==<br/>what we sent re-encoded}
+        n34d -->|mismatch on a pushed field| n34e[3.4e — LOUD failure message:<br/>Notion stored value differently<br/>than we sent. Show field name +<br/>sent vs stored. Investigate before<br/>next push.]
+        n34d -->|all pushed fields match| n35a[3.5a — Re-query Notion for this row<br/>to read back its authoritative<br/>new last-edited time]
+        n35a --> n36a[3.6a — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
+
+        n34 -->|no| n34a[3.4a — First failure detected]
+        n34a --> n34b{3.4b — Retry 2 more times<br/>with delays<br/>e.g. 5s then 15s}
+        n34b -->|still failing| n34c[3.4c — LOUD failure message:<br/>show file path + Notion's error +<br/>what user/agent must fix<br/>before the next push run]
+        n34b -->|succeeds on retry| n34f{3.4f — Verify pushed fields<br/>were stored correctly<br/>same check as 3.4d}
+        n34f -->|mismatch on a pushed field| n34g[3.4g — LOUD failure message:<br/>Notion stored value differently<br/>than we sent on retry. Show field +<br/>sent vs stored. Investigate before<br/>next push.]
+        n34f -->|all pushed fields match| n35b[3.5b — Re-query Notion for this row<br/>to read back its authoritative<br/>new last-edited time]
+        n35b --> n36b[3.6b — Write that exact timestamp<br/>into the local file.<br/>Local stamp == Notion now.]
     end
 
     Call --> Validate

--- a/.context/features/push/features/confirmation-gate.md
+++ b/.context/features/push/features/confirmation-gate.md
@@ -1,0 +1,54 @@
+# Confirmation gate before push
+
+**Status:** proposed for v1.4.0
+**Target release:** v1.4.0 (ship-blocker)
+**DAG nodes:** `n12b` → `n13` → `n13a`
+**Source:** pass-2 critical review (commit `1bcc903`)
+
+## What
+
+Before sending any write to Notion, `push` must:
+
+1. **Show the queue** — list every local file it plans to push (paths + count).
+2. **Require explicit consent** before any API write:
+   - Interactive (TTY): `y/N` prompt, default `N`.
+   - Non-interactive (CI, agent, scripted): require `--yes` flag.
+3. If declined, or `--yes` missing in non-interactive mode → end with status `cancelled`, exit `0`, send nothing to Notion.
+
+## Why
+
+`push` is the **only** command in notion-sync that writes to a shared system. Every other command (`import`, `refresh`, `list`) is local-only and recoverable via `git`.
+
+An accidental `push`:
+
+- Modifies rows for every human and integration in the workspace.
+- Bumps `last_edited_time`, firing automations, webhooks, downstream syncs.
+- Has no undo — Notion has no "revert this push" button.
+
+The gate is the only mechanism that prevents the tool from doing the wrong thing in the first place. Everything else in the v1.4.0 push redesign is about reporting errors *after* they happen.
+
+## Acceptance
+
+- Running `push` in a TTY and answering `n` (or pressing Enter on default) → nothing sent to Notion, status `cancelled`, exit `0`.
+- Running `push` non-interactively without `--yes` → nothing sent, status `cancelled`, exit `0`. Stderr explains how to opt in.
+- Running `push` non-interactively with `--yes` → queue executes as planned.
+- Preview output lists every file in the queue *before* the prompt fires.
+- Cancelling at the prompt does **not** count as a failure (exit 0, distinct from `partial`/`halted`).
+
+## Out of scope
+
+- **Per-field diff in the preview.** Depends on the cell-level diff (WS2 in the epic). MVP preview shows file paths and a count only.
+- **`--dry-run` mode.** Separate concern. This is a consent gate, not a planning tool.
+- **Interactive selection** (e.g. uncheck rows from the queue). Not in v1.4.0.
+
+## Implementation notes
+
+- TTY detection: standard `isatty` on stdin/stderr.
+- `--yes` flag is the audit trail for unattended runs — present in CI config = someone deliberately allowed automated pushes from this pipeline.
+- The preview is emitted to stderr so it doesn't pollute the JSON summary at `n41`.
+
+## References
+
+- Epic: issue #55
+- DAG: `.context/features/push/dag-v1.4.0.mmd` nodes `n12b`, `n13`, `n13a`
+- Triage: pass-2 review classified this as the only ship-blocker; everything else is hardening (see `.context/features/push/backlog/`)

--- a/.context/scr/2026-05-05 - push feature anaylsis/legacy-issue.md
+++ b/.context/scr/2026-05-05 - push feature anaylsis/legacy-issue.md
@@ -1,3 +1,9 @@
+# Legacy issue body — snapshot before reframing
+
+Snapshot of issue #55's body prior to the 2026-05-06 reframe. The current issue body is now just a short epic header pointing at three sub-actions (document the flow, implement cell-level push, verify formatting survives). The detailed workstream / SOT / equality-semantics analysis below is preserved here for reference only.
+
+---
+
 # Epic: Push feature — design re-evaluation
 
 **Status:** scratch / pre-issue

--- a/.context/scr/2026-05-05 - push feature anaylsis/new-issue-body.md
+++ b/.context/scr/2026-05-05 - push feature anaylsis/new-issue-body.md
@@ -1,0 +1,13 @@
+# Epic: Push feature — design re-evaluation
+
+**Status:** epic
+**Date:** 2026-05-05
+**Trigger:** issue #55 (rich_text/title flattening) surfaced a deeper design gap — push was added without an explicit conflict / source-of-truth model, and operates at row granularity when the API supports cell granularity.
+
+This epic covers three things:
+
+1. **Document how push works today.** A flow diagram of end-to-end push behavior so the design is legible before we change it.
+2. **Make push only send fields the user actually changed.** Today push re-sends every editable field on every row, even untouched ones. Diff each field against Notion's current value and only send genuine local edits.
+3. **Verify rich-text/title formatting survives.** The original #55 symptom — bold/links on unedited fields get flattened on push — used as the acceptance test that #2 actually fixed the problem.
+
+Why it matters: today's "send everything" shortcut bumps `last_edited_time` on every push (firing automations, polluting edit history), strips formatting on fields nobody touched, and burns API quota on no-ops. All three fall out of one architectural shape — push doesn't diff before sending. Fix the diff, fix all three.


### PR DESCRIPTION
## Context
- First action item from issue #55: document the push design before implementation.
- Captures the proposed v1.4.0 push redesign so the flow is legible before any code changes.

## Changes
- Add [`.context/features/push/dag-v1.4.0.mmd`](https://github.com/Drexel-UHC/notion-sync/blob/fa09a0650bd75cc3aeb52112f4b0fd203482bfe0/.context/features/push/dag-v1.4.0.mmd) — Mermaid DAG of the four-phase flow: user call → validation gate → cell-level push → agent-readable summary.

ref #55

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)