### PR TITLE
Notino-sycn puhs v1.4 pahse 1 delveopement -   confirmation gate before any Notion write

### DIFF
--- a/.claude/reference/test-databases/README.md
+++ b/.claude/reference/test-databases/README.md
@@ -8,11 +8,13 @@ Reference databases used for integration testing of `notion-sync`.
 |------|------|-------------|--------|
 | Complex (Property & Block Coverage) | Single data source | `2fe57008-e885-8003-b1f3-cc05981dc6b0` | [single-data-source/](single-data-source/) |
 | Double Data Source | Multi data source (2) | `c9aa5ab2-b470-429c-ba9c-86c853782bb2` | [double-data-source/](double-data-source/) |
+| Push E2E Fixtures (`notion-sync-test-database-push`) | Single data source | `35957008-e885-80c5-9e34-f4191fd83907` | [push-e2e/](push-e2e/) |
 
 ## Links
 
 - **Complex:** https://www.notion.so/2fe57008e8858003b1f3cc05981dc6b0
 - **Double Data Source:** https://www.notion.so/c9aa5ab2b470429cba9c86c853782bb2
+- **Push E2E:** https://www.notion.so/35957008e88580c59e34f4191fd83907
 
 ## What They Test
 
@@ -30,3 +32,12 @@ Reference databases used for integration testing of `notion-sync`.
 - Top-level refresh delegating to sub-source folders
 - Edge cases: null properties, special chars in titles, unicode, long filenames, duplicate names across sources, negative numbers, empty content
 - 2 data sources, 13 pages total (7 Projects + 6 Clients)
+
+### Push E2E Fixtures
+- Dedicated DB for the v1.4.0 `push` redesign — used by `/test-push`
+- 7 pages, schema is a subset of the Complex DB (only push-writable types)
+- Phase 1: confirmation gate (cancel / proceed / dry-run)
+- Phase 2: validation halts (multi-conflict aggregation, soft-delete skip, null edges)
+- Phase 3: cell-level diff + rich-text formatting preservation (the original #55 symptom)
+- Phase 4: run summary JSON across every status enum
+- See [push-e2e/setup.md](push-e2e/setup.md) for the full protocol, page IDs, and "do not edit" fixture conventions.

--- a/.claude/reference/test-databases/push-e2e/setup.md
+++ b/.claude/reference/test-databases/push-e2e/setup.md
@@ -1,0 +1,311 @@
+# Test Database: Push E2E Fixtures
+
+**Status:** ✅ Created
+**Name:** `notion-sync-test-database-push`
+**URL:** https://www.notion.so/35957008e88580c59e34f4191fd83907
+**Database ID:** `35957008-e885-80c5-9e34-f4191fd83907`
+**Data Source ID:** `35957008-e885-8068-9080-000b89086bb3`
+
+Reproducible protocol for creating a Notion database dedicated to E2E testing of the v1.4.0 `push` redesign across all four phases. Used by `/test-push`.
+
+## Created fixtures (page IDs)
+
+| # | Name | Page ID | URL |
+|---|---|---|---|
+| 1 | Push: Canary | `35957008-e885-813a-886b-cbb6dd7c1598` | https://www.notion.so/35957008e885813a886bcbb6dd7c1598 |
+| 2 | Push: Conflict Subject A | `35957008-e885-811d-ae4b-eb73607cc037` | https://www.notion.so/35957008e885811dae4beb73607cc037 |
+| 3 | Push: Conflict Subject B | `35957008-e885-8141-9e44-ef7c58e4a487` | https://www.notion.so/35957008e88581419e44ef7c58e4a487 |
+| 4 | Push: Formatting Fixture | `35957008-e885-8192-ab0f-c75e6a011b10` | https://www.notion.so/35957008e8858192ab0fc75e6a011b10 |
+| 5 | Push: Cell-Level Test | `35957008-e885-815e-8e73-ea79c22f96d4` | https://www.notion.so/35957008e885815e8e73ea79c22f96d4 |
+| 6 | Push: Soft Deleted | `35957008-e885-81e0-83c1-ff9fb4dbfda5` | https://www.notion.so/35957008e88581e083c1ff9fb4dbfda5 |
+| 7 | Push: Null Edges | `35957008-e885-814f-9f19-c401d454b08d` | https://www.notion.so/35957008e885814f9f19c401d454b08d |
+
+Relations wired: Page 1 → Page 4, Page 5 → Page 4 (both `Related` arrays contain Page 4's URL).
+
+## Why a separate DB
+
+The single-data-source DB (`single-data-source/setup.md`) is shared with `/test-single-datasource-db` and exercises **import / refresh** — its rich-text content is not pinned for push verification. The v1.4.0 push redesign needs:
+
+- **Phase 2** deliberately mutates pages into broken (stale-timestamp) states. Sharing a DB risks leaving rows in conflict states between runs.
+- **Phase 3** verifies that **rich-text formatting on un-edited cells survives a push** (the original #55 symptom). This requires hand-curated, **stable** rich-text fixtures that no other skill ever pushes to.
+
+Sharing breaks both. A dedicated DB is cheaper than retrofitting isolation later.
+
+## Phase coverage
+
+This DB is sized to cover all four phases of the v1.4.0 push redesign without renumbering or re-curating between phases.
+
+| Phase | DAG nodes | Fixtures used | New rows needed? |
+|---|---|---|---|
+| 1: Confirmation gate | n12b → n13a | Page 1 (Canary) | No — covered today |
+| 2: Validation halts | n21 → n22b | Pages 2, 3, 6, 7 | No |
+| 3: Cell-level diff | n31 → n37 | Pages 4 (formatting), 5 (cell-level), 7 (nulls) | No |
+| 4: Run summary JSON | n41 | All pages — exercises every status enum | No |
+
+Total: **7 pages**, 1 schema, 1 self-relation.
+
+---
+
+## Prerequisites
+
+- Notion MCP tools available (`notion-create-database`, `notion-update-data-source`, `notion-create-pages`, `notion-update-page`, `notion-fetch`)
+- A parent page in the user's workspace where the DB can live
+- The Notion integration that owns `NOTION_SYNC_API_KEY` must be granted access to this DB
+
+---
+
+## Step 1: Create the database
+
+```
+Database name: notion-sync-test-database-push
+```
+
+Place under whichever parent page the user designates. Capture the returned `database_id` and `data_source_id` — fill them into the `Database ID` line at the top of this doc and into the `/test-push` skill's Step 2 import command.
+
+## Step 2: Add property columns
+
+Use `update-data-source` to add the schema in a single call. Schema is a **subset** of the single-source DB — only types `push` actually writes (no `people`, `files`, `formula`, `rollup`, etc.).
+
+| Property Name | Type | Config |
+|---|---|---|
+| Name | title | (default) |
+| Description | rich_text | `{}` |
+| Score | number | `{"format": "number"}` |
+| Category | select | Options: Research (blue), Engineering (green), Design (purple), Marketing (orange) |
+| Tags | multi_select | Options: alpha (red), beta (blue), gamma (green), delta (gray) |
+| Due Date | date | `{}` |
+| Approved | checkbox | `{}` |
+| Website | url | `{}` |
+| Contact Email | email | `{}` |
+| Phone | phone_number | `{}` |
+| Related | relation | Self-relation: `{"data_source_id": "<this db's data_source_id>", "type": "single_property", "single_property": {}}` |
+
+**Deliberately omitted** (push doesn't write these):
+- `people`, `files`, `created_time`, `last_edited_time`, `created_by`, `last_edited_by`
+- `formula`, `rollup`, `button`, `unique_id`, `verification`, `status`
+
+## Step 3: Create the 7 fixture pages
+
+Use `create-pages` with `parent: {"data_source_id": "<data_source_id>"}`. **All 7 pages in a single API call** so they share a creation timestamp.
+
+### Page 1 — "Push: Canary" — phase 1 gate
+
+**Purpose:** Single-page fixture for confirmation-gate cancel/proceed/dry-run paths. The skill's `Score` canary lives here.
+
+```
+Name:          Push: Canary
+Description:   Phase 1 fixture — confirmation gate cancel/proceed/dry-run.
+Score:         100
+Category:      Research
+Tags:          [alpha]
+Due Date:      2026-06-01
+Approved:      true
+Website:       https://example.com/canary
+Contact Email: canary@example.com
+Phone:         +1-555-0001
+```
+
+**Body:** single paragraph: `Phase 1 canary fixture. Do not edit body — push never touches block content.`
+
+### Page 2 — "Push: Conflict Subject A" — phase 2 halt aggregation
+
+**Purpose:** Paired with Page 3. Used to verify multi-conflict aggregation halts the entire run (n22a). Its `notion-last-edited` will be staled locally to trigger n21d.
+
+```
+Name:          Push: Conflict Subject A
+Description:   Phase 2 halt fixture A. Stale-timestamped during tests.
+Score:         200
+Category:      Engineering
+Tags:          [beta]
+Due Date:      2026-07-01
+Approved:      false
+Website:       https://example.com/halt-a
+Contact Email: halt-a@example.com
+Phone:         +1-555-0002
+```
+
+**Body:** single paragraph: `Phase 2 halt fixture A.`
+
+### Page 3 — "Push: Conflict Subject B" — phase 2 halt aggregation
+
+**Purpose:** Second halt subject. With Page 2, exercises "two halts → run-level halt with both reasons listed."
+
+```
+Name:          Push: Conflict Subject B
+Description:   Phase 2 halt fixture B. Stale-timestamped during tests.
+Score:         300
+Category:      Design
+Tags:          [gamma]
+Due Date:      2026-07-15
+Approved:      true
+Website:       https://example.com/halt-b
+Contact Email: halt-b@example.com
+Phone:         +1-555-0003
+```
+
+**Body:** single paragraph: `Phase 2 halt fixture B.`
+
+### Page 4 — "Push: Formatting Fixture" — phase 3 critical
+
+**🚨 CRITICAL — DO NOT EDIT THIS PAGE'S TITLE OR DESCRIPTION FROM ANY SKILL.**
+
+**Purpose:** Pin the original-#55 symptom. Has rich-text formatting in **both `Name` (title)** and **`Description` (rich_text)**. Phase 3 tests verify that pushing edits to **other fields** (Score, Category) does NOT clobber this formatting.
+
+Created via Notion-flavored Markdown (the MCP tool parses these into rich-text annotations on save):
+
+```
+Name (markdown source — parses to rich text on save):
+    Push: **Formatting** *Fixture* [anchor](https://example.com/anchor)
+
+Description (markdown source — parses to rich text on save):
+    **Bold here.** *Italic here.* `inline code` [link to xkcd](https://xkcd.com) ~~struck~~ Trailing plain text. $E = mc^2$
+
+Score:         400
+Category:      Marketing
+Tags:          [alpha, delta]
+Due Date:      2026-08-01
+Approved:      true
+Website:       https://example.com/fmt
+Contact Email: fmt@example.com
+Phone:         +1-555-0004
+```
+
+**Annotations stored on Notion (verified via fetch):** bold on `Formatting`, italic on `Fixture`, link on `anchor` → `https://example.com/anchor` (Name); bold on `Bold here.`, italic on `Italic here.`, inline code on `inline code`, link on `link to xkcd` → `https://xkcd.com`, strikethrough on `struck`, inline equation `E = mc^2` (Description).
+
+**Body:** single paragraph: `Phase 3 formatting fixture. Title and Description have intentional rich-text formatting that other-field pushes must preserve.`
+
+**Convention:** the `/test-push` skill's phase-3 section reads this page's `Name` and `Description` rich-text payload from Notion via `notion-fetch` BEFORE editing other fields, snapshots the structured payload (annotations array), pushes a `Score` change, then re-fetches and **diffs the structured payload** to verify zero drift in formatting. If a future fix breaks this, the test fails loudly.
+
+### Page 5 — "Push: Cell-Level Test" — phase 3 single-cell diff
+
+**Purpose:** Multiple non-formatting fields populated. Phase 3 picks ONE field to edit, pushes, and verifies only that field hit Notion's wire (others not in payload).
+
+```
+Name:          Push: Cell-Level Test
+Description:   Phase 3 fixture — single-cell push verification.
+Score:         500
+Category:      Research
+Tags:          [beta, gamma]
+Due Date:      2026-09-01
+Approved:      false
+Website:       https://example.com/cell
+Contact Email: cell@example.com
+Phone:         +1-555-0005
+```
+
+**Body:** single paragraph: `Phase 3 cell-level fixture.`
+
+### Page 6 — "Push: Soft Deleted" — phase 2 skip path
+
+**Purpose:** Verify `notion-deleted: true` rows are skipped (n21b). Note: the soft-delete is a **frontmatter flag in the synced .md**, not a Notion-side state. This page lives normally on Notion; the test marks the local file's frontmatter.
+
+```
+Name:          Push: Soft Deleted
+Description:   Phase 2 fixture — soft-delete skip path.
+Score:         600
+Category:      Engineering
+Tags:          [delta]
+Due Date:      2026-10-01
+Approved:      false
+Website:       https://example.com/deleted
+Contact Email: deleted@example.com
+Phone:         +1-555-0006
+```
+
+**Body:** single paragraph: `Phase 2 soft-delete fixture.`
+
+### Page 7 — "Push: Null Edges" — phase 2/3/4 null handling
+
+**Purpose:** Edge case for null/empty property handling on push. Validates that null `Due Date`, empty `Website`, etc. round-trip without producing spurious diffs or push errors.
+
+```
+Name:          Push: Null Edges
+Description:   Phase 2/3 fixture — null and empty property handling.
+Score:         (null)
+Category:      (null)
+Tags:          []
+Due Date:      (null)
+Approved:      false
+Website:       (null)
+Contact Email: (null)
+Phone:         (null)
+```
+
+**Body:** single paragraph: `Phase 2/3 null-edges fixture.`
+
+---
+
+## Step 4: Wire up relations
+
+After all 7 pages exist, use `update-page` to set `Related` on a couple of pages so the relation property type has coverage:
+
+- Page 1 (Canary) → relates to Page 4 (Formatting Fixture)
+- Page 5 (Cell-Level) → relates to Page 4 (Formatting Fixture)
+
+Phase 3 will use this to verify that pushing an unrelated field on Page 5 does NOT clobber the relation array. (Push currently sends every property — known issue. Phase 3's whole point.)
+
+---
+
+## Property coverage matrix
+
+| Property Type | Populated | Null/Empty | Notes |
+|---|---|---|---|
+| title | All 7 | – | Page 4 has rich-text formatting in title |
+| rich_text | 7 of 7 | – | Page 4 has heavy formatting; others plain |
+| number | 6 of 7 | Page 7 null | |
+| select | 6 of 7 | Page 7 null | All 4 options used at least once |
+| multi_select | 6 of 7 | Page 7 empty `[]` | All 4 options used |
+| date | 6 of 7 | Page 7 null | |
+| checkbox | All 7 | – | true and false both represented |
+| url | 6 of 7 | Page 7 null | |
+| email | 6 of 7 | Page 7 null | |
+| phone_number | 6 of 7 | Page 7 null | |
+| relation | 2 of 7 | 5 empty | Page 1 → 4; Page 5 → 4 |
+
+## Per-phase fixture map
+
+| Fixture | Phase 1 | Phase 2 | Phase 3 | Phase 4 |
+|---|:---:|:---:|:---:|:---:|
+| Page 1 — Canary | ✅ primary | – | – | ✅ pushed/no-op |
+| Page 2 — Conflict A | – | ✅ halt subject | – | ✅ halted |
+| Page 3 — Conflict B | – | ✅ halt subject | – | ✅ halted |
+| Page 4 — Formatting | – | – | ✅ **untouched fixture** | ✅ skippedNoOp |
+| Page 5 — Cell-Level | – | – | ✅ primary | ✅ pushed |
+| Page 6 — Soft Deleted | – | ✅ skip path | – | ✅ skippedNonRow |
+| Page 7 — Null Edges | – | ✅ partial | ✅ null roundtrip | ✅ pushed/no-op |
+
+---
+
+## Naming and identification convention
+
+- Every page name starts with `Push:` so they're trivially distinguishable from any other DB or workspace content.
+- Database name is `notion-sync push e2e fixtures` — long but unambiguous.
+- All fake email addresses use `@example.com` (RFC 2606 reserved domain — never resolves).
+- All phone numbers use the `+1-555-000N` test pattern (NANP test prefix — never dials).
+
+## Things to NEVER do (regression hazards)
+
+1. **Never edit Page 4 directly.** Its rich-text annotations are the phase-3 fixture. Any test that *intentionally* edits Page 4's title/description must also restore the exact original annotation payload. Non-trivial — better not to touch it.
+2. **Never invent new `select` or `multi_select` options.** Notion auto-creates them on push and never garbage-collects. Stick to the 4+4 options spec'd above.
+3. **Never push with `--force` against this DB unless the test specifically requires it.** Force masks conflict bugs; phase 2 needs to actually trigger conflicts to test halts.
+4. **Don't use any of these pages from `/test-single-datasource-db` or any other skill.** This DB is `/test-push`-only. Add a comment to other skills referencing this constraint if needed.
+
+---
+
+## State invariants for `/test-push`
+
+The skill MUST ensure all 7 pages return to their original (Step 3) values after every run. The skill's Step F1 ("Final state verification") snapshots Notion via `notion-fetch` against the values documented in this file and fails the run if any drift remains.
+
+If a run crashes mid-way and leaves drift:
+- Re-importing into a fresh `test-output/push-e2e/` folder doesn't fix Notion-side drift — only local state
+- Notion-side drift requires manual repair: open the page in Notion UI, restore the values per this doc
+- Phase 4's run summary will help here — failed/halted entries point to which pages need attention
+
+---
+
+## Out of scope (intentionally)
+
+- **`status` property** — can't create via API. Push currently doesn't write `status` either way (it's read-only in `pushSkipTypes`).
+- **`people`, `files`** — push doesn't write these.
+- **Block-level content** — push is frontmatter-only. Bodies are minimal placeholders.
+- **Multi-data-source variants** — push contract is the same regardless. Multi-source coverage lives in `/test-double-datasource-db`.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,9 @@
       "mcp__notion__API-patch-page",
       "Bash",
       "WebSearch",
-      "WebFetch"
+      "WebFetch",
+      "PowerShell",
+      "mcp__claude_ai_Notion__notion-update-data-source"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/skills/test-push/SKILL.md
+++ b/.claude/skills/test-push/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: test-push
+description: E2E test for the push command's full contract against real Notion — confirmation gate, validation halts, cell-level diff, and run summary. Grows phase-by-phase as the v1.4.0 push redesign lands.
+version: 1.0.0
+args: "[--verbose] [--no-cleanup]"
+---
+
+# E2E Test: Push Command
+
+End-to-end test of `notion-sync push` against a real Notion database. Covers behavior the unit and CLI-e2e tests can't observe — **what Notion actually receives** (or, for negative cases, what it *doesn't* receive).
+
+Reference: epic [issue #55](https://github.com/Drexel-UHC/notion-sync/issues/55), DAG `.context/features/push/dag-v1.4.0.mmd`, gate spec `.context/features/push/features/confirmation-gate.md`.
+
+## Why this skill exists separately from `/test-single-datasource-db`
+
+| Concern | Skill |
+|---|---|
+| Single-source schema integration (import / refresh / --ids / --force / push runs) | `/test-single-datasource-db` |
+| Push command **contract** (gate, halts, cell-level, summary) — grows with v1.4.0 epic | **`/test-push`** (this skill) |
+
+`/test-single-datasource-db` keeps a sanity-only push step. Deep push contract lives here so neither skill turns into a kitchen sink as the push feature grows.
+
+## Phase coverage
+
+Step-group letters map to the four-phase v1.4.0 push DAG. Each phase PR appends its group; existing steps don't get renumbered.
+
+| Phase | DAG nodes | Step prefix | Status |
+|---|---|---|---|
+| 1: Confirmation gate | n12b → n13 → n13a | **G** | ✅ included (PR #77) |
+| 2: Validation halts | n21 series → n22a/b | **V** | ⏳ TODO |
+| 3: Cell-level push + verify | n31 → n37 | **C** | ⏳ TODO |
+| 4: Run summary JSON | n41 | **S** | ⏳ TODO |
+
+When adding a phase: append a new `## Phase N — <name>` section with new step IDs (`V1`, `V2`, ... or `C1`, ...). Don't modify existing G/V/C/S blocks unless the phase explicitly redefines that contract.
+
+## Test database
+
+- **DB ID:** `35957008-e885-80c5-9e34-f4191fd83907` (dedicated push e2e fixture DB — `notion-sync-test-database-push`)
+- **Notion URL:** https://www.notion.so/35957008e88580c59e34f4191fd83907
+- **Schema reference:** `.claude/reference/test-databases/push-e2e/setup.md`
+- **Output folder for this skill:** `test-output/push-e2e/` — distinct from `/test-single-datasource-db`'s folder so the two skills can run side-by-side without collision.
+
+Imported fresh on every run (Step 2). Reverted to original state on every run (final step).
+
+## Mode
+
+Check the skill args:
+
+- **Default (concise):** Run all steps automatically, no questions. One-line status per step (e.g., `Step G1: Cancel without --yes... PASS`). Print summary table + final pass/fail at the end. Do NOT use `AskUserQuestion`.
+- **`--verbose`:** Interactive. `AskUserQuestion` with selectable options before every command. Show exact CLI calls, wait for confirmation, show `git diff --stat` + a `Git Analysis:` section after every action.
+- **`--no-cleanup`:** Skip the final cleanup step. Leave `test-output/push-e2e/` on disk for manual inspection.
+
+## State invariants (re-runnability)
+
+This skill must be **idempotent** — runnable cleanly on a fresh checkout AND immediately after a previous run. Every step that mutates Notion has a corresponding revert step. If a step fails mid-run, the cleanup section's revert + summary will tell you what state needs manual fix-up.
+
+The push e2e DB is dedicated to this skill, but the `setup.md` "do not edit" conventions still apply across runs and across phases. Don't leave behind:
+- Locally-edited `.md` files with non-original property values (Step 3 documents the originals; F1 verifies them)
+- Notion-side drift on any of the 7 fixtures — especially Page 4's rich-text annotations (the phase-3 regression target; see `setup.md` "Things to NEVER do")
+- Auto-created `select` / `multi_select` options. Use only the spec'd options: Research / Engineering / Design / Marketing for `Category`; alpha / beta / gamma / delta for `Tags`.
+
+---
+
+## Setup steps (run for every skill invocation)
+
+### Step 0: Build
+
+Run: `go build ./cmd/notion-sync`
+
+- **Pass:** exit 0, `notion-sync.exe` exists at repo root.
+
+### Step 1: Clean slate
+
+- If `test-output/push-e2e/` exists, delete it (in `--verbose` mode, ask first).
+- Don't touch `test-output/` itself or any sibling folders — `/test-single-datasource-db` may be running there.
+
+### Step 2: Fresh import
+
+Run: `./notion-sync.exe import 35957008-e885-80c5-9e34-f4191fd83907 --output ./test-output/push-e2e`
+
+- **Pass:** created > 0, exit 0, `_database.json` present at `./test-output/push-e2e/notion-sync-test-database-push/_database.json`.
+
+### Step 3: Snapshot the canary fixture (Page 1 — `Push: Canary`)
+
+The push DB has 7 fixed fixtures. See [`.claude/reference/test-databases/push-e2e/setup.md`](../../reference/test-databases/push-e2e/setup.md) for the full per-fixture reference. Phase 1's canary is **Page 1 — `Push: Canary`** (https://www.notion.so/35957008e885813a886bcbb6dd7c1598).
+
+Use Notion MCP `notion-fetch` to snapshot its property values — needed for negative assertions (cancel paths) and the F1 final state check.
+
+| Property | Frontmatter key | Original value | Notes |
+|---|---|---|---|
+| `title` | `Name` | `Push: Canary` | |
+| `rich_text` | `Description` | `Phase 1 fixture — confirmation gate cancel/proceed/dry-run.` | |
+| `select` | `Category` | `Research` | Never invent options — use only Research / Engineering / Design / Marketing |
+| `number` | `Score` | `100` | Phase 1 canary — gets edited to 9999 / 8888 across G1-G4 |
+| `date` | `Due Date` | `2026-06-01` | |
+
+**🚨 NEVER use Page 4 (`Push: Formatting Fixture`) in phase 1.** Its rich-text annotations are the phase-3 fixture; touching it from a phase-1 step pollutes phase-3 verification.
+
+Record the page `notion-id` and the 5 values in the run notes.
+
+### Step 4: Isolate canary for phase 1 (delete Pages 2-7 from local folder)
+
+The push command iterates **every** `.md` file in the folder and sends each one's full property payload to Notion. Until phase 3 (cell-level diff) lands, this means a single `push --yes` against the full folder strips Page 4's rich-text annotations on Notion — silently corrupting the phase-3 fixture.
+
+**Phase 1 only needs Page 1.** Delete the other six pages' `.md` files so the push queue contains exactly the canary:
+
+- Keep: `Push- Canary.md` (the `:` in `Push: Canary` is sanitized to `-` on import)
+- Delete: every other `.md` file in `./test-output/push-e2e/notion-sync-test-database-push/`
+- Don't touch: `_database.json`, `AGENTS.md`
+
+Verify: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --dry-run` should show `Push queue (1 file)` listing only the canary.
+
+When phase 3 lands and cell-level diff is in place, this step becomes optional — until then it's the cheapest way to keep the phase-3 fixture intact across phase-1 runs.
+
+---
+
+## Phase 1 — Confirmation gate (DAG n12b → n13 → n13a)
+
+### Step G1: Cancel without `--yes` — verify no Notion write
+
+Edit the canary page's local `.md`: change `Score` to `9999` (single-property edit is enough — push currently sends every populated property, but only `Score` is the canary here).
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push"`
+
+- **Pass:**
+  - Exit code **0** (cancel is not a failure)
+  - Combined output contains `Cancelled` and `--yes`
+  - Combined output contains `Push queue (` (preview fired before the gate)
+  - Combined output does **NOT** contain `Pushing properties to Notion...` (gate fired before push flow)
+  - **Notion MCP fetch** of the canary page: `Score` is the **original snapshot value**, NOT 9999. (This is the critical real-Notion negative assertion — proves the gate fires before any API write.)
+
+**Revert local edit before next step:** restore the canary page's `Score` to the original snapshot value.
+
+### Step G2: `--yes` proceeds and writes to Notion
+
+Edit the canary page's local `.md`: change `Score` to `9999`.
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes`
+
+- **Pass:**
+  - Exit code 0
+  - Combined output contains `Proceeding (--yes).`
+  - `Pushed >= 1`, `Pushed + Skipped == Total`
+  - No `Conflicts:` or `Failed:` lines
+  - The canary page's local `.md` now has `notion-last-pushed:`
+  - **Notion MCP fetch** of the canary page: `Score` is now `9999`.
+
+### Step G3: Revert via push (`--yes`)
+
+Restore the canary page's local `.md`: change `Score` back to the original snapshot value.
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes`
+
+- **Pass:**
+  - Exit code 0
+  - **Notion MCP fetch** of the canary page: `Score` matches the original snapshot value again.
+
+### Step G4: `--dry-run` skips the gate AND doesn't write
+
+Edit the canary page's local `.md`: change `Score` to `8888`.
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --dry-run`
+
+- **Pass:**
+  - Exit code 0
+  - Output starts with `Pushing properties (dry run)...`
+  - Output contains `Dry run:` and `Would push:` (not `Pushed:`)
+  - Output does **NOT** contain `Push queue (` (gate skipped — `--dry-run` short-circuits before the preview)
+  - **Notion MCP fetch** of the canary page: `Score` is the original snapshot value, NOT 8888 (dry-run touched no API state).
+
+**Revert local edit before next step:** restore the canary page's local `Score` to the original snapshot value. No push needed — Notion was never written to.
+
+---
+
+## Phase 2 — Validation halts (TODO — added by phase 2 PR)
+
+When phase 2 lands (n21 series + n22a halt aggregation), this section gets steps `V1`...`Vn`. Expected coverage:
+- Multi-file conflict aggregation: every halt reason listed, **nothing** pushed.
+- Single conflict halts the run (current behavior is per-row partial — phase 2 changes this).
+- Non-row file types (AGENTS.md, notion-deleted) classified correctly.
+
+## Phase 3 — Cell-level push (TODO — added by phase 3 PR)
+
+Steps `C1`...`Cn`. Expected coverage (the original #55 symptom):
+- Edit one field locally; push.
+- **Other fields' rich-text formatting (bold, links, mentions) survives on Notion** — the original epic motivation.
+- Untouched fields don't bump `last_edited_time` on Notion's side beyond the changed cell.
+
+## Phase 4 — Run summary JSON (TODO — added by phase 4 PR)
+
+Steps `S1`...`Sn`. Expected coverage:
+- JSON schema matches `dag-v1.4.0.mmd` header comment.
+- `status` enum: `clean` / `partial` / `halted` / `cancelled`.
+- Exit code matrix: `0` for clean/cancelled, `1` for partial/halted.
+- Per-row `pushed` / `skippedNoOp` / `skippedNonRow` / `failed` / `halted` arrays populated correctly.
+
+---
+
+## Final steps
+
+### Step F1: Final state verification
+
+Notion MCP fetch of the canary page. Compare against **the canonical Step 3 table values hardcoded in this skill** — NOT just the run's own Step 3 fetch. Within-run-only comparison is unsafe: if a prior run left the fixture drifted, a fresh Step 3 fetch records the drifted state and F1 then "matches" itself, silently passing while the bug persists. F1's job is to detect drift against the source-of-truth canonical, full stop.
+
+For each canonical property in the Step 3 table:
+
+| Property | Canonical value | Notion shape to assert |
+|---|---|---|
+| `Name` | `Push: Canary` | `title` text == canonical |
+| `Description` | `Phase 1 fixture — confirmation gate cancel/proceed/dry-run.` | `rich_text` plain text == canonical |
+| `Category` | `Research` | `select.name` == canonical |
+| `Score` | `100` | `number` == canonical |
+| `Due Date` | `2026-06-01` (date-only) | `date.start` == canonical AND `is_datetime` == `0`/`false` |
+
+If any property's Notion shape doesn't match the canonical, mark the run as TESTS FAILED and list the field + got/want values — don't try to auto-fix; investigate.
+
+**Note on `Due Date`:** the `is_datetime` flag is load-bearing here. A common bug class is push promoting date-only properties to UTC datetimes (the original parser-roundtrip bug). F1 must assert *both* `start` matches AND `is_datetime` is false; matching only on the calendar day misses the type drift.
+
+### Step F2: Cleanup
+
+If `--no-cleanup` was passed: skip and print `Step F2: Skipped (--no-cleanup)`.
+
+Otherwise:
+1. Delete `test-output/push-e2e/`.
+2. If `test-output/` is now empty, delete it.
+3. Don't touch `notion-sync.exe` at the repo root — other skills use it.
+
+---
+
+## Done
+
+Print a summary table:
+
+```
+| Step | Action                                  | Result |
+|------|-----------------------------------------|--------|
+| 0    | Build                                   | PASS   |
+| 1    | Clean slate                             | PASS   |
+| 2    | Fresh import                            | PASS   |
+| 3    | Snapshot the canary page                | PASS   |
+| 4    | Isolate canary (delete Pages 2-7 .md)   | PASS   |
+| G1   | Cancel without --yes (no Notion write)  | PASS   |
+| G2   | --yes proceeds, Notion updated          | PASS   |
+| G3   | Revert via push --yes                   | PASS   |
+| G4   | --dry-run skips gate, Notion untouched  | PASS   |
+| F1   | Final state matches snapshot            | PASS   |
+| F2   | Cleanup                                 | PASS   |
+```
+
+If all pass:
+
+```
+ALL TESTS PASSED
+```
+
+If any failed:
+
+```
+TESTS FAILED
+```
+
+followed by a bullet list of each failed step + what went wrong + whether Notion state needs manual repair.

--- a/.claude/skills/test-single-datasource-db/SKILL.md
+++ b/.claude/skills/test-single-datasource-db/SKILL.md
@@ -123,7 +123,7 @@ Edit page B's `.md` file: change the 5 property values in the frontmatter to cle
 - `Due Date` (date): `2026-04-30`
 - `Category` (select): pick a **different existing option** from the schema (Research / Engineering / Design / Marketing — pick whichever is not page B's current value). Do **not** invent a new string — Notion auto-creates select options on push and never garbage-collects them, which would leave cruft in the test DB across runs.
 
-Run: `./notion-sync.exe push "./test-output/test database obsdiain complex"`
+Run: `./notion-sync.exe push "./test-output/test database obsdiain complex" --yes`
 
 - **Pass criteria:**
   - Exit code 0
@@ -137,7 +137,7 @@ Then use Notion MCP (`notion-fetch` on page B's URL) to verify Notion now reflec
 ### Step 9d: Revert page B via push
 Restore page B's `.md` frontmatter to the original values recorded in Step 9b. Run push again:
 
-`./notion-sync.exe push "./test-output/test database obsdiain complex"`
+`./notion-sync.exe push "./test-output/test database obsdiain complex" --yes`
 
 - **Pass criteria:** exit 0, `Pushed + Skipped == Total`, no `Conflicts:` or `Failed:` lines in output.
 
@@ -146,7 +146,7 @@ Use Notion MCP to confirm page B's properties are back to their original values.
 ### Step 9e: Conflict detection
 Pick a third page (page C, not page A from Step 4 and not page B). Manually edit page C's `.md` to set `notion-last-edited:` to a clearly stale value like `2020-01-01T00:00:00.000Z`. Don't change any other properties.
 
-Run: `./notion-sync.exe push "./test-output/test database obsdiain complex"`
+Run: `./notion-sync.exe push "./test-output/test database obsdiain complex" --yes`
 
 - **Pass criteria:**
   - Exit code is **non-zero**
@@ -160,7 +160,7 @@ Page C still has its stale `notion-last-edited:` from the previous step. Re-run 
 
 > **Expected behavior (continued):** like Step 9e, force push writes every non-empty file. The point is to verify the override path on page C; the other 11 writes are no-ops on data values but still bump Notion timestamps. The resulting `Pushed:` count will be `Total`, not `1`.
 
-`./notion-sync.exe push "./test-output/test database obsdiain complex" --force`
+`./notion-sync.exe push "./test-output/test database obsdiain complex" --force --yes`
 
 - **Pass criteria:**
   - Exit code 0

--- a/.context/features/push/backlog/backlog-testing-phase1-identified-gaps.md
+++ b/.context/features/push/backlog/backlog-testing-phase1-identified-gaps.md
@@ -1,0 +1,68 @@
+# Phase 1 testing gaps identified during /test-push iterations 1-3
+
+**Status:** backlog (low-priority test hardening)
+**Tier:** test coverage — closes regression gaps surfaced by the push-roundtrip incident in #78
+
+## What
+
+Two integration tests in `internal/sync/push_test.go` that lock in the **end-to-end** date-roundtrip path (`frontmatter.Parse` → `buildPropertyPayload` → Notion payload), not just the `stripMidnightUTC` helper in isolation.
+
+```go
+// frontmatter.Parse currently lossily promotes `2026-06-01` (date-only) to
+// an RFC3339 datetime via yaml.v3's auto-time.Time parsing, which is the
+// bug `stripMidnightUTC` exists to paper over. This test pins the *integrated*
+// behavior: a date-only YAML scalar must end up as a date-only payload to
+// Notion, regardless of which layer is doing the work.
+//
+// If the proper parser fix lands (see date-only-roundtrip.md) this test
+// keeps passing — its purpose then becomes a regression marker against
+// future re-breaks.
+func TestPush_DateOnlyFrontmatter_RoundTripsAsDateOnly(t *testing.T) {
+    fm, err := frontmatter.Parse("---\nDue Date: 2026-06-01\n---\n")
+    if err != nil { t.Fatal(err) }
+    schema := map[string]notion.DatabaseProperty{"Due Date": {Type: "date"}}
+    payload, _ := buildPropertyPayload(fm, schema)
+    d := payload["Due Date"].(map[string]interface{})["date"].(map[string]interface{})
+    if d["start"] != "2026-06-01" {
+        t.Errorf("date-only round-trip broke: got %q, want '2026-06-01'", d["start"])
+    }
+}
+
+// Mirrors the state import writes when Notion already holds a date-only
+// property as a datetime (e.g. after a prior corruption). The fix B path
+// must still send a date-only payload — otherwise we'd push the corruption
+// back instead of repairing it.
+func TestPush_DatetimeFrontmatter_AtMidnightUTC_RoundTripsAsDateOnly(t *testing.T) {
+    fm, err := frontmatter.Parse(`---` + "\n" + `"Due Date": "2026-06-01T00:00:00.000+00:00"` + "\n" + `---` + "\n")
+    if err != nil { t.Fatal(err) }
+    schema := map[string]notion.DatabaseProperty{"Due Date": {Type: "date"}}
+    payload, _ := buildPropertyPayload(fm, schema)
+    d := payload["Due Date"].(map[string]interface{})["date"].(map[string]interface{})
+    if d["start"] != "2026-06-01" {
+        t.Errorf("midnight-UTC datetime should demote to date-only on send: got %q", d["start"])
+    }
+}
+```
+
+## Why
+
+Existing `TestBuildPropertyValue_Date_*` tests cover `stripMidnightUTC` in isolation — they pass even if `frontmatter.Parse` later changes its lossy behavior, or if the helper is removed alongside a parser fix that doesn't fully restore round-trip. The actual bug observed in `/test-push` iteration 1 lived in the *integration* between those two layers, and only an integration test catches a future re-break of the integration.
+
+This is a defense-in-depth test: it doesn't exercise new code, it proves the seams between `frontmatter.Parse` and `buildPropertyPayload` agree on date semantics.
+
+## Why deferred
+
+- Push-side fix B + the existing isolated unit tests give acceptable coverage for v1.4.0 ship.
+- Adding these now means a follow-up commit on this branch; bundling with the proper parser fix (see `date-only-roundtrip.md`) makes more sense — that PR is *also* going to add `frontmatter_test.go` round-trip tests, and the integration tests should land alongside that work to share the same setup.
+- Not blocking phase 2 or phase 3 — neither phase touches date-property serialization.
+
+## Acceptance
+
+- Both tests live in `internal/sync/push_test.go` (or a new `push_roundtrip_test.go`).
+- Both tests pass against the **current** `stripMidnightUTC`-based fix B.
+- Both tests pass against the future yaml.Node-based parser fix (i.e. they don't pin behavior to a specific implementation, only to the contract).
+- A regression where someone removes `stripMidnightUTC` without fixing the parser causes `TestPush_DateOnlyFrontmatter_RoundTripsAsDateOnly` to fail.
+
+## How discovered
+
+`/test-push` iteration 1 in PR #78 caught the date-roundtrip bug in production-equivalent usage. Iterations 2 and 3 surfaced that the existing unit tests covered the helper but not the integrated path through `frontmatter.Parse`. See PR #78 conversation and `date-only-roundtrip.md` for the underlying parser bug this gap is adjacent to.

--- a/.context/features/push/backlog/date-only-roundtrip.md
+++ b/.context/features/push/backlog/date-only-roundtrip.md
@@ -1,0 +1,71 @@
+# Date-only frontmatter properties round-trip through push as datetimes
+
+**Status:** backlog (proper fix; pragmatic workaround shipped in #78)
+**Tier:** correctness — affects all date-typed properties on every push
+
+## What
+
+Date-only Notion properties (`is_datetime: false`) get promoted to UTC datetimes (`is_datetime: true`) when push reads the frontmatter and forwards the value to Notion's API.
+
+**Symptom on Notion:**
+- Before push: `Due Date` shows as `Jun 1, 2026` (date-only).
+- After push (any field edit): `Due Date` shows as `Jun 1, 2026, 12:00 AM UTC` (datetime).
+- Notion's response: `is_datetime` flips `false` → `true`, `start` becomes `2026-06-01T00:00:00.000Z` instead of `2026-06-01`.
+
+Once promoted, the property is permanently in datetime form on Notion until manually toggled back. This affects **every** date-typed property in **every** pushed row, regardless of whether the user touched it.
+
+## Root cause
+
+`internal/frontmatter/parser.go:38-51` — `normalizeMapValues` formats parsed `time.Time` values with `time.RFC3339`:
+
+```go
+case time.Time:
+    m[k] = val.Format(time.RFC3339)   // "2006-01-02T15:04:05Z07:00"
+```
+
+`yaml.v3` auto-parses any ISO-shaped scalar (including bare `2026-06-01`) to `time.Time` and **discards the original string**. So by the time `normalizeMapValues` runs, the parser cannot tell whether the user wrote `2026-06-01` or `2026-06-01T00:00:00Z` — both arrive as identical `time.Time` values. Reformatting with RFC3339 always emits the time portion, so date-only signal is destroyed at parse time and propagated to every consumer.
+
+`parseDatePayload` in `push.go` then forwards that lossy string straight into the Notion payload, which Notion correctly interprets as a datetime.
+
+## Pragmatic workaround (shipped in #78)
+
+Added `stripMidnightUTC` to `internal/sync/push.go`. It demotes `YYYY-MM-DDT00:00:00Z` (and `+00:00`, `.000Z`, etc.) back to `YYYY-MM-DD` before sending to Notion, but only when:
+- Hour, minute, second, and nanosecond are all zero, AND
+- Timezone offset is zero.
+
+This is a heuristic: a user who genuinely wrote a UTC midnight datetime gets demoted to date-only. False-positive surface is small (a real "midnight UTC" datetime is unusual), and the workaround keeps the push contract correct for the common case.
+
+Localized to push so the parser's contract doesn't change for other consumers.
+
+## Why this needs a proper fix anyway
+
+The workaround is fragile across three axes:
+
+1. **Lossy for legitimate midnight-UTC datetimes.** A user who legitimately wants `is_datetime: true` at exactly `T00:00:00Z` cannot express it through frontmatter — push will demote it. Niche but real.
+2. **Doesn't fix the parser.** Any future code path that reads dates from frontmatter (e.g. comparison logic for cell-level diff in phase 3, validation in phase 2) will hit the same lossy round-trip and need its own workaround.
+3. **Phase 3 (cell-level diff) needs precise round-trip.** Cell-level diff compares local frontmatter to Notion's current value to decide what to push. If the comparison normalizes `2026-06-01` and `2026-06-01T00:00:00Z` differently, every date will look "changed" on every push and we lose the whole point of cell-level. The workaround happens to align them today, but only because `stripMidnightUTC` runs on the push side. If diff logic runs *before* `stripMidnightUTC`, drift returns.
+
+## Proper fix
+
+Replace `yaml.Unmarshal` + `normalizeMapValues` with a `yaml.Node`-based parser that walks the AST and preserves the original scalar string for each value. Two main jobs:
+
+- For values tagged `!!timestamp` (RFC3339 datetime), keep the original string.
+- For values tagged `!!str` that happen to look ISO-shaped, leave them as strings.
+
+The yaml.v3 docs example is the canonical shape; `internal/frontmatter/parser.go` becomes ~30-40 lines longer but every consumer gets exact round-trip semantics for free.
+
+## Why deferred
+
+Workaround is sufficient for v1.4.0 push correctness. Proper fix touches a shared parser used by import, refresh, push, and validation — wider blast radius, deserves its own PR + test pass. Schedule alongside or after phase 3 (cell-level diff), since phase 3 will surface any remaining round-trip bugs in adjacent property types (e.g. numbers, multi_select strings that look numeric).
+
+## Acceptance
+
+- `internal/frontmatter/parser.go` parses date-only YAML scalars as plain strings (`"2026-06-01"`), not `time.Time`.
+- `stripMidnightUTC` in `push.go` is removed (or kept as a defense-in-depth no-op with a deprecation comment).
+- New unit test in `frontmatter_test.go`: parsing `Due Date: 2026-06-01` yields the literal string `"2026-06-01"` in the result map; parsing `Due Date: 2026-06-01T00:00:00Z` yields `"2026-06-01T00:00:00Z"`. Both round-trip identically through `Write` + `Parse`.
+- `/test-push` F1 still passes against the canonical date-only `Due Date`, with no within-run drift on Notion.
+- Other date consumers (refresh stale-detection, push diff) tested for round-trip stability.
+
+## How discovered
+
+`/test-push` iteration 1 (PR #78): F1 caught the drift on the first run; iteration 2 silently passed because the fixture was already corrupted from iteration 1, exposing a separate test-design weakness (within-run-only comparison) which was also fixed in #78. See PR #78 conversation for the full diagnosis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Custom skills live in `.claude/skills/`. Invoke with `/skill-name`.
 | `/test-single-datasource-db` | Integration test against the single data source test database |
 | `/test-double-datasource-db` | Integration test against the double data source test database |
 | `/test-standalone-page` | Integration test for standalone page import/refresh/list |
+| `/test-push` | E2E test for the push command's full contract — gate, halts, cell-level, summary (grows with v1.4.0 epic) |
 | `/release` | Tag and publish a new release interactively |
 | `/clean` | Clean up merged branches |
 

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/term"
+
 	"github.com/ran-codes/notion-sync/internal/clean"
 	"github.com/ran-codes/notion-sync/internal/config"
 	"github.com/ran-codes/notion-sync/internal/notion"
@@ -460,13 +462,11 @@ func confirmPush(queue []string, yes, isTTY bool, stdin io.Reader, stderr io.Wri
 }
 
 // isStdinTTY reports whether stdin is connected to a terminal (vs a pipe or
-// redirect). Stdlib-only check that works on Windows and Unix.
+// redirect). Uses x/term so mintty-based shells (Git Bash, MSYS2, Cygwin)
+// are detected correctly — the stdlib `os.ModeCharDevice` check misses them
+// because mintty wraps stdio in named pipes.
 func isStdinTTY() bool {
-	fi, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return (fi.Mode() & os.ModeCharDevice) != 0
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func runPush(args []string) error {

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/ran-codes/notion-sync/internal/clean"
@@ -22,6 +25,7 @@ var boolFlags = map[string]bool{
 	"--force": true, "-f": true,
 	"--keep-presigned-params": true,
 	"--dry-run":               true,
+	"--yes":                   true, "-y": true,
 }
 
 // reorderArgs moves flag arguments (starting with "-") before positional arguments
@@ -60,7 +64,7 @@ var usage = `notion-sync — Sync Notion databases and pages to Markdown (v` + v
 Usage:
   notion-sync import <database-or-page-id> [--output <folder>] [--api-key <key>] [--keep-presigned-params]
   notion-sync refresh <folder> [--ids id1,id2] [--force] [--api-key <key>] [--keep-presigned-params]
-  notion-sync push <folder> [--force] [--dry-run] [--api-key <key>]
+  notion-sync push <folder> [--force] [--dry-run] [--yes] [--api-key <key>]
   notion-sync list [<output-folder>]
   notion-sync clean <folder> [--dry-run]
   notion-sync agents-md <folder>
@@ -76,9 +80,12 @@ Commands:
             --force, -f    Resync all entries, ignoring timestamps
             --keep-presigned-params  Keep AWS S3 pre-signed query strings on file URLs
   push      Push local frontmatter property changes back to Notion (properties only, no body)
+            Previews the push queue and prompts y/N before any API write (TTY only).
+            Non-interactive runs (CI / pipes) must pass --yes; otherwise the run is cancelled.
             Refuses to push files where Notion has been edited since last sync, unless --force.
             --force, -f    Push even if Notion has newer edits (overwrites Notion-side changes)
             --dry-run      Show what would be pushed without writing to Notion (still reads from Notion for conflict detection)
+            --yes, -y      Skip the confirmation prompt (required in non-interactive runs)
   list      List all synced databases and pages in a folder
   clean     Strip AWS S3 pre-signed query strings from existing .md files in a folder.
             Useful one-time backfill after upgrading. No API calls.
@@ -417,12 +424,59 @@ func runRefreshPage(client *notion.Client, folderPath string, force, stripPresig
 
 //// 2.3 Push ----
 
+// confirmPush previews the push queue to stderr and gates execution on user
+// consent. Returns true if push should proceed, false to cancel cleanly
+// (caller exits 0). TTY: y/N prompt, default N. Non-TTY: requires `yes`,
+// otherwise cancels with a stderr hint. Caller must short-circuit on empty
+// queue before calling.
+func confirmPush(queue []string, yes, isTTY bool, stdin io.Reader, stderr io.Writer) bool {
+	noun := "file"
+	if len(queue) != 1 {
+		noun = "files"
+	}
+	fmt.Fprintf(stderr, "Push queue (%d %s):\n", len(queue), noun)
+	for _, p := range queue {
+		fmt.Fprintf(stderr, "  %s\n", filepath.Base(p))
+	}
+	fmt.Fprintln(stderr)
+
+	if yes {
+		fmt.Fprintln(stderr, "Proceeding (--yes).")
+		return true
+	}
+	if !isTTY {
+		fmt.Fprintln(stderr, "Cancelled — non-interactive run requires --yes to push.")
+		return false
+	}
+
+	fmt.Fprint(stderr, "Proceed? [y/N]: ")
+	line, _ := bufio.NewReader(stdin).ReadString('\n')
+	answer := strings.ToLower(strings.TrimSpace(line))
+	if answer == "y" || answer == "yes" {
+		return true
+	}
+	fmt.Fprintln(stderr, "Cancelled — nothing pushed to Notion.")
+	return false
+}
+
+// isStdinTTY reports whether stdin is connected to a terminal (vs a pipe or
+// redirect). Stdlib-only check that works on Windows and Unix.
+func isStdinTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
 func runPush(args []string) error {
 	fs := flag.NewFlagSet("push", flag.ExitOnError)
 	apiKey := fs.String("api-key", "", "Notion API key")
 	force := fs.Bool("force", false, "Push even if Notion has newer edits")
 	forceShort := fs.Bool("f", false, "Push even if Notion has newer edits (shorthand)")
 	dryRun := fs.Bool("dry-run", false, "Show what would be pushed without writing to Notion")
+	yes := fs.Bool("yes", false, "Skip the confirmation prompt (required for non-interactive runs)")
+	yesShort := fs.Bool("y", false, "Skip the confirmation prompt (shorthand)")
 
 	if err := fs.Parse(reorderArgs(args)); err != nil {
 		return err
@@ -430,7 +484,7 @@ func runPush(args []string) error {
 
 	if fs.NArg() == 0 {
 		return fmt.Errorf("missing folder path\n" +
-			"Usage: notion-sync push <folder> [--force] [--dry-run] [--api-key <key>]\n" +
+			"Usage: notion-sync push <folder> [--force] [--dry-run] [--yes] [--api-key <key>]\n" +
 			"Example: notion-sync push ./notion/My\\ Database")
 	}
 
@@ -449,6 +503,24 @@ func runPush(args []string) error {
 
 	folderPath := fs.Arg(0)
 	forceFlag := *force || *forceShort
+	yesFlag := *yes || *yesShort
+
+	// Confirmation gate (DAG nodes n12b → n13 → n13a in v1.4.0 push design).
+	// Push is the only command that writes to Notion; gate fires before any
+	// API call. Skipped under --dry-run since no writes occur.
+	if !*dryRun {
+		queue, err := sync.BuildPushQueue(folderPath)
+		if err != nil {
+			return err
+		}
+		if len(queue) == 0 {
+			fmt.Fprintln(os.Stderr, "Nothing to push: no synced .md files in folder.")
+			return nil
+		}
+		if !confirmPush(queue, yesFlag, isStdinTTY(), os.Stdin, os.Stderr) {
+			return nil
+		}
+	}
 
 	if *dryRun {
 		fmt.Println("Pushing properties (dry run)...")

--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -214,3 +214,106 @@ func TestCLI_Version(t *testing.T) {
 		t.Error("expected version output")
 	}
 }
+
+// --- CLI e2e tests for the push confirmation gate ---
+//
+// These exercise the full CLI wiring (flag parsing → API-key validation →
+// gate → push flow) that the in-process confirmPush unit tests above don't
+// cover. Subprocess stdin is non-TTY, so isStdinTTY() returns false in the
+// child process — exactly the CI / piped-input scenario we care about.
+
+// dummyAPIKey is a syntactically valid Notion API key (ntn_ prefix, >= 20
+// chars) that passes config.ValidateAPIKey but won't authenticate against
+// the real API. Lets these tests reach the gate without a real key, and
+// guarantees any subsequent Notion call fails fast.
+const dummyAPIKey = "ntn_0000000000000000000000000000000000000000000000"
+
+// setupPushFolder creates a tmp folder with a minimal _database.json plus
+// one .md file with a notion-id frontmatter — enough for BuildPushQueue to
+// return a non-empty queue so the gate actually fires.
+func setupPushFolder(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+
+	meta := `{
+  "databaseId": "00000000-0000-0000-0000-000000000001",
+  "title": "Test DB",
+  "url": "",
+  "folderPath": "",
+  "lastSyncedAt": "",
+  "entryCount": 1
+}
+`
+	if err := os.WriteFile(filepath.Join(tmp, "_database.json"), []byte(meta), 0644); err != nil {
+		t.Fatal(err)
+	}
+	page := "---\nnotion-id: 00000000-0000-0000-0000-000000000002\ntitle: Page One\n---\n\nbody\n"
+	if err := os.WriteFile(filepath.Join(tmp, "page-one.md"), []byte(page), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return tmp
+}
+
+// pushCmd builds a `go run . push <folder> [extra...]` command with a dummy
+// API key in the env so validation passes and the run reaches the gate.
+func pushCmd(folder string, extra ...string) *exec.Cmd {
+	args := append([]string{"run", ".", "push", folder}, extra...)
+	cmd := exec.Command("go", args...)
+	cmd.Env = append(os.Environ(), "NOTION_SYNC_API_KEY="+dummyAPIKey)
+	return cmd
+}
+
+// Non-TTY (subprocess stdin) without --yes must cancel cleanly with exit 0
+// and a stderr hint pointing at --yes. The push flow ("Pushing properties
+// to Notion...") must NOT execute — proves the gate fired before any
+// Notion API call.
+func TestCLI_Push_NonTTY_NoYes_Cancels(t *testing.T) {
+	tmp := setupPushFolder(t)
+
+	out, err := pushCmd(tmp).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 on cancel, got %v\n%s", err, out)
+	}
+	s := string(out)
+	if !strings.Contains(s, "Cancelled") {
+		t.Errorf("expected 'Cancelled' in output, got:\n%s", s)
+	}
+	if !strings.Contains(s, "--yes") {
+		t.Errorf("expected '--yes' hint in output, got:\n%s", s)
+	}
+	if strings.Contains(s, "Pushing properties to Notion...") {
+		t.Errorf("gate should fire before push flow, but push started:\n%s", s)
+	}
+}
+
+// --yes bypasses the gate even in non-TTY. We don't care that the push
+// itself fails (dummy key → 401); we only need to prove control reached
+// the push flow past the gate.
+func TestCLI_Push_Yes_PassesGate(t *testing.T) {
+	tmp := setupPushFolder(t)
+
+	out, _ := pushCmd(tmp, "--yes").CombinedOutput()
+	s := string(out)
+	if strings.Contains(s, "Cancelled — non-interactive") {
+		t.Errorf("--yes should bypass gate, but got cancellation:\n%s", s)
+	}
+	if !strings.Contains(s, "Pushing properties to Notion...") {
+		t.Errorf("expected push flow to start past the gate, got:\n%s", s)
+	}
+}
+
+// --dry-run skips the gate entirely (no writes, no consent needed). The
+// gate's preview header ("Push queue (") must not appear, and the dry-run
+// banner must.
+func TestCLI_Push_DryRun_SkipsGate(t *testing.T) {
+	tmp := setupPushFolder(t)
+
+	out, _ := pushCmd(tmp, "--dry-run").CombinedOutput()
+	s := string(out)
+	if strings.Contains(s, "Push queue (") {
+		t.Errorf("--dry-run should skip the gate, but preview ran:\n%s", s)
+	}
+	if !strings.Contains(s, "Pushing properties (dry run)...") {
+		t.Errorf("expected dry-run banner, got:\n%s", s)
+	}
+}

--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -113,6 +114,94 @@ func TestCLI_AgentsMD_OverwritesExisting(t *testing.T) {
 	}
 	if strings.Contains(string(got), "# old") {
 		t.Errorf("AGENTS.md was not overwritten:\n%s", got)
+	}
+}
+
+// --- confirmPush tests (DAG n13 — consent gate before any Notion write) ---
+
+func TestConfirmPush_YesFlag_Proceeds(t *testing.T) {
+	var stderr bytes.Buffer
+	ok := confirmPush([]string{"a/page.md"}, true, false, strings.NewReader(""), &stderr)
+	if !ok {
+		t.Error("expected confirmPush to return true with --yes flag")
+	}
+	if !strings.Contains(stderr.String(), "Proceeding (--yes)") {
+		t.Errorf("expected 'Proceeding (--yes)' notice, got:\n%s", stderr.String())
+	}
+}
+
+// Non-interactive runs without --yes must cancel — that's the whole point of
+// requiring a flag in CI / piped contexts. Hint must mention --yes so the
+// user/agent knows how to opt in.
+func TestConfirmPush_NonTTY_NoFlag_Cancels(t *testing.T) {
+	var stderr bytes.Buffer
+	ok := confirmPush([]string{"a/page.md"}, false, false, strings.NewReader(""), &stderr)
+	if ok {
+		t.Error("expected confirmPush to cancel in non-TTY without --yes")
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "Cancelled") {
+		t.Errorf("expected cancellation message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--yes") {
+		t.Errorf("expected hint to mention --yes, got:\n%s", out)
+	}
+}
+
+func TestConfirmPush_TTY_Yes_Proceeds(t *testing.T) {
+	for _, ans := range []string{"y\n", "Y\n", "yes\n", "YES\n"} {
+		var stderr bytes.Buffer
+		ok := confirmPush([]string{"a/page.md"}, false, true, strings.NewReader(ans), &stderr)
+		if !ok {
+			t.Errorf("answer %q: expected proceed, got cancel\nstderr: %s", ans, stderr.String())
+		}
+	}
+}
+
+// Default-N is the safety property. Empty input (Enter), explicit "n", or
+// anything other than y/yes must cancel.
+func TestConfirmPush_TTY_DefaultN_Cancels(t *testing.T) {
+	for _, ans := range []string{"\n", "n\n", "N\n", "no\n", "maybe\n", ""} {
+		var stderr bytes.Buffer
+		ok := confirmPush([]string{"a/page.md"}, false, true, strings.NewReader(ans), &stderr)
+		if ok {
+			t.Errorf("answer %q: expected cancel, got proceed", ans)
+		}
+		if !strings.Contains(stderr.String(), "Cancelled") {
+			t.Errorf("answer %q: expected cancellation message, got:\n%s", ans, stderr.String())
+		}
+	}
+}
+
+// Preview must show every queued file and the count *before* the prompt
+// fires. Acceptance criterion from confirmation-gate.md.
+func TestConfirmPush_Preview_ListsFilesAndCount(t *testing.T) {
+	queue := []string{
+		"notion/db/page-001.md",
+		"notion/db/page-002.md",
+		"notion/db/page-003.md",
+	}
+	var stderr bytes.Buffer
+	confirmPush(queue, true, false, strings.NewReader(""), &stderr)
+
+	out := stderr.String()
+	if !strings.Contains(out, "3 files") {
+		t.Errorf("expected '3 files' in preview, got:\n%s", out)
+	}
+	for _, p := range queue {
+		base := filepath.Base(p)
+		if !strings.Contains(out, base) {
+			t.Errorf("expected %s in preview, got:\n%s", base, out)
+		}
+	}
+}
+
+// Singular noun for one file — small UX detail but worth pinning.
+func TestConfirmPush_Preview_SingularForOneFile(t *testing.T) {
+	var stderr bytes.Buffer
+	confirmPush([]string{"only.md"}, true, false, strings.NewReader(""), &stderr)
+	if !strings.Contains(stderr.String(), "1 file)") {
+		t.Errorf("expected '1 file)' (singular), got:\n%s", stderr.String())
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/zalando/go-keyring v0.2.4
+	golang.org/x/term v0.27.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/zalando/go-keyring v0.2.4 h1:wi2xxTqdiwMKbM6TWwi+uJCG/Tum2UV0jqaQhCa9
 github.com/zalando/go-keyring v0.2.4/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
 golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -357,14 +357,35 @@ func parseDatePayload(s string) interface{} {
 		parts := strings.SplitN(s, " → ", 2)
 		return map[string]interface{}{
 			"date": map[string]interface{}{
-				"start": strings.TrimSpace(parts[0]),
-				"end":   strings.TrimSpace(parts[1]),
+				"start": stripMidnightUTC(strings.TrimSpace(parts[0])),
+				"end":   stripMidnightUTC(strings.TrimSpace(parts[1])),
 			},
 		}
 	}
 	return map[string]interface{}{
-		"date": map[string]interface{}{"start": s},
+		"date": map[string]interface{}{"start": stripMidnightUTC(s)},
 	}
+}
+
+// stripMidnightUTC demotes "YYYY-MM-DDT00:00:00Z" back to "YYYY-MM-DD".
+// Workaround for yaml.v3 + frontmatter.Parse collapsing date-only scalars
+// into RFC3339 datetimes — without this, every date-only property gets
+// promoted to a UTC datetime on Notion (is_datetime flips false→true) on
+// every push. See .context/features/push/backlog/date-only-roundtrip.md
+// for the proper fix (yaml.Node parsing to preserve original tokens).
+func stripMidnightUTC(s string) string {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return s
+	}
+	if t.Hour() != 0 || t.Minute() != 0 || t.Second() != 0 || t.Nanosecond() != 0 {
+		return s
+	}
+	_, off := t.Zone()
+	if off != 0 {
+		return s
+	}
+	return t.Format("2006-01-02")
 }
 
 func coerceString(val interface{}) string {

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -11,27 +11,23 @@ import (
 	"github.com/ran-codes/notion-sync/internal/notion"
 )
 
-// BuildPushQueue returns the .md file paths in folderPath that PushDatabase
-// would attempt to push: linked to Notion (`notion-id` present) and not
-// soft-deleted. Used by the confirmation gate (DAG n12b) before any Notion
-// API call. AGENTS.md and other non-synced files drop out via the notion-id
-// check. Errors if folderPath isn't a synced database so the user sees
-// "not a sync folder" rather than a misleading "nothing to push".
-func BuildPushQueue(folderPath string) ([]string, error) {
-	metadata, err := ReadDatabaseMetadata(folderPath)
-	if err != nil {
-		return nil, fmt.Errorf("read metadata: %w", err)
-	}
-	if metadata == nil {
-		return nil, fmt.Errorf("no %s found in %s. Use 'import' to import the database first", DatabaseMetadataFile, folderPath)
-	}
+// pushableFile is a folder entry the push pipeline will act on: a .md file
+// linked to Notion (`notion-id` present) and not soft-deleted.
+type pushableFile struct {
+	path string
+	fm   map[string]interface{}
+}
 
+// scanPushable is the single source of truth for "what counts as pushable" —
+// both BuildPushQueue (preview) and PushDatabase (action) call it so the
+// confirmation gate's preview-equals-action contract holds by construction,
+// not by hand-keeping two filter loops in sync.
+func scanPushable(folderPath string) ([]pushableFile, error) {
 	dirEntries, err := os.ReadDir(folderPath)
 	if err != nil {
 		return nil, fmt.Errorf("read folder: %w", err)
 	}
-
-	var queue []string
+	var files []pushableFile
 	for _, entry := range dirEntries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
 			continue
@@ -51,7 +47,30 @@ func BuildPushQueue(folderPath string) ([]string, error) {
 		if deleted, ok := fm["notion-deleted"].(bool); ok && deleted {
 			continue
 		}
-		queue = append(queue, filePath)
+		files = append(files, pushableFile{path: filePath, fm: fm})
+	}
+	return files, nil
+}
+
+// BuildPushQueue returns the .md file paths in folderPath that PushDatabase
+// would attempt to push. Used by the confirmation gate (DAG n12b) before any
+// Notion API call. Errors if folderPath isn't a synced database so the user
+// sees "not a sync folder" rather than a misleading "nothing to push".
+func BuildPushQueue(folderPath string) ([]string, error) {
+	metadata, err := ReadDatabaseMetadata(folderPath)
+	if err != nil {
+		return nil, fmt.Errorf("read metadata: %w", err)
+	}
+	if metadata == nil {
+		return nil, fmt.Errorf("no %s found in %s. Use 'import' to import the database first", DatabaseMetadataFile, folderPath)
+	}
+	files, err := scanPushable(folderPath)
+	if err != nil {
+		return nil, err
+	}
+	queue := make([]string, 0, len(files))
+	for _, f := range files {
+		queue = append(queue, f.path)
 	}
 	return queue, nil
 }
@@ -97,37 +116,9 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		onProgress(ProgressPhase{Phase: PhasePushScanning})
 	}
 
-	type fileEntry struct {
-		path string
-		fm   map[string]interface{}
-	}
-
-	dirEntries, err := os.ReadDir(opts.FolderPath)
+	files, err := scanPushable(opts.FolderPath)
 	if err != nil {
-		return nil, fmt.Errorf("read folder: %w", err)
-	}
-
-	var files []fileEntry
-	for _, entry := range dirEntries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
-			continue
-		}
-		filePath := filepath.Join(opts.FolderPath, entry.Name())
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			continue
-		}
-		fm, err := frontmatter.Parse(string(content))
-		if err != nil || fm == nil {
-			continue
-		}
-		if _, ok := fm["notion-id"].(string); !ok {
-			continue
-		}
-		if deleted, ok := fm["notion-deleted"].(bool); ok && deleted {
-			continue
-		}
-		files = append(files, fileEntry{filePath, fm})
+		return nil, err
 	}
 
 	result.Total = len(files)

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -11,6 +11,51 @@ import (
 	"github.com/ran-codes/notion-sync/internal/notion"
 )
 
+// BuildPushQueue returns the .md file paths in folderPath that PushDatabase
+// would attempt to push: linked to Notion (`notion-id` present) and not
+// soft-deleted. Used by the confirmation gate (DAG n12b) before any Notion
+// API call. AGENTS.md and other non-synced files drop out via the notion-id
+// check. Errors if folderPath isn't a synced database so the user sees
+// "not a sync folder" rather than a misleading "nothing to push".
+func BuildPushQueue(folderPath string) ([]string, error) {
+	metadata, err := ReadDatabaseMetadata(folderPath)
+	if err != nil {
+		return nil, fmt.Errorf("read metadata: %w", err)
+	}
+	if metadata == nil {
+		return nil, fmt.Errorf("no %s found in %s. Use 'import' to import the database first", DatabaseMetadataFile, folderPath)
+	}
+
+	dirEntries, err := os.ReadDir(folderPath)
+	if err != nil {
+		return nil, fmt.Errorf("read folder: %w", err)
+	}
+
+	var queue []string
+	for _, entry := range dirEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		filePath := filepath.Join(folderPath, entry.Name())
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+		fm, err := frontmatter.Parse(string(content))
+		if err != nil || fm == nil {
+			continue
+		}
+		if _, ok := fm["notion-id"].(string); !ok {
+			continue
+		}
+		if deleted, ok := fm["notion-deleted"].(bool); ok && deleted {
+			continue
+		}
+		queue = append(queue, filePath)
+	}
+	return queue, nil
+}
+
 // PushDatabase pushes local frontmatter property changes back to Notion.
 // Only page properties are updated; page body content is never modified.
 func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, error) {

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -847,6 +847,70 @@ func TestBuildPushQueue_ErrorsWhenMetadataMissing(t *testing.T) {
 	}
 }
 
+// Parity contract: the gate's preview must equal the action. BuildPushQueue
+// (preview) and PushDatabase (action) both call scanPushable, so this test
+// pins the invariant — if anyone re-introduces a divergent filter, this
+// fails.
+func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	// Mix of pushable + every kind of non-pushable file the filter should
+	// exclude. If the two code paths disagree on any of these, the gate is
+	// a lie.
+	files := map[string]string{
+		"keep-001.md":      "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\nnotion-database-id: db-001\n---\n",
+		"keep-002.md":      "---\nnotion-id: page-002\nnotion-last-edited: 2024-01-01T00:00:00Z\nnotion-database-id: db-001\n---\n",
+		"AGENTS.md":        "# Guide for downstream agents\n",
+		"no-notion-id.md":  "---\ntitle: stray\n---\n",
+		"deleted.md":       "---\nnotion-id: page-deleted\nnotion-deleted: true\n---\n",
+		"not-markdown.txt": "ignored",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	queue, err := BuildPushQueue(dir)
+	if err != nil {
+		t.Fatalf("BuildPushQueue: %v", err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Name": {Type: "title"},
+		},
+	}
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+	client.pages["page-002"] = &notion.Page{ID: "page-002", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, DryRun: true}, nil)
+	if err != nil {
+		t.Fatalf("PushDatabase: %v", err)
+	}
+
+	if result.Total != len(queue) {
+		t.Fatalf("preview/action divergence: BuildPushQueue=%d PushDatabase.Total=%d", len(queue), result.Total)
+	}
+	queueBasenames := make(map[string]bool, len(queue))
+	for _, p := range queue {
+		queueBasenames[filepath.Base(p)] = true
+	}
+	for _, want := range []string{"keep-001.md", "keep-002.md"} {
+		if !queueBasenames[want] {
+			t.Errorf("queue missing %s; got %v", want, queue)
+		}
+	}
+	for _, exclude := range []string{"AGENTS.md", "no-notion-id.md", "deleted.md", "not-markdown.txt"} {
+		if queueBasenames[exclude] {
+			t.Errorf("queue should not include %s; got %v", exclude, queue)
+		}
+	}
+}
+
 // writeDatabaseMeta writes a minimal _database.json for tests.
 func writeDatabaseMeta(t *testing.T, dir, dbID string) {
 	t.Helper()

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -767,6 +767,86 @@ func TestUpdateAfterPush_DoesNotCorruptValueContainingKey(t *testing.T) {
 	}
 }
 
+// --- BuildPushQueue tests (DAG n12b — preview-side queue construction) ---
+
+func TestBuildPushQueue_IncludesLinkedFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	queue, err := BuildPushQueue(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queue) != 1 {
+		t.Fatalf("expected 1 file, got %d (%v)", len(queue), queue)
+	}
+	if filepath.Base(queue[0]) != "page-001.md" {
+		t.Errorf("expected page-001.md, got %s", queue[0])
+	}
+}
+
+// AGENTS.md (no notion-id) and arbitrary unlinked files must be excluded —
+// the queue is "rows we'd push to Notion," and these aren't rows.
+func TestBuildPushQueue_SkipsFilesWithoutNotionID(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# Agent guide\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "stray.md"), []byte("---\ntitle: stray\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	queue, err := BuildPushQueue(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queue) != 0 {
+		t.Errorf("expected empty queue, got %v", queue)
+	}
+}
+
+func TestBuildPushQueue_SkipsDeletedEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-001\nnotion-deleted: true\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	queue, err := BuildPushQueue(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(queue) != 0 {
+		t.Errorf("expected deleted entry to be skipped, got %v", queue)
+	}
+}
+
+func TestBuildPushQueue_ErrorsWhenMetadataMissing(t *testing.T) {
+	dir := t.TempDir()
+	// No _database.json — folder is not a synced database.
+	md := "---\nnotion-id: page-001\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := BuildPushQueue(dir)
+	if err == nil {
+		t.Fatal("expected error for folder without _database.json, got nil")
+	}
+	if !strings.Contains(err.Error(), "_database.json") {
+		t.Errorf("expected error to mention _database.json, got: %v", err)
+	}
+}
+
 // writeDatabaseMeta writes a minimal _database.json for tests.
 func writeDatabaseMeta(t *testing.T, dir, dbID string) {
 	t.Helper()

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -254,6 +254,62 @@ func TestBuildPropertyValue_DateRange(t *testing.T) {
 	}
 }
 
+// frontmatter.Parse normalizes date-only YAML scalars (e.g. `Due Date: 2026-06-01`)
+// into RFC3339 datetimes (e.g. `2026-06-01T00:00:00Z`) because yaml.v3 auto-parses
+// them to time.Time. Without stripMidnightUTC, push then sends that datetime
+// string to Notion, which flips `is_datetime` false→true on every push.
+func TestBuildPropertyValue_Date_StripsMidnightUTC(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"Z suffix", "2026-06-01T00:00:00Z", "2026-06-01"},
+		{"Z with millis", "2026-06-01T00:00:00.000Z", "2026-06-01"},
+		{"plus offset zero", "2026-06-01T00:00:00+00:00", "2026-06-01"},
+		{"already date-only", "2026-06-01", "2026-06-01"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildPropertyValue("date", tc.in).(map[string]interface{})
+			d := got["date"].(map[string]interface{})
+			if d["start"] != tc.want {
+				t.Errorf("got %q, want %q", d["start"], tc.want)
+			}
+		})
+	}
+}
+
+// Real datetimes (non-midnight or non-UTC) must pass through untouched —
+// stripMidnightUTC is a date-only repair, not a general datetime sanitizer.
+func TestBuildPropertyValue_Date_PreservesRealDatetimes(t *testing.T) {
+	cases := []string{
+		"2026-06-01T09:30:00Z",      // non-midnight UTC
+		"2026-06-01T00:00:00-05:00", // midnight non-UTC
+		"2026-06-01T00:00:01Z",      // off-by-one second
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			got := buildPropertyValue("date", in).(map[string]interface{})
+			d := got["date"].(map[string]interface{})
+			if d["start"] != in {
+				t.Errorf("got %q, want %q (real datetime should pass through)", d["start"], in)
+			}
+		})
+	}
+}
+
+func TestBuildPropertyValue_DateRange_StripsMidnightUTC(t *testing.T) {
+	got := buildPropertyValue("date", "2026-06-01T00:00:00Z → 2026-06-05T00:00:00Z").(map[string]interface{})
+	d := got["date"].(map[string]interface{})
+	if d["start"] != "2026-06-01" {
+		t.Errorf("start: got %q, want '2026-06-01'", d["start"])
+	}
+	if d["end"] != "2026-06-05" {
+		t.Errorf("end: got %q, want '2026-06-05'", d["end"])
+	}
+}
+
 func TestBuildPropertyValue_Relation(t *testing.T) {
 	got := buildPropertyValue("relation", []interface{}{"id1", "id2"}).(map[string]interface{})
 	rels := got["relation"].([]interface{})


### PR DESCRIPTION
## Context
- Phase 1 of   #55
- Ship-blocker per [`.context/features/push/features/confirmation-gate.md`](https://github.com/Drexel-UHC/notion-sync/blob/b7ce8fae98293759769298c95077d8a5a20c174b/.context/features/push/features/confirmation-gate.md): push is the only command writing to Notion, no undo.

## Changes
- `BuildPushQueue` helper in [`internal/sync/push.go`](https://github.com/Drexel-UHC/notion-sync/blob/b7ce8fae98293759769298c95077d8a5a20c174b/internal/sync/push.go) — local-only queue scan, no API.
- `--yes` / `-y` flag + `confirmPush` gate in [`cmd/notion-sync/main.go`](https://github.com/Drexel-UHC/notion-sync/blob/b7ce8fae98293759769298c95077d8a5a20c174b/cmd/notion-sync/main.go). TTY → y/N (default N); non-TTY → require `--yes`; `--dry-run` skips gate.
- Preview to stderr (file basenames + count) before prompt.
- Cancellation = exit 0, nothing sent.
- Tests: 4 BuildPushQueue + 6 confirmPush.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)