### PR TITLE
feat(push): phase 2 — validation gate halts run before any Notion write

### DIFF
--- a/.claude/skills/test-push/SKILL.md
+++ b/.claude/skills/test-push/SKILL.md
@@ -104,8 +104,9 @@ The push command iterates **every** `.md` file in the folder and sends each one'
 
 **Phase 1 only needs Page 1.** Delete the other six pages' `.md` files so the push queue contains exactly the canary:
 
-- Keep: `Push- Canary.md` (the `:` in `Push: Canary` is sanitized to `-` on import)
-- Delete: every other `.md` file in `./test-output/push-e2e/notion-sync-test-database-push/`
+- **Filename convention:** the importer writes `.md` files named `<notion-id>.md` (e.g. `35957008-e885-813a-886b-cbb6dd7c1598.md`), NOT title-derived names. Every "edit Page X's `.md`" step below means "edit the file whose name matches Page X's notion-id from the `setup.md` fixture table."
+- Keep: `35957008-e885-813a-886b-cbb6dd7c1598.md` (Page 1 — Canary)
+- Delete: the six `.md` files for Pages 2–7 (notion-ids in `setup.md`)
 - Don't touch: `_database.json`, `AGENTS.md`
 
 Verify: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --dry-run` should show `Push queue (1 file)` listing only the canary.
@@ -172,12 +173,141 @@ Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-p
 
 ---
 
-## Phase 2 — Validation halts (TODO — added by phase 2 PR)
+## Phase 2 — Validation halts (DAG n21 series → n22a)
 
-When phase 2 lands (n21 series + n22a halt aggregation), this section gets steps `V1`...`Vn`. Expected coverage:
-- Multi-file conflict aggregation: every halt reason listed, **nothing** pushed.
-- Single conflict halts the run (current behavior is per-row partial — phase 2 changes this).
-- Non-row file types (AGENTS.md, notion-deleted) classified correctly.
+The validation gate classifies every `.md` against 8 outcomes (n21a–h). Any halt-class file aborts the **entire** run before any Notion write — all-or-nothing. `--force` bypasses the entire gate.
+
+**🚨 NEVER push Page 4 in this phase.** Same rule as Phase 1 — Page 4's rich-text annotations are the phase-3 fixture. Every V step below either operates on a single page's `.md` (Pages 2 / 3 / 6 / 7) or explicitly excludes Page 4 from the folder. If you can't guarantee Page 4 is excluded, stop and re-run Step 1 (clean slate).
+
+**Halt → exit 1.** A halted run prints `Halted: "<title>"` and an enumerated halt list to stdout, plus `push halted by validation gate (N halt(s))` to stderr, and exits **1**. Cancel (Phase 1) is exit 0; halt is exit 1. Don't conflate them.
+
+**Filename quick reference** (from `setup.md`; importer writes `<notion-id>.md`):
+
+| Page | notion-id (filename without `.md`) |
+|---|---|
+| 1 — Canary | `35957008-e885-813a-886b-cbb6dd7c1598` |
+| 2 — Conflict A | `35957008-e885-811d-ae4b-eb73607cc037` |
+| 3 — Conflict B | `35957008-e885-8141-9e44-ef7c58e4a487` |
+| 4 — Formatting (NEVER touch) | `35957008-e885-8192-ab0f-c75e6a011b10` |
+| 5 — Cell-Level | `35957008-e885-815e-8e73-ea79c22f96d4` |
+| 6 — Soft Deleted | `35957008-e885-81e0-83c1-ff9fb4dbfda5` |
+| 7 — Null Edges | `35957008-e885-814f-9f19-c401d454b08d` |
+
+### Step V0: Re-import for Phase 2
+
+Phase 1's Step 4 deleted Pages 2–7 from disk. Phase 2 needs them back.
+
+Run: `./notion-sync.exe import 35957008-e885-80c5-9e34-f4191fd83907 --output ./test-output/push-e2e`
+
+- **Pass:** all 7 `.md` files present in `./test-output/push-e2e/notion-sync-test-database-push/`. `_database.json` and `AGENTS.md` also present.
+
+### Step V1: Single conflict halts the run (n21d)
+
+Edit Page 2's local `.md` (`35957008-e885-811d-ae4b-eb73607cc037.md`): change `notion-last-edited` to `2020-01-01T00:00:00Z` (definitively stale). Don't touch any property values.
+
+Isolate to Page 2: delete every other page's `.md` so the gate halts on Page 2 alone. Keep `_database.json` and `AGENTS.md`.
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes`
+
+- **Pass:**
+  - Exit code **1**
+  - stdout contains `Halted:` and `[conflict]`
+  - stderr contains `push halted by validation gate`
+  - **Notion MCP fetch** of Page 2: `Score` is still **200** (canonical from `setup.md`), proving no UpdatePage fired.
+
+**Revert local edit:** restore Page 2's `notion-last-edited` to its pre-edit value (or just re-run V0 to re-import fresh). No Notion revert needed — nothing was written.
+
+### Step V2: Multi-halt aggregation (n22a)
+
+Re-run V0 if needed for a clean folder. Then:
+
+1. Stale-stamp Page 2's `notion-last-edited` → `2020-01-01T00:00:00Z`.
+2. Stale-stamp Page 3's (`35957008-e885-8141-9e44-ef7c58e4a487.md`) `notion-last-edited` → `2020-01-01T00:00:00Z`.
+3. Drop a `random-stray.md` in the folder with no frontmatter (just `# stray` body).
+4. Delete every other page's `.md` (including Page 4 — critical) so the gate sees exactly Page 2 + Page 3 + the stray.
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes`
+
+- **Pass:**
+  - Exit code **1**
+  - stdout enumerates **3 halts**: Page 2 `[conflict]`, Page 3 `[conflict]`, `random-stray.md` `[stray]`. Fix-once-rerun-once UX — all three listed in one pass, not "fix the first then come back."
+  - Summary line shows a halts count of **3** (the renderer prints `Halts:` followed by aligned whitespace then the number — match loosely on the count, not the spacing).
+  - **Notion MCP fetch** of Page 2 (`Score` 200) and Page 3 (`Score` 300): both unchanged.
+
+**Revert:** re-run V0 to re-import fresh. No Notion revert needed.
+
+### Step V3: Soft-deleted skip (n21b)
+
+Re-run V0. Then:
+
+1. Edit Page 6's local `.md`: add `notion-deleted: true` to its frontmatter.
+2. Keep Page 5's `.md` alongside Page 6 — without a non-deleted file, the queue ends up empty and the CLI short-circuits with `"Nothing to push: no synced .md files in folder."` *before* the validation gate fires (so n21b never gets exercised). Page 5 is the safest neighbor: clean by default, not the phase-3 fixture, and pushing it round-trips its current canonical values without drift.
+3. Delete the other 5 pages' `.md` (Page 4 critical) so the folder has Pages 5 + 6 only.
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes`
+
+- **Pass:**
+  - Exit code **0** — soft-deleted is skip, not halt.
+  - stdout does NOT contain `Halted:`.
+  - stdout shows a Pushed count of **1** (Page 5 round-trip) and a summary line, NOT `"Nothing to push"` (gate ran). The renderer aligns the `Pushed:` line with whitespace — match on the count, not the spacing.
+  - **Notion MCP fetch** of Page 6: `Score` still **600**, all properties unchanged (skip path proven).
+  - **Notion MCP fetch** of Page 5: `Score` still **500** (round-trip with no value drift).
+
+**Revert:** re-run V0 to re-import fresh. Note: V3's push bumps Page 5's Notion `last_edited_time` (the round-trip is a real write). The next V0 re-import realigns local timestamps, so this is harmless across runs — just don't be surprised if Page 5's `last_edited_time` keeps drifting forward across V3 invocations.
+
+### Step V4: Malformed YAML halts (n21g)
+
+Re-run V0. Then:
+
+1. Corrupt Page 7's local `.md` (`35957008-e885-814f-9f19-c401d454b08d.md`): introduce an unclosed quoted string in the frontmatter (e.g. change a property value to `"unclosed`).
+2. Delete every other page's `.md` (Page 4 critical) so the folder has only the broken Page 7.
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes`
+
+- **Pass:**
+  - Exit code **1**
+  - stdout contains `Halted:` and `[malformed]`
+  - The halt's reason mentions `YAML` (so the user knows to fix frontmatter, not hunt for a stray).
+  - **Notion MCP fetch** of Page 7: unchanged (whatever its canonical state was).
+
+**Revert:** re-run V0 to re-import fresh.
+
+### Step V5: `--force` bypasses every halt class
+
+Re-run V0. Then build the worst-case mixed folder:
+
+1. Stale-stamp Page 2's `notion-last-edited` → `2020-01-01T00:00:00Z` (would trigger n21d).
+2. Stale-stamp Page 3's `notion-last-edited` → `2020-01-01T00:00:00Z` (would trigger n21d).
+3. Drop `random-stray.md` with no frontmatter (would trigger n21e).
+4. Edit Page 2's `Score` locally → `2222` and Page 3's `Score` locally → `3333` (the actual writes we expect to land).
+5. Delete every other page's `.md` (Page 4 **critical** — `--force` would otherwise push it and clobber phase-3's formatting fixture).
+
+Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes --force`
+
+- **Pass:**
+  - Exit code **0**
+  - stdout does NOT contain `Halted:` — gate fully bypassed.
+  - stdout shows a Pushed count of **2** (Page 2 + Page 3; the stray has no `notion-id` so `scanPushable` filters it). Match on the count, not the spacing.
+  - **Notion MCP fetch** of Page 2: `Score` is now **2222**.
+  - **Notion MCP fetch** of Page 3: `Score` is now **3333**.
+
+**Revert (mandatory — V5 actually wrote to Notion).** Pick one branch and follow it in order — the two branches need different orderings because re-importing rewrites the entire `.md`, including any local Score edit.
+
+*Branch A — re-import (faster, recommended):*
+1. Drop the stray `random-stray.md`.
+2. Re-run V0 (`./notion-sync.exe import ...`). This pulls Notion's current state — Score `2222`/`3333` and matching `notion-last-edited` — into local Pages 2 & 3.
+3. Edit Page 2's local `Score` → `200` and Page 3's local `Score` → `300`. Timestamps already match Notion, so the gate will pass.
+4. Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes` (no `--force` — proves the gate clears now that local state is sane).
+5. **Notion MCP fetch** of Page 2 (`Score` 200) and Page 3 (`Score` 300): both back to canonical.
+
+*Branch B — hand-fix (no re-import):*
+1. Restore Page 2's local `Score` → `200` and Page 3's local `Score` → `300`.
+2. Drop the stray `random-stray.md`.
+3. Hand-edit Page 2's & Page 3's `notion-last-edited` to match Notion's current `last_edited_time` (fetch via Notion MCP). Required for the gate to clear without `--force`.
+4. Run: `./notion-sync.exe push "./test-output/push-e2e/notion-sync-test-database-push" --yes`.
+5. **Notion MCP fetch** of Page 2 (`Score` 200) and Page 3 (`Score` 300): both back to canonical.
+
+⚠️ Don't mix branches — restoring Score first and then re-importing in step 3 will overwrite your Score edit and round-trip `2222`/`3333` to Notion on the next push.
 
 ## Phase 3 — Cell-level push (TODO — added by phase 3 PR)
 
@@ -200,9 +330,9 @@ Steps `S1`...`Sn`. Expected coverage:
 
 ### Step F1: Final state verification
 
-Notion MCP fetch of the canary page. Compare against **the canonical Step 3 table values hardcoded in this skill** — NOT just the run's own Step 3 fetch. Within-run-only comparison is unsafe: if a prior run left the fixture drifted, a fresh Step 3 fetch records the drifted state and F1 then "matches" itself, silently passing while the bug persists. F1's job is to detect drift against the source-of-truth canonical, full stop.
+Notion MCP fetch of **every page touched by the run** — Pages 1–7 once any phase 2+ step has executed. Compare against **the canonical values hardcoded in `setup.md`** (per-page property tables) — NOT just the run's own Step 3 fetch. Within-run-only comparison is unsafe: if a prior run left a fixture drifted, a fresh Step 3 fetch records the drifted state and F1 then "matches" itself, silently passing while the bug persists. F1's job is to detect drift against the source-of-truth canonical, full stop.
 
-For each canonical property in the Step 3 table:
+**Phase 1 minimum — Page 1 (canary):**
 
 | Property | Canonical value | Notion shape to assert |
 |---|---|---|
@@ -211,6 +341,8 @@ For each canonical property in the Step 3 table:
 | `Category` | `Research` | `select.name` == canonical |
 | `Score` | `100` | `number` == canonical |
 | `Due Date` | `2026-06-01` (date-only) | `date.start` == canonical AND `is_datetime` == `0`/`false` |
+
+**Phase 2 additions — re-fetch Pages 2, 3, 6, 7 against `setup.md` canonicals.** V1/V2 stale-stamp Pages 2 & 3 (must end at `Score` 200 / 300). V3 marks Page 6 deleted in the local file only (Notion-side `Score` 600 must be untouched). V4 corrupts Page 7's local YAML (Notion-side unchanged). V5 actually writes to Notion — its mandatory revert step must restore Page 2 → 200 and Page 3 → 300 before F1 runs. Don't duplicate the canonical values here — read them from `setup.md`'s per-page sections (Pages 2/3/6/7).
 
 If any property's Notion shape doesn't match the canonical, mark the run as TESTS FAILED and list the field + got/want values — don't try to auto-fix; investigate.
 
@@ -243,7 +375,13 @@ Print a summary table:
 | G2   | --yes proceeds, Notion updated          | PASS   |
 | G3   | Revert via push --yes                   | PASS   |
 | G4   | --dry-run skips gate, Notion untouched  | PASS   |
-| F1   | Final state matches snapshot            | PASS   |
+| V0   | Re-import for Phase 2                   | PASS   |
+| V1   | Single conflict halts (n21d)            | PASS   |
+| V2   | Multi-halt aggregation (n22a)           | PASS   |
+| V3   | Soft-deleted skip (n21b)                | PASS   |
+| V4   | Malformed YAML halts (n21g)             | PASS   |
+| V5   | --force bypasses every halt class       | PASS   |
+| F1   | Final state matches canonical (1–7)     | PASS   |
 | F2   | Cleanup                                 | PASS   |
 ```
 

--- a/.context/features/push/backlog/api-call-doubling.md
+++ b/.context/features/push/backlog/api-call-doubling.md
@@ -1,0 +1,37 @@
+# Halve GetPage call volume by reusing the validation pass result
+
+**Status:** backlog (v1.4.0 phase 3)
+**DAG node:** `n21+n22 → n23+`
+**Tier:** performance / cost
+
+## What
+
+Phase 2 added a validation gate (`ValidatePushQueue`) that calls `GetPage` for every linked `.md` to read Notion's `last_edited_time`. The per-row push loop in `PushDatabase` *also* calls `GetPage` for every linked file — first as a TOCTOU defense before `UpdatePage`, then again after the write to grab the precise (non-minute-quantized) timestamp.
+
+For an N-row push with M actual writes, the new flow makes **`2N + 2M` `GetPage` calls** plus M `UpdatePage` calls. The Notion client throttles to ~3 req/s, so the validation pass alone takes ~`N/3` seconds before any write happens.
+
+## Why this matters
+
+- **100-row database, 10 actual property changes:** validation = ~33 s wall time before the first `UpdatePage`. With pre-phase-2 behavior the same push was ~3 s.
+- **All linked files pay**, even ones that won't be modified — `buildPropertyPayload` returning empty (no diff) still incurred the validation `GetPage`.
+- The work is duplicated: the validation pass already fetched Notion's `last_edited_time` for every row, but the push loop refetches it.
+
+## Why deferred to phase 3
+
+Phase 2 is intentionally a pure read+classify pass per the DAG spec (`n21` is a classification node, not a state-passing node). Plumbing the `*ValidationReport` through to the push loop is a phase-3 concern because:
+
+1. Phase 3 will introduce cell-level diffing (`n23+`), which restructures the per-row inner loop anyway. Adding plumbing now then rewriting it next phase is churn.
+2. The TOCTOU defense at `push.go:158-171` is real (Notion can be edited between the gate and the per-row check). Phase 3's per-cell diff will need its own answer to TOCTOU; the optimization should land alongside that design.
+
+## Acceptance
+
+- `PushDatabase` consumes `ValidationReport.Files` instead of calling `GetPage` again in the per-row loop. For Ready-class rows, the gate's `Page` is reused.
+- TOCTOU is either explicitly accepted (gate-then-push is optimistic) or the per-row check stays for the narrow race window — but the GetPage call itself is gone for the common case.
+- A 100-row push with 0 changes makes ≤ 100 + small-constant `GetPage` calls, not ~200.
+- Test: `TestPushDatabase_DoesNotDoubleGetPageCalls` counts `mockNotionClient.getPageCalls` and asserts the bound.
+
+## Touch points
+
+- `internal/sync/push.go` — `PushDatabase` per-row loop (lines ~148-227 today)
+- `internal/sync/validation.go` — possibly expose a `ReadyFiles()` helper on `*ValidationReport`
+- `internal/sync/mock_client_test.go` — add a call counter for `GetPage` so the test above can assert

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -430,15 +430,32 @@ func runRefreshPage(client *notion.Client, folderPath string, force, stripPresig
 // consent. Returns true if push should proceed, false to cancel cleanly
 // (caller exits 0). TTY: y/N prompt, default N. Non-TTY: requires `yes`,
 // otherwise cancels with a stderr hint. Caller must short-circuit on empty
-// queue before calling.
-func confirmPush(queue []string, yes, isTTY bool, stdin io.Reader, stderr io.Writer) bool {
+// queue + empty halts before calling.
+//
+// Local halts (stray .md, malformed YAML — detected without any Notion
+// API call) are surfaced here so the user sees them at consent time
+// instead of confirming a queue and then getting halted on a file they
+// were never shown. The validation gate enumerates the full halt list
+// later; this preview is the early warning.
+func confirmPush(preview *sync.PushPreview, yes, isTTY bool, stdin io.Reader, stderr io.Writer) bool {
 	noun := "file"
-	if len(queue) != 1 {
+	if len(preview.Queue) != 1 {
 		noun = "files"
 	}
-	fmt.Fprintf(stderr, "Push queue (%d %s):\n", len(queue), noun)
-	for _, p := range queue {
+	fmt.Fprintf(stderr, "Push queue (%d %s):\n", len(preview.Queue), noun)
+	for _, p := range preview.Queue {
 		fmt.Fprintf(stderr, "  %s\n", filepath.Base(p))
+	}
+
+	if len(preview.LocalHalts) > 0 {
+		haltNoun := "file"
+		if len(preview.LocalHalts) != 1 {
+			haltNoun = "files"
+		}
+		fmt.Fprintf(stderr, "\nWill halt the run (%d %s — fix before continuing):\n", len(preview.LocalHalts), haltNoun)
+		for _, h := range preview.LocalHalts {
+			fmt.Fprintf(stderr, "  %s — %s\n", filepath.Base(h.Path), h.Reason)
+		}
 	}
 	fmt.Fprintln(stderr)
 
@@ -509,15 +526,15 @@ func runPush(args []string) error {
 	// Push is the only command that writes to Notion; gate fires before any
 	// API call. Skipped under --dry-run since no writes occur.
 	if !*dryRun {
-		queue, err := sync.BuildPushQueue(folderPath)
+		preview, err := sync.BuildPushQueue(folderPath)
 		if err != nil {
 			return err
 		}
-		if len(queue) == 0 {
+		if len(preview.Queue) == 0 && len(preview.LocalHalts) == 0 {
 			fmt.Fprintln(os.Stderr, "Nothing to push: no synced .md files in folder.")
 			return nil
 		}
-		if !confirmPush(queue, yesFlag, isStdinTTY(), os.Stdin, os.Stderr) {
+		if !confirmPush(preview, yesFlag, isStdinTTY(), os.Stdin, os.Stderr) {
 			return nil
 		}
 	}
@@ -551,6 +568,19 @@ func runPush(args []string) error {
 	}
 
 	fmt.Println()
+
+	// Validation halted (DAG n22a) — print the enumerated halt list and
+	// exit non-zero so scripts/CI can detect the abort. No "Done"
+	// message because nothing was pushed.
+	if result.Halted {
+		fmt.Printf("Halted: \"%s\"\n", result.Title)
+		fmt.Printf("  Inspected: %d\n", result.Total)
+		fmt.Printf("  Halts:     %d (nothing pushed — fix all before retrying)\n", len(result.Halts))
+		for _, h := range result.Halts {
+			fmt.Printf("    - %s [%s] — %s\n", filepath.Base(h.Path), haltClassLabel(h.Class), h.Reason)
+		}
+		return fmt.Errorf("push halted by validation gate (%d halt(s))", len(result.Halts))
+	}
 
 	if *dryRun {
 		fmt.Printf("Dry run: \"%s\"\n", result.Title)
@@ -587,6 +617,24 @@ func runPush(args []string) error {
 	}
 
 	return nil
+}
+
+// haltClassLabel renders a Classification as a short user-facing label
+// for the halt list. Mirrors the DAG node taxonomy so the user can map
+// an output line back to the spec without a code dive.
+func haltClassLabel(c sync.Classification) string {
+	switch c {
+	case sync.ClassHaltConflict:
+		return "conflict"
+	case sync.ClassHaltUnexpected:
+		return "stray"
+	case sync.ClassHaltUnreachable:
+		return "unreachable"
+	case sync.ClassHaltMalformed:
+		return "malformed"
+	default:
+		return "halt"
+	}
 }
 
 //// 2.4 List ----

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -576,12 +576,7 @@ func runPush(args []string) error {
 	// exit non-zero so scripts/CI can detect the abort. No "Done"
 	// message because nothing was pushed.
 	if result.Halted {
-		fmt.Printf("Halted: \"%s\"\n", result.Title)
-		fmt.Printf("  Inspected: %d\n", result.Total)
-		fmt.Printf("  Halts:     %d (nothing pushed — fix all before retrying)\n", len(result.Halts))
-		for _, h := range result.Halts {
-			fmt.Printf("    - %s [%s] — %s\n", filepath.Base(h.Path), haltClassLabel(h.Class), h.Reason)
-		}
+		renderHaltedResult(result, os.Stdout)
 		return fmt.Errorf("push halted by validation gate (%d halt(s))", len(result.Halts))
 	}
 
@@ -620,6 +615,19 @@ func runPush(args []string) error {
 	}
 
 	return nil
+}
+
+// renderHaltedResult writes the validation-gate halt summary (DAG n22a)
+// to w. Extracted so the user-visible halt format — header lines, per-halt
+// line shape, and the haltClassLabel mapping — is unit-testable without a
+// subprocess or a fake Notion server.
+func renderHaltedResult(result *sync.PushResult, w io.Writer) {
+	fmt.Fprintf(w, "Halted: \"%s\"\n", result.Title)
+	fmt.Fprintf(w, "  Inspected: %d\n", result.Total)
+	fmt.Fprintf(w, "  Halts:     %d (nothing pushed — fix all before retrying)\n", len(result.Halts))
+	for _, h := range result.Halts {
+		fmt.Fprintf(w, "    - %s [%s] — %s\n", filepath.Base(h.Path), haltClassLabel(h.Class), h.Reason)
+	}
 }
 
 // haltClassLabel renders a Classification as a short user-facing label

--- a/cmd/notion-sync/main.go
+++ b/cmd/notion-sync/main.go
@@ -84,8 +84,11 @@ Commands:
   push      Push local frontmatter property changes back to Notion (properties only, no body)
             Previews the push queue and prompts y/N before any API write (TTY only).
             Non-interactive runs (CI / pipes) must pass --yes; otherwise the run is cancelled.
-            Refuses to push files where Notion has been edited since last sync, unless --force.
-            --force, -f    Push even if Notion has newer edits (overwrites Notion-side changes)
+            Runs a validation gate before any write: stray .md, malformed YAML, conflicting
+            timestamps, or unreachable rows halt the entire run (all-or-nothing).
+            --force, -f    Skip the validation gate entirely. Pushes despite conflicts,
+                           strays, malformed YAML, unreadable files, or unreachable rows.
+                           Use only after manual review — overwrites Notion-side changes.
             --dry-run      Show what would be pushed without writing to Notion (still reads from Notion for conflict detection)
             --yes, -y      Skip the confirmation prompt (required in non-interactive runs)
   list      List all synced databases and pages in a folder
@@ -489,8 +492,8 @@ func isStdinTTY() bool {
 func runPush(args []string) error {
 	fs := flag.NewFlagSet("push", flag.ExitOnError)
 	apiKey := fs.String("api-key", "", "Notion API key")
-	force := fs.Bool("force", false, "Push even if Notion has newer edits")
-	forceShort := fs.Bool("f", false, "Push even if Notion has newer edits (shorthand)")
+	force := fs.Bool("force", false, "Skip the validation gate entirely (bypasses conflicts, strays, malformed YAML, and unreachable rows)")
+	forceShort := fs.Bool("f", false, "Skip the validation gate entirely (shorthand)")
 	dryRun := fs.Bool("dry-run", false, "Show what would be pushed without writing to Notion")
 	yes := fs.Bool("yes", false, "Skip the confirmation prompt (required for non-interactive runs)")
 	yesShort := fs.Bool("y", false, "Skip the confirmation prompt (shorthand)")
@@ -632,6 +635,8 @@ func haltClassLabel(c sync.Classification) string {
 		return "unreachable"
 	case sync.ClassHaltMalformed:
 		return "malformed"
+	case sync.ClassHaltUnreadable:
+		return "unreadable"
 	default:
 		return "halt"
 	}

--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -8,7 +8,15 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/ran-codes/notion-sync/internal/sync"
 )
+
+// previewOf wraps a queue (and optional local halts) into the *PushPreview
+// shape confirmPush now takes. Keeps the tests below readable.
+func previewOf(queue []string, halts ...sync.FileClassification) *sync.PushPreview {
+	return &sync.PushPreview{Queue: queue, LocalHalts: halts}
+}
 
 func TestReorderArgs_FlagsBeforePositional(t *testing.T) {
 	tests := []struct {
@@ -121,7 +129,7 @@ func TestCLI_AgentsMD_OverwritesExisting(t *testing.T) {
 
 func TestConfirmPush_YesFlag_Proceeds(t *testing.T) {
 	var stderr bytes.Buffer
-	ok := confirmPush([]string{"a/page.md"}, true, false, strings.NewReader(""), &stderr)
+	ok := confirmPush(previewOf([]string{"a/page.md"}), true, false, strings.NewReader(""), &stderr)
 	if !ok {
 		t.Error("expected confirmPush to return true with --yes flag")
 	}
@@ -135,7 +143,7 @@ func TestConfirmPush_YesFlag_Proceeds(t *testing.T) {
 // user/agent knows how to opt in.
 func TestConfirmPush_NonTTY_NoFlag_Cancels(t *testing.T) {
 	var stderr bytes.Buffer
-	ok := confirmPush([]string{"a/page.md"}, false, false, strings.NewReader(""), &stderr)
+	ok := confirmPush(previewOf([]string{"a/page.md"}), false, false, strings.NewReader(""), &stderr)
 	if ok {
 		t.Error("expected confirmPush to cancel in non-TTY without --yes")
 	}
@@ -151,7 +159,7 @@ func TestConfirmPush_NonTTY_NoFlag_Cancels(t *testing.T) {
 func TestConfirmPush_TTY_Yes_Proceeds(t *testing.T) {
 	for _, ans := range []string{"y\n", "Y\n", "yes\n", "YES\n"} {
 		var stderr bytes.Buffer
-		ok := confirmPush([]string{"a/page.md"}, false, true, strings.NewReader(ans), &stderr)
+		ok := confirmPush(previewOf([]string{"a/page.md"}), false, true, strings.NewReader(ans), &stderr)
 		if !ok {
 			t.Errorf("answer %q: expected proceed, got cancel\nstderr: %s", ans, stderr.String())
 		}
@@ -163,7 +171,7 @@ func TestConfirmPush_TTY_Yes_Proceeds(t *testing.T) {
 func TestConfirmPush_TTY_DefaultN_Cancels(t *testing.T) {
 	for _, ans := range []string{"\n", "n\n", "N\n", "no\n", "maybe\n", ""} {
 		var stderr bytes.Buffer
-		ok := confirmPush([]string{"a/page.md"}, false, true, strings.NewReader(ans), &stderr)
+		ok := confirmPush(previewOf([]string{"a/page.md"}), false, true, strings.NewReader(ans), &stderr)
 		if ok {
 			t.Errorf("answer %q: expected cancel, got proceed", ans)
 		}
@@ -182,7 +190,7 @@ func TestConfirmPush_Preview_ListsFilesAndCount(t *testing.T) {
 		"notion/db/page-003.md",
 	}
 	var stderr bytes.Buffer
-	confirmPush(queue, true, false, strings.NewReader(""), &stderr)
+	confirmPush(previewOf(queue), true, false, strings.NewReader(""), &stderr)
 
 	out := stderr.String()
 	if !strings.Contains(out, "3 files") {
@@ -199,9 +207,34 @@ func TestConfirmPush_Preview_ListsFilesAndCount(t *testing.T) {
 // Singular noun for one file — small UX detail but worth pinning.
 func TestConfirmPush_Preview_SingularForOneFile(t *testing.T) {
 	var stderr bytes.Buffer
-	confirmPush([]string{"only.md"}, true, false, strings.NewReader(""), &stderr)
+	confirmPush(previewOf([]string{"only.md"}), true, false, strings.NewReader(""), &stderr)
 	if !strings.Contains(stderr.String(), "1 file)") {
 		t.Errorf("expected '1 file)' (singular), got:\n%s", stderr.String())
+	}
+}
+
+// Local halts (stray .md, malformed YAML) must surface in the confirmation
+// preview — otherwise the user confirms a queue and gets halted on a file
+// they were never shown. The DAG calls this the fix-once-rerun-once UX.
+func TestConfirmPush_Preview_ListsLocalHaltsBeforePrompt(t *testing.T) {
+	preview := &sync.PushPreview{
+		Queue: []string{"notion/db/page-001.md"},
+		LocalHalts: []sync.FileClassification{
+			{Path: "notion/db/stray.md", Class: sync.ClassHaltUnexpected, Reason: "no notion-id"},
+			{Path: "notion/db/broken.md", Class: sync.ClassHaltMalformed, Reason: "could not parse YAML"},
+		},
+	}
+	var stderr bytes.Buffer
+	confirmPush(preview, true, false, strings.NewReader(""), &stderr)
+
+	out := stderr.String()
+	if !strings.Contains(out, "Will halt") {
+		t.Errorf("expected halt warning in preview, got:\n%s", out)
+	}
+	for _, name := range []string{"stray.md", "broken.md"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("expected halt list to mention %s, got:\n%s", name, out)
+		}
 	}
 }
 

--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -332,6 +333,65 @@ func TestCLI_Push_Yes_PassesGate(t *testing.T) {
 	}
 	if !strings.Contains(s, "Pushing properties to Notion...") {
 		t.Errorf("expected push flow to start past the gate, got:\n%s", s)
+	}
+}
+
+// renderHaltedResult formats the user-visible halt summary the CLI prints
+// when the validation gate aborts. Pins the exact output shape so a refactor
+// that breaks the "Halted:" header, drops the [class] label, mangles the
+// inspected/halts counts, or stops base-naming the halt path trips this test.
+// The full subprocess CLI test can't reach this code path (the dummy API key
+// dies on schema fetch before the gate fires) — extracting + testing the
+// renderer directly is the path that actually pins the contract.
+func TestRenderHaltedResult_FormatsHeaderAndPerHaltLines(t *testing.T) {
+	halts := []sync.FileClassification{
+		{Path: "/tmp/folder/page-2.md", Class: sync.ClassHaltConflict, Reason: "row changed on Notion since last sync"},
+		{Path: "/tmp/folder/stray.md", Class: sync.ClassHaltUnexpected, Reason: "no notion-id in frontmatter"},
+	}
+	// Total intentionally != len(Halts): pins that the header reads from
+	// result.Total (full inspected count), not from len(Halts).
+	result := &sync.PushResult{
+		Title:  "Test DB",
+		Total:  4,
+		Halted: true,
+		Halts:  halts,
+	}
+	var buf bytes.Buffer
+	renderHaltedResult(result, &buf)
+	out := buf.String()
+
+	// Header: title quoted, inspected count from result.Total (NOT len(Halts)),
+	// halts count + the "nothing pushed" hint.
+	if !strings.Contains(out, `Halted: "Test DB"`) {
+		t.Errorf("expected quoted title in 'Halted:' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Inspected: 4") {
+		t.Errorf("expected 'Inspected: 4' (from result.Total), got:\n%s", out)
+	}
+	if !strings.Contains(out, "Halts:     2 (nothing pushed") {
+		t.Errorf("expected halts count + 'nothing pushed' hint, got:\n%s", out)
+	}
+
+	// Per-halt lines: basename only (not full path), the literal [class] label,
+	// and the reason from the input fixture (matched against the fixture, not a
+	// hardcoded reason slice — keeps this test from breaking when validation.go
+	// rewords the real reason text). The labels are pinned LITERALLY ([conflict],
+	// [stray]) rather than via haltClassLabel(h.Class): asserting against the same
+	// function the renderer calls would be a tautology — if the switch regressed
+	// to return "halt" for every class, both the rendered line and the expectation
+	// would read [halt] and still match. Literal labels make a broken
+	// haltClassLabel switch actually trip this test.
+	wantLabels := []string{"conflict", "stray"} // halts[0]=ClassHaltConflict, halts[1]=ClassHaltUnexpected
+	for i, h := range halts {
+		want := fmt.Sprintf("%s [%s] — %s", filepath.Base(h.Path), wantLabels[i], h.Reason)
+		if !strings.Contains(out, want) {
+			t.Errorf("expected halt line %q, got:\n%s", want, out)
+		}
+	}
+	// Full path must NOT appear — basename only, otherwise output bloats with
+	// the user's tmp paths.
+	if strings.Contains(out, "/tmp/folder/page-2.md") {
+		t.Errorf("expected basename only in halt line, got full path in:\n%s", out)
 	}
 }
 

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -35,7 +35,11 @@ func scanPushable(folderPath string) ([]pushableFile, error) {
 		filePath := filepath.Join(folderPath, entry.Name())
 		content, err := os.ReadFile(filePath)
 		if err != nil {
-			continue
+			// Read failures bubble up — the gate classifies them as
+			// ClassHaltUnreadable, but under --force the gate is skipped, so
+			// silently dropping the file would leave the user unaware their
+			// .md was excluded. Loud > silent.
+			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
 		}
 		fm, err := frontmatter.Parse(string(content))
 		if err != nil || fm == nil {

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -35,11 +35,15 @@ func scanPushable(folderPath string) ([]pushableFile, error) {
 		filePath := filepath.Join(folderPath, entry.Name())
 		content, err := os.ReadFile(filePath)
 		if err != nil {
-			// Read failures bubble up — the gate classifies them as
-			// ClassHaltUnreadable, but under --force the gate is skipped, so
-			// silently dropping the file would leave the user unaware their
-			// .md was excluded. Loud > silent.
-			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
+			// Silent skip is correct here: the validation gate
+			// (ValidatePushQueue) and the preview's scanLocalHalts both
+			// classify unreadable files as ClassHaltUnreadable, so the user
+			// sees them in the halt list. Erroring here would short-circuit
+			// BuildPushQueue before scanLocalHalts runs and turn a nice halt
+			// list into a raw "read foo.md: permission denied" error.
+			// Under --force the gate is skipped — silent drop matches the
+			// rest of yolo mode (strays, malformed YAML also silently skip).
+			continue
 		}
 		fm, err := frontmatter.Parse(string(content))
 		if err != nil || fm == nil {

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -52,11 +52,17 @@ func scanPushable(folderPath string) ([]pushableFile, error) {
 	return files, nil
 }
 
-// BuildPushQueue returns the .md file paths in folderPath that PushDatabase
-// would attempt to push. Used by the confirmation gate (DAG n12b) before any
-// Notion API call. Errors if folderPath isn't a synced database so the user
-// sees "not a sync folder" rather than a misleading "nothing to push".
-func BuildPushQueue(folderPath string) ([]string, error) {
+// BuildPushQueue returns the phase-1 confirmation preview: the .md files
+// PushDatabase would attempt to push, plus any halts detectable from disk
+// alone (stray .md, malformed YAML). Used by the confirmation gate (DAG
+// n12b) before any Notion API call.
+//
+// Errors if folderPath isn't a synced database so the user sees "not a
+// sync folder" rather than a misleading "nothing to push". Surfacing
+// LocalHalts here keeps the preview honest with the validation gate: if
+// strays exist, the user sees them at consent time instead of confirming
+// a queue and then getting halted on a file they were never shown.
+func BuildPushQueue(folderPath string) (*PushPreview, error) {
 	metadata, err := ReadDatabaseMetadata(folderPath)
 	if err != nil {
 		return nil, fmt.Errorf("read metadata: %w", err)
@@ -72,7 +78,11 @@ func BuildPushQueue(folderPath string) ([]string, error) {
 	for _, f := range files {
 		queue = append(queue, f.path)
 	}
-	return queue, nil
+	localHalts, err := scanLocalHalts(folderPath)
+	if err != nil {
+		return nil, err
+	}
+	return &PushPreview{Queue: queue, LocalHalts: localHalts}, nil
 }
 
 // PushDatabase pushes local frontmatter property changes back to Notion.
@@ -131,6 +141,10 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 				}
 			}
 			result.Halted = true
+			// Total reflects everything classified, not just halts — gives
+			// the CLI summary "halted: 3 of 9 inspected" instead of the
+			// useless "Total: 0".
+			result.Total = len(report.Files)
 			if onProgress != nil {
 				onProgress(ProgressPhase{Phase: PhaseComplete})
 			}
@@ -153,7 +167,11 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		notionID := f.fm["notion-id"].(string)
 		localLastEdited, _ := f.fm["notion-last-edited"].(string)
 
-		// Conflict check: compare local last-edited timestamp with Notion's current value.
+		// TOCTOU defense: the validation gate already covered the !Force
+		// common case, but Notion could be edited in the window between
+		// the gate's GetPage and this one. The gate makes per-row halts
+		// nearly impossible in practice; this catches the rare race so
+		// we never overwrite a freshly-edited row.
 		var notionPage *notion.Page
 		if !opts.Force {
 			page, err := opts.Client.GetPage(notionID)

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -116,6 +116,28 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		onProgress(ProgressPhase{Phase: PhasePushScanning})
 	}
 
+	// Validation gate (DAG n21+n22). All-or-nothing: any halt-class file
+	// across the whole folder aborts before any Notion write. --force skips
+	// the gate entirely (existing escape hatch, matches phase-1 behavior).
+	if !opts.Force {
+		report, err := ValidatePushQueue(opts.Client, opts.FolderPath)
+		if err != nil {
+			return nil, err
+		}
+		if report.Halted {
+			for _, f := range report.Files {
+				if f.Class.IsHalt() {
+					result.Halts = append(result.Halts, f)
+				}
+			}
+			result.Halted = true
+			if onProgress != nil {
+				onProgress(ProgressPhase{Phase: PhaseComplete})
+			}
+			return result, nil
+		}
+	}
+
 	files, err := scanPushable(opts.FolderPath)
 	if err != nil {
 		return nil, err

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -488,6 +488,65 @@ func TestPushDatabase_ForcePushesTitleRenameOverConflict(t *testing.T) {
 	}
 }
 
+// n22a integration — when the validation gate halts (any halt-class file),
+// PushDatabase must abort BEFORE any UpdatePage call, even for the rows that
+// classified clean. This is the all-or-nothing contract that phase 2 introduces.
+func TestPushDatabase_ValidationHaltAbortsRun_NoUpdatePageCalls(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	// One ready file + one stray (n21e halt) + one conflict (n21d halt).
+	// All three classified in one pass; the run must NOT push the ready one.
+	files := map[string]string{
+		"ready.md":      "---\nnotion-id: page-ready\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Done\n---\n",
+		"stray.md":      "---\ntitle: stray\n---\n",
+		"conflict.md":   "---\nnotion-id: page-conflict\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Blocked\n---\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+	client.pages["page-ready"] = &notion.Page{ID: "page-ready", LastEditedTime: "2024-01-01T00:00:00Z"}
+	client.pages["page-conflict"] = &notion.Page{ID: "page-conflict", LastEditedTime: "2024-06-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatalf("validation halt is not an error return; surfaced via result.Halted: %v", err)
+	}
+
+	if !result.Halted {
+		t.Fatal("expected result.Halted=true when validation surfaces any halt")
+	}
+	if len(client.updateRequests) != 0 {
+		t.Errorf("expected 0 UpdatePage calls when halted, got %d", len(client.updateRequests))
+	}
+	if result.Pushed != 0 {
+		t.Errorf("expected 0 pushed when halted, got %d", result.Pushed)
+	}
+
+	// Both halts must be enumerated — fix-once-rerun-once UX, not fix-loop.
+	gotHalts := map[string]Classification{}
+	for _, h := range result.Halts {
+		gotHalts[filepath.Base(h.Path)] = h.Class
+	}
+	if gotHalts["stray.md"] != ClassHaltUnexpected {
+		t.Errorf("stray.md: expected ClassHaltUnexpected, got %v", gotHalts["stray.md"])
+	}
+	if gotHalts["conflict.md"] != ClassHaltConflict {
+		t.Errorf("conflict.md: expected ClassHaltConflict, got %v", gotHalts["conflict.md"])
+	}
+}
+
+// n21d → n22a — a single conflicting row halts the entire run (no
+// best-effort push of other rows). Phase 2 contract: validation is
+// all-or-nothing.
 func TestPushDatabase_DetectsConflict(t *testing.T) {
 	dir := t.TempDir()
 	writeDatabaseMeta(t, dir, "db-001")
@@ -519,8 +578,11 @@ func TestPushDatabase_DetectsConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result.Conflicts != 1 {
-		t.Errorf("expected 1 conflict, got %d", result.Conflicts)
+	if !result.Halted {
+		t.Error("expected result.Halted=true on conflict (phase 2 gate)")
+	}
+	if len(result.Halts) != 1 || result.Halts[0].Class != ClassHaltConflict {
+		t.Errorf("expected 1 ClassHaltConflict in Halts, got %v", result.Halts)
 	}
 	if len(client.updateRequests) != 0 {
 		t.Error("expected no UpdatePage calls on conflict")
@@ -906,7 +968,11 @@ func TestBuildPushQueue_ErrorsWhenMetadataMissing(t *testing.T) {
 // Parity contract: the gate's preview must equal the action. BuildPushQueue
 // (preview) and PushDatabase (action) both call scanPushable, so this test
 // pins the invariant — if anyone re-introduces a divergent filter, this
-// fails.
+// fails. Note: the unexpected-stray case (n21e) is excluded here because
+// phase 2's validation gate now halts on it before the per-row loop runs;
+// see TestPushDatabase_ValidationHaltAbortsRun_NoUpdatePageCalls for that
+// contract. This test still pins parity over the AGENTS.md / deleted /
+// non-markdown skip cases.
 func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
 	dir := t.TempDir()
 	writeDatabaseMeta(t, dir, "db-001")
@@ -918,7 +984,6 @@ func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
 		"keep-001.md":      "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\nnotion-database-id: db-001\n---\n",
 		"keep-002.md":      "---\nnotion-id: page-002\nnotion-last-edited: 2024-01-01T00:00:00Z\nnotion-database-id: db-001\n---\n",
 		"AGENTS.md":        "# Guide for downstream agents\n",
-		"no-notion-id.md":  "---\ntitle: stray\n---\n",
 		"deleted.md":       "---\nnotion-id: page-deleted\nnotion-deleted: true\n---\n",
 		"not-markdown.txt": "ignored",
 	}
@@ -960,7 +1025,7 @@ func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
 			t.Errorf("queue missing %s; got %v", want, queue)
 		}
 	}
-	for _, exclude := range []string{"AGENTS.md", "no-notion-id.md", "deleted.md", "not-markdown.txt"} {
+	for _, exclude := range []string{"AGENTS.md", "deleted.md", "not-markdown.txt"} {
 		if queueBasenames[exclude] {
 			t.Errorf("queue should not include %s; got %v", exclude, queue)
 		}

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -1104,6 +1104,57 @@ func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
 	}
 }
 
+// --force bypasses the entire validation gate, not just conflict detection.
+// A folder containing every halt class (stray, malformed YAML, conflict)
+// alongside a clean row must still push the linked rows under --force, with
+// Halted=false and zero entries in result.Halts. Pins the expanded escape-
+// hatch semantics so a future tightening (e.g. "force only bypasses
+// conflicts") can't silently break callers who rely on yolo mode.
+func TestPushDatabase_ForceBypassesAllHaltClasses(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	files := map[string]string{
+		"ready.md":     "---\nnotion-id: page-ready\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Done\n---\n",
+		"conflict.md":  "---\nnotion-id: page-conflict\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Blocked\n---\n",
+		"stray.md":     "---\ntitle: stray\n---\n",
+		"malformed.md": "---\nnotion-id: \"unclosed\nStatus: Done\n---\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+	client.pages["page-ready"] = &notion.Page{ID: "page-ready", LastEditedTime: "2024-01-01T00:00:00Z"}
+	// Notion's timestamp is newer — would be n21d under the gate, force must override.
+	client.pages["page-conflict"] = &notion.Page{ID: "page-conflict", LastEditedTime: "2024-06-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, Force: true}, nil)
+	if err != nil {
+		t.Fatalf("force push must not error on halt-class fixtures: %v", err)
+	}
+	if result.Halted {
+		t.Error("--force must skip the validation gate (Halted=false)")
+	}
+	if len(result.Halts) != 0 {
+		t.Errorf("--force must produce no Halts entries, got %v", result.Halts)
+	}
+	// Both linked rows push; stray and malformed are filtered by scanPushable
+	// (no notion-id / unparseable), not by the gate.
+	if len(client.updateRequests) != 2 {
+		t.Errorf("expected 2 UpdatePage calls under --force (ready + conflict), got %d", len(client.updateRequests))
+	}
+	if result.Pushed != 2 {
+		t.Errorf("expected Pushed=2 under --force, got %d", result.Pushed)
+	}
+}
+
 // writeDatabaseMeta writes a minimal _database.json for tests.
 func writeDatabaseMeta(t *testing.T, dir, dbID string) {
 	t.Helper()

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -896,20 +896,26 @@ func TestBuildPushQueue_IncludesLinkedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	queue, err := BuildPushQueue(dir)
+	preview, err := BuildPushQueue(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(queue) != 1 {
-		t.Fatalf("expected 1 file, got %d (%v)", len(queue), queue)
+	if len(preview.Queue) != 1 {
+		t.Fatalf("expected 1 file, got %d (%v)", len(preview.Queue), preview.Queue)
 	}
-	if filepath.Base(queue[0]) != "page-001.md" {
-		t.Errorf("expected page-001.md, got %s", queue[0])
+	if filepath.Base(preview.Queue[0]) != "page-001.md" {
+		t.Errorf("expected page-001.md, got %s", preview.Queue[0])
+	}
+	if len(preview.LocalHalts) != 0 {
+		t.Errorf("expected no local halts on a clean queue, got %v", preview.LocalHalts)
 	}
 }
 
-// AGENTS.md (no notion-id) and arbitrary unlinked files must be excluded —
-// the queue is "rows we'd push to Notion," and these aren't rows.
+// AGENTS.md (no notion-id) is excluded from the queue and silently. A
+// stray .md without notion-id is also excluded from the queue but surfaces
+// in LocalHalts so the confirmation prompt can warn the user before they
+// consent — otherwise the validation gate would halt on a file the user
+// was never shown (fix-loop UX).
 func TestBuildPushQueue_SkipsFilesWithoutNotionID(t *testing.T) {
 	dir := t.TempDir()
 	writeDatabaseMeta(t, dir, "db-001")
@@ -921,12 +927,58 @@ func TestBuildPushQueue_SkipsFilesWithoutNotionID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	queue, err := BuildPushQueue(dir)
+	preview, err := BuildPushQueue(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(queue) != 0 {
-		t.Errorf("expected empty queue, got %v", queue)
+	if len(preview.Queue) != 0 {
+		t.Errorf("expected empty queue, got %v", preview.Queue)
+	}
+	if len(preview.LocalHalts) != 1 {
+		t.Fatalf("expected stray.md to surface as a local halt, got %v", preview.LocalHalts)
+	}
+	got := preview.LocalHalts[0]
+	if filepath.Base(got.Path) != "stray.md" {
+		t.Errorf("expected stray.md in local halts, got %s", got.Path)
+	}
+	if got.Class != ClassHaltUnexpected {
+		t.Errorf("expected ClassHaltUnexpected, got %v", got.Class)
+	}
+	if got.Reason == "" {
+		t.Error("local halts must populate Reason for the user")
+	}
+}
+
+// Malformed YAML is a locally-detectable halt — surfaces in LocalHalts so
+// the confirmation prompt warns before the validation gate halts on it.
+// Reason must mention YAML parsing, not "no notion-id" (that would send
+// the user hunting for a stray file when the issue is corrupt frontmatter).
+func TestBuildPushQueue_MalformedYAMLSurfacesAsLocalHalt(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	// Unclosed quote → yaml.Unmarshal returns an error.
+	bad := "---\nnotion-id: \"unclosed\nStatus: Done\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "broken.md"), []byte(bad), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := BuildPushQueue(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(preview.Queue) != 0 {
+		t.Errorf("expected empty queue, got %v", preview.Queue)
+	}
+	if len(preview.LocalHalts) != 1 {
+		t.Fatalf("expected 1 local halt for malformed YAML, got %v", preview.LocalHalts)
+	}
+	got := preview.LocalHalts[0]
+	if got.Class != ClassHaltMalformed {
+		t.Errorf("expected ClassHaltMalformed, got %v", got.Class)
+	}
+	if !strings.Contains(got.Reason, "YAML") && !strings.Contains(got.Reason, "yaml") {
+		t.Errorf("expected reason to mention YAML, got %q", got.Reason)
 	}
 }
 
@@ -939,12 +991,15 @@ func TestBuildPushQueue_SkipsDeletedEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	queue, err := BuildPushQueue(dir)
+	preview, err := BuildPushQueue(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(queue) != 0 {
-		t.Errorf("expected deleted entry to be skipped, got %v", queue)
+	if len(preview.Queue) != 0 {
+		t.Errorf("expected deleted entry to be skipped, got %v", preview.Queue)
+	}
+	if len(preview.LocalHalts) != 0 {
+		t.Errorf("deleted entries are not halts, got %v", preview.LocalHalts)
 	}
 }
 
@@ -965,25 +1020,24 @@ func TestBuildPushQueue_ErrorsWhenMetadataMissing(t *testing.T) {
 	}
 }
 
-// Parity contract: the gate's preview must equal the action. BuildPushQueue
-// (preview) and PushDatabase (action) both call scanPushable, so this test
-// pins the invariant — if anyone re-introduces a divergent filter, this
-// fails. Note: the unexpected-stray case (n21e) is excluded here because
-// phase 2's validation gate now halts on it before the per-row loop runs;
-// see TestPushDatabase_ValidationHaltAbortsRun_NoUpdatePageCalls for that
-// contract. This test still pins parity over the AGENTS.md / deleted /
-// non-markdown skip cases.
+// Parity contract: the preview must agree with the action. BuildPushQueue
+// (preview) and PushDatabase (action) both call scanPushable for the queue,
+// and BuildPushQueue.LocalHalts uses the same notion-id rule the validation
+// gate uses for ClassHaltUnexpected — so a stray file that halts the run
+// is the same stray file the user saw at confirmation time. This test
+// pins both invariants: queue parity over skip cases, halt parity over
+// stray cases.
 func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
 	dir := t.TempDir()
 	writeDatabaseMeta(t, dir, "db-001")
 
 	// Mix of pushable + every kind of non-pushable file the filter should
-	// exclude. If the two code paths disagree on any of these, the gate is
-	// a lie.
+	// exclude, plus a stray that the gate will halt on.
 	files := map[string]string{
 		"keep-001.md":      "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\nnotion-database-id: db-001\n---\n",
 		"keep-002.md":      "---\nnotion-id: page-002\nnotion-last-edited: 2024-01-01T00:00:00Z\nnotion-database-id: db-001\n---\n",
 		"AGENTS.md":        "# Guide for downstream agents\n",
+		"stray.md":         "---\ntitle: stray\n---\n",
 		"deleted.md":       "---\nnotion-id: page-deleted\nnotion-deleted: true\n---\n",
 		"not-markdown.txt": "ignored",
 	}
@@ -993,7 +1047,7 @@ func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
 		}
 	}
 
-	queue, err := BuildPushQueue(dir)
+	preview, err := BuildPushQueue(dir)
 	if err != nil {
 		t.Fatalf("BuildPushQueue: %v", err)
 	}
@@ -1013,21 +1067,39 @@ func TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet(t *testing.T) {
 		t.Fatalf("PushDatabase: %v", err)
 	}
 
-	if result.Total != len(queue) {
-		t.Fatalf("preview/action divergence: BuildPushQueue=%d PushDatabase.Total=%d", len(queue), result.Total)
+	// Action halts on stray.md; preview must surface it too.
+	if !result.Halted {
+		t.Fatalf("expected validation to halt on stray.md")
 	}
-	queueBasenames := make(map[string]bool, len(queue))
-	for _, p := range queue {
+	if len(preview.LocalHalts) != 1 || filepath.Base(preview.LocalHalts[0].Path) != "stray.md" {
+		t.Errorf("preview must surface stray.md as a local halt, got %v", preview.LocalHalts)
+	}
+	// Halt-class parity: every local halt must show up as a halt in the
+	// gate's report (the action). If the preview warns about a stray and
+	// the gate doesn't halt on it, the warning is a lie.
+	gateHaltPaths := map[string]bool{}
+	for _, h := range result.Halts {
+		gateHaltPaths[filepath.Base(h.Path)] = true
+	}
+	for _, h := range preview.LocalHalts {
+		if !gateHaltPaths[filepath.Base(h.Path)] {
+			t.Errorf("preview/gate divergence: %s in LocalHalts but not in PushResult.Halts", filepath.Base(h.Path))
+		}
+	}
+
+	// Queue parity over the non-halt cases.
+	queueBasenames := make(map[string]bool, len(preview.Queue))
+	for _, p := range preview.Queue {
 		queueBasenames[filepath.Base(p)] = true
 	}
 	for _, want := range []string{"keep-001.md", "keep-002.md"} {
 		if !queueBasenames[want] {
-			t.Errorf("queue missing %s; got %v", want, queue)
+			t.Errorf("queue missing %s; got %v", want, preview.Queue)
 		}
 	}
-	for _, exclude := range []string{"AGENTS.md", "deleted.md", "not-markdown.txt"} {
+	for _, exclude := range []string{"AGENTS.md", "stray.md", "deleted.md", "not-markdown.txt"} {
 		if queueBasenames[exclude] {
-			t.Errorf("queue should not include %s; got %v", exclude, queue)
+			t.Errorf("queue should not include %s; got %v", exclude, preview.Queue)
 		}
 	}
 }

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -76,6 +76,16 @@ type PushOptions struct {
 	DryRun     bool // report planned changes without writing
 }
 
+// PushPreview is what the phase-1 confirmation gate displays to the user
+// before any Notion write. Queue is the .md paths that would be pushed if
+// validation passes; LocalHalts enumerates halts detectable without a
+// Notion API call (stray .md, malformed YAML). Network-dependent halts
+// (conflicts, unreachable) only surface later at the validation gate.
+type PushPreview struct {
+	Queue      []string
+	LocalHalts []FileClassification
+}
+
 // PushResult contains the result of a push operation.
 type PushResult struct {
 	Title         string

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -87,4 +87,9 @@ type PushResult struct {
 	Failed        int
 	Errors        []string
 	ConflictFiles []string
+	// Halted is true iff the validation gate (DAG n22a) aborted the run before
+	// any Notion write. When true, Halts enumerates every halt-class file from
+	// the validation pass so the caller can surface them all at once.
+	Halted bool
+	Halts  []FileClassification
 }

--- a/internal/sync/validation.go
+++ b/internal/sync/validation.go
@@ -21,14 +21,16 @@ const (
 	ClassHaltUnexpected                        // n21e — unlinked, not AGENTS.md
 	ClassHaltUnreachable                       // n21f — Notion unreachable during read
 	ClassHaltMalformed                         // n21g — YAML frontmatter could not be parsed
+	ClassHaltUnreadable                        // n21h — file could not be read from disk
 )
 
-// IsHalt returns true for the four halt-class values.
+// IsHalt returns true for any halt-class value.
 func (c Classification) IsHalt() bool {
 	return c == ClassHaltConflict ||
 		c == ClassHaltUnexpected ||
 		c == ClassHaltUnreachable ||
-		c == ClassHaltMalformed
+		c == ClassHaltMalformed ||
+		c == ClassHaltUnreadable
 }
 
 // FileClassification is one file's row in the validation report.
@@ -97,7 +99,16 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
+			// IO errors (permission denied, transient FS hiccup) classify as
+			// halt rather than abort the whole pass — surfaces the file in
+			// the halt list with a fixable reason instead of dropping the
+			// entire validation report on the floor.
+			add(FileClassification{
+				Path:   fullPath,
+				Class:  ClassHaltUnreadable,
+				Reason: fmt.Sprintf("could not read file: %v", err),
+			})
+			continue
 		}
 		fm, parseErr := frontmatter.Parse(string(content))
 		if parseErr != nil {
@@ -192,7 +203,12 @@ func scanLocalHalts(folderPath string) ([]FileClassification, error) {
 		fullPath := filepath.Join(folderPath, entry.Name())
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
+			halts = append(halts, FileClassification{
+				Path:   fullPath,
+				Class:  ClassHaltUnreadable,
+				Reason: fmt.Sprintf("could not read file: %v", err),
+			})
+			continue
 		}
 		fm, parseErr := frontmatter.Parse(string(content))
 		if parseErr != nil {

--- a/internal/sync/validation.go
+++ b/internal/sync/validation.go
@@ -1,0 +1,137 @@
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ran-codes/notion-sync/internal/frontmatter"
+)
+
+// Classification is a single file's outcome from the validation pass (DAG n21).
+// Halt-class values cause the whole run to abort at n22a; skip/ready proceed.
+type Classification int
+
+const (
+	ClassSkipAgentsMD    Classification = iota // n21a — generated guide, not a row
+	ClassSkipDeleted                           // n21b — already soft-deleted
+	ClassReady                                 // n21c — linked, timestamps match
+	ClassHaltConflict                          // n21d — Notion edited since last sync
+	ClassHaltUnexpected                        // n21e — unlinked, not AGENTS.md
+	ClassHaltUnreachable                       // n21f — Notion unreachable during read
+)
+
+// IsHalt returns true for the three halt-class values (n21d/n21e/n21f).
+func (c Classification) IsHalt() bool {
+	return c == ClassHaltConflict || c == ClassHaltUnexpected || c == ClassHaltUnreachable
+}
+
+// FileClassification is one file's row in the validation report.
+type FileClassification struct {
+	Path     string
+	Class    Classification
+	Reason   string // populated for halts; user-facing
+	NotionID string // empty when not applicable (AGENTS.md, unexpected)
+}
+
+// ValidationReport is the result of n21+n22 across every file in folderPath.
+type ValidationReport struct {
+	Files  []FileClassification
+	Halted bool // true iff any FileClassification has a halt-class
+}
+
+// ValidatePushQueue runs the n21+n22 pass: classify every .md in folderPath,
+// then set Halted = true if any classification is a halt class. Pure
+// read+classify — no writes, no UpdatePage calls.
+func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationReport, error) {
+	dirEntries, err := os.ReadDir(folderPath)
+	if err != nil {
+		return nil, fmt.Errorf("read folder: %w", err)
+	}
+
+	report := &ValidationReport{}
+	for _, entry := range dirEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		fullPath := filepath.Join(folderPath, entry.Name())
+		if entry.Name() == "AGENTS.md" {
+			report.Files = append(report.Files, FileClassification{
+				Path:  fullPath,
+				Class: ClassSkipAgentsMD,
+			})
+			continue
+		}
+
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
+		}
+		fm, _ := frontmatter.Parse(string(content))
+		if fm == nil {
+			fm = map[string]interface{}{}
+		}
+
+		if deleted, _ := fm["notion-deleted"].(bool); deleted {
+			notionID, _ := fm["notion-id"].(string)
+			report.Files = append(report.Files, FileClassification{
+				Path:     fullPath,
+				Class:    ClassSkipDeleted,
+				NotionID: notionID,
+			})
+			continue
+		}
+
+		notionID, hasID := fm["notion-id"].(string)
+		if !hasID || notionID == "" {
+			report.Files = append(report.Files, FileClassification{
+				Path:   fullPath,
+				Class:  ClassHaltUnexpected,
+				Reason: "file has no notion-id and is not AGENTS.md — does not belong to this synced folder",
+			})
+			continue
+		}
+
+		localLastEdited, _ := fm["notion-last-edited"].(string)
+		page, err := client.GetPage(notionID)
+		if err != nil {
+			report.Files = append(report.Files, FileClassification{
+				Path:     fullPath,
+				Class:    ClassHaltUnreachable,
+				NotionID: notionID,
+				Reason:   fmt.Sprintf("could not read Notion last_edited_time: %v", err),
+			})
+			continue
+		}
+		if timestampsEqual(localLastEdited, page.LastEditedTime) {
+			report.Files = append(report.Files, FileClassification{
+				Path:     fullPath,
+				Class:    ClassReady,
+				NotionID: notionID,
+			})
+			continue
+		}
+
+		report.Files = append(report.Files, FileClassification{
+			Path:     fullPath,
+			Class:    ClassHaltConflict,
+			NotionID: notionID,
+			Reason: fmt.Sprintf(
+				"Notion's row has changed since last sync (local %s, Notion %s) — refresh before pushing",
+				localLastEdited, page.LastEditedTime,
+			),
+		})
+	}
+
+	// n22 — single-source-of-truth aggregation: Halted is derived from the
+	// classifications, not maintained inline at every halt site (where it
+	// would be one missed assignment away from a silent gate-bypass).
+	for _, f := range report.Files {
+		if f.Class.IsHalt() {
+			report.Halted = true
+			break
+		}
+	}
+	return report, nil
+}

--- a/internal/sync/validation.go
+++ b/internal/sync/validation.go
@@ -20,19 +20,29 @@ const (
 	ClassHaltConflict                          // n21d — Notion edited since last sync
 	ClassHaltUnexpected                        // n21e — unlinked, not AGENTS.md
 	ClassHaltUnreachable                       // n21f — Notion unreachable during read
+	ClassHaltMalformed                         // n21g — YAML frontmatter could not be parsed
 )
 
-// IsHalt returns true for the three halt-class values (n21d/n21e/n21f).
+// IsHalt returns true for the four halt-class values.
 func (c Classification) IsHalt() bool {
-	return c == ClassHaltConflict || c == ClassHaltUnexpected || c == ClassHaltUnreachable
+	return c == ClassHaltConflict ||
+		c == ClassHaltUnexpected ||
+		c == ClassHaltUnreachable ||
+		c == ClassHaltMalformed
 }
 
 // FileClassification is one file's row in the validation report.
+//
+// NotionID is populated whenever the file declares one in frontmatter
+// (Ready, ClassHaltConflict, ClassHaltUnreachable, and ClassSkipDeleted
+// for soft-deleted rows that still carry their original notion-id). It's
+// empty for ClassSkipAgentsMD, ClassHaltUnexpected, ClassHaltMalformed,
+// and any ClassSkipDeleted file whose frontmatter never carried notion-id.
 type FileClassification struct {
 	Path     string
 	Class    Classification
 	Reason   string // populated for halts; user-facing
-	NotionID string // empty when not applicable (AGENTS.md, unexpected)
+	NotionID string
 }
 
 // ValidationReport is the result of n21+n22 across every file in folderPath.
@@ -41,9 +51,15 @@ type ValidationReport struct {
 	Halted bool // true iff any FileClassification has a halt-class
 }
 
-// ValidatePushQueue runs the n21+n22 pass: classify every .md in folderPath,
-// then set Halted = true if any classification is a halt class. Pure
-// read+classify — no writes, no UpdatePage calls.
+// ValidatePushQueue runs the n21+n22 pass: classify every .md in folderPath
+// and flip Halted on any halt-class outcome. Pure read+classify — no writes,
+// no UpdatePage calls.
+//
+// This is a classifier-only function: it assumes folder identity (e.g.
+// _database.json presence) has already been validated upstream by the
+// caller. PushDatabase does that check before invoking the gate; direct
+// callers must do the same or accept that the report says nothing about
+// whether the folder is a real synced database.
 func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationReport, error) {
 	dirEntries, err := os.ReadDir(folderPath)
 	if err != nil {
@@ -51,13 +67,28 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 	}
 
 	report := &ValidationReport{}
+	// add appends a classification and flips Halted in lockstep, so Halted
+	// can never drift out of sync with the underlying classifications. The
+	// rule is centralized here (not at every call site) — one bug-fix
+	// surface, no missed assignments.
+	add := func(fc FileClassification) {
+		report.Files = append(report.Files, fc)
+		if fc.Class.IsHalt() {
+			report.Halted = true
+		}
+	}
+
 	for _, entry := range dirEntries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
 			continue
 		}
 		fullPath := filepath.Join(folderPath, entry.Name())
-		if entry.Name() == "AGENTS.md" {
-			report.Files = append(report.Files, FileClassification{
+		// Case-insensitive: defensive on Windows / default-config macOS,
+		// where agents.md or Agents.md could land here. Misclassifying
+		// the generated agents guide as a stray would halt the run for
+		// the user's filesystem casing alone.
+		if strings.EqualFold(entry.Name(), "AGENTS.md") {
+			add(FileClassification{
 				Path:  fullPath,
 				Class: ClassSkipAgentsMD,
 			})
@@ -68,14 +99,22 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
 		}
-		fm, _ := frontmatter.Parse(string(content))
+		fm, parseErr := frontmatter.Parse(string(content))
+		if parseErr != nil {
+			add(FileClassification{
+				Path:   fullPath,
+				Class:  ClassHaltMalformed,
+				Reason: fmt.Sprintf("could not parse YAML frontmatter: %v", parseErr),
+			})
+			continue
+		}
 		if fm == nil {
 			fm = map[string]interface{}{}
 		}
 
 		if deleted, _ := fm["notion-deleted"].(bool); deleted {
 			notionID, _ := fm["notion-id"].(string)
-			report.Files = append(report.Files, FileClassification{
+			add(FileClassification{
 				Path:     fullPath,
 				Class:    ClassSkipDeleted,
 				NotionID: notionID,
@@ -85,7 +124,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 
 		notionID, hasID := fm["notion-id"].(string)
 		if !hasID || notionID == "" {
-			report.Files = append(report.Files, FileClassification{
+			add(FileClassification{
 				Path:   fullPath,
 				Class:  ClassHaltUnexpected,
 				Reason: "file has no notion-id and is not AGENTS.md — does not belong to this synced folder",
@@ -96,7 +135,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 		localLastEdited, _ := fm["notion-last-edited"].(string)
 		page, err := client.GetPage(notionID)
 		if err != nil {
-			report.Files = append(report.Files, FileClassification{
+			add(FileClassification{
 				Path:     fullPath,
 				Class:    ClassHaltUnreachable,
 				NotionID: notionID,
@@ -105,7 +144,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 			continue
 		}
 		if timestampsEqual(localLastEdited, page.LastEditedTime) {
-			report.Files = append(report.Files, FileClassification{
+			add(FileClassification{
 				Path:     fullPath,
 				Class:    ClassReady,
 				NotionID: notionID,
@@ -113,7 +152,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 			continue
 		}
 
-		report.Files = append(report.Files, FileClassification{
+		add(FileClassification{
 			Path:     fullPath,
 			Class:    ClassHaltConflict,
 			NotionID: notionID,
@@ -123,15 +162,61 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 			),
 		})
 	}
+	return report, nil
+}
 
-	// n22 — single-source-of-truth aggregation: Halted is derived from the
-	// classifications, not maintained inline at every halt site (where it
-	// would be one missed assignment away from a silent gate-bypass).
-	for _, f := range report.Files {
-		if f.Class.IsHalt() {
-			report.Halted = true
-			break
+// scanLocalHalts walks folderPath and returns the halt-class files that
+// can be detected without any Notion API call: ClassHaltUnexpected (stray
+// .md missing notion-id) and ClassHaltMalformed (corrupt YAML frontmatter).
+//
+// Used by BuildPushQueue so the phase-1 confirmation preview can warn the
+// user about locally-detectable halts before they consent. Without this,
+// the user confirms a queue, validation halts on a stray they were never
+// shown, and they get the fix-loop UX phase 2's halt enumerator was meant
+// to avoid. Network-dependent halts (Conflict, Unreachable) still only
+// surface at the validation gate — by definition we can't predict them
+// from disk alone.
+func scanLocalHalts(folderPath string) ([]FileClassification, error) {
+	dirEntries, err := os.ReadDir(folderPath)
+	if err != nil {
+		return nil, fmt.Errorf("read folder: %w", err)
+	}
+	var halts []FileClassification
+	for _, entry := range dirEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		if strings.EqualFold(entry.Name(), "AGENTS.md") {
+			continue
+		}
+		fullPath := filepath.Join(folderPath, entry.Name())
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", entry.Name(), err)
+		}
+		fm, parseErr := frontmatter.Parse(string(content))
+		if parseErr != nil {
+			halts = append(halts, FileClassification{
+				Path:   fullPath,
+				Class:  ClassHaltMalformed,
+				Reason: fmt.Sprintf("could not parse YAML frontmatter: %v", parseErr),
+			})
+			continue
+		}
+		if fm == nil {
+			fm = map[string]interface{}{}
+		}
+		if deleted, _ := fm["notion-deleted"].(bool); deleted {
+			continue
+		}
+		notionID, hasID := fm["notion-id"].(string)
+		if !hasID || notionID == "" {
+			halts = append(halts, FileClassification{
+				Path:   fullPath,
+				Class:  ClassHaltUnexpected,
+				Reason: "file has no notion-id and is not AGENTS.md — does not belong to this synced folder",
+			})
 		}
 	}
-	return report, nil
+	return halts, nil
 }

--- a/internal/sync/validation_test.go
+++ b/internal/sync/validation_test.go
@@ -1,0 +1,313 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ran-codes/notion-sync/internal/notion"
+)
+
+// n21a — AGENTS.md is the generated downstream-agent guide; never a Notion
+// row. Validation must classify it as skip (not halt-unexpected) so its
+// presence in a synced folder doesn't abort the run.
+func TestValidate_n21a_AgentsMDClassifiedAsSkip(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# Agent guide\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	got := report.Files[0]
+	if filepath.Base(got.Path) != "AGENTS.md" {
+		t.Errorf("expected AGENTS.md, got %s", got.Path)
+	}
+	if got.Class != ClassSkipAgentsMD {
+		t.Errorf("expected ClassSkipAgentsMD, got %v", got.Class)
+	}
+	if report.Halted {
+		t.Error("AGENTS.md alone must not halt the run")
+	}
+}
+
+// n21b — `notion-deleted: true` marks a soft-deleted row. Push must skip,
+// not halt: the user has already accepted the row is gone, and the next
+// refresh will reconcile.
+func TestValidate_n21b_DeletedClassifiedAsSkip(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-001\nnotion-deleted: true\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	if report.Files[0].Class != ClassSkipDeleted {
+		t.Errorf("expected ClassSkipDeleted, got %v", report.Files[0].Class)
+	}
+	if report.Halted {
+		t.Error("deleted row must not halt the run")
+	}
+}
+
+// n21e — a .md without `notion-id` and not named AGENTS.md is unexpected:
+// it doesn't belong to the synced database. Push must HALT the run rather
+// than silently ignoring (could be a misplaced file the user thinks is
+// being synced) or pushing (no row to push to).
+func TestValidate_n21e_StrayMDClassifiedAsHaltUnexpected(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	if err := os.WriteFile(filepath.Join(dir, "stray.md"), []byte("---\ntitle: stray\n---\nbody\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	if report.Files[0].Class != ClassHaltUnexpected {
+		t.Errorf("expected ClassHaltUnexpected, got %v", report.Files[0].Class)
+	}
+	if report.Files[0].Reason == "" {
+		t.Error("halt classifications must populate Reason for the user")
+	}
+	if !report.Halted {
+		t.Error("a halt-class file must flip Halted=true")
+	}
+}
+
+// n21c — file linked to Notion (notion-id present) and Notion's current
+// last_edited_time matches the local notion-last-edited stamp. Safe to push.
+func TestValidate_n21c_MatchedTimestampsClassifiedAsReady(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	if report.Files[0].Class != ClassReady {
+		t.Errorf("expected ClassReady, got %v", report.Files[0].Class)
+	}
+	if report.Files[0].NotionID != "page-001" {
+		t.Errorf("expected NotionID=page-001, got %q", report.Files[0].NotionID)
+	}
+	if report.Halted {
+		t.Error("a clean file must not halt the run")
+	}
+}
+
+// n21d — file linked, but Notion's last_edited_time has advanced past the
+// local stamp. Pushing would clobber whatever changed in Notion since the
+// last sync. HALT (not skip) so the user reconciles before any writes.
+func TestValidate_n21d_MismatchedTimestampsClassifiedAsHaltConflict(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	// Notion's row has advanced past the local stamp.
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-06-01T00:00:00Z"}
+
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	got := report.Files[0]
+	if got.Class != ClassHaltConflict {
+		t.Errorf("expected ClassHaltConflict, got %v", got.Class)
+	}
+	if got.Reason == "" {
+		t.Error("conflict halt must populate Reason")
+	}
+	if got.NotionID != "page-001" {
+		t.Errorf("expected NotionID=page-001, got %q", got.NotionID)
+	}
+	if !report.Halted {
+		t.Error("a conflict must flip Halted=true")
+	}
+}
+
+// n21f — GetPage failed during the validation read (network error, 5xx,
+// timeout). The row cannot be safely classified, so HALT rather than
+// optimistically push (could clobber unread Notion changes) or skip
+// (would silently drop the row). Per backlog/network-blip-validation-halt.md.
+func TestValidate_n21f_GetPageErrorClassifiedAsHaltUnreachable(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-missing\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-missing.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock client returns "page not found" for unknown IDs — same code path
+	// as a network/5xx failure for our purposes (any GetPage error halts).
+	client := newMockClient()
+
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("validation must surface GetPage failures via classification, not err: %v", err)
+	}
+
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	got := report.Files[0]
+	if got.Class != ClassHaltUnreachable {
+		t.Errorf("expected ClassHaltUnreachable, got %v", got.Class)
+	}
+	if got.Reason == "" {
+		t.Error("unreachable halt must populate Reason")
+	}
+	if got.NotionID != "page-missing" {
+		t.Errorf("expected NotionID=page-missing, got %q", got.NotionID)
+	}
+	if !report.Halted {
+		t.Error("an unreachable file must flip Halted=true")
+	}
+}
+
+// n22 / n22a — every halt across every file must be enumerated in one pass.
+// Surfacing only the first halt would force the user into a fix-one-then-rerun
+// loop; surfacing all of them lets them fix the whole batch at once. This
+// also confirms that ready/skip files coexist with halt files in the report
+// (the gate is aggregate, not per-file fail-fast).
+func TestValidate_n22a_AnyHaltMakesReportHalted_AllHaltsEnumerated(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	files := map[string]string{
+		"AGENTS.md":      "# guide\n",
+		"ready.md":       "---\nnotion-id: page-ready\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n",
+		"deleted.md":     "---\nnotion-id: page-deleted\nnotion-deleted: true\n---\n",
+		"conflict.md":    "---\nnotion-id: page-conflict\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n",
+		"unexpected.md":  "---\ntitle: stray\n---\n",
+		"unreachable.md": "---\nnotion-id: page-missing\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := newMockClient()
+	client.pages["page-ready"] = &notion.Page{ID: "page-ready", LastEditedTime: "2024-01-01T00:00:00Z"}
+	client.pages["page-conflict"] = &notion.Page{ID: "page-conflict", LastEditedTime: "2024-06-01T00:00:00Z"}
+	// page-missing is intentionally absent → GetPage errors → unreachable halt.
+
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Files) != 6 {
+		t.Fatalf("expected 6 classifications, got %d", len(report.Files))
+	}
+	if !report.Halted {
+		t.Fatal("any halt-class file must flip Halted=true")
+	}
+
+	got := map[string]Classification{}
+	for _, f := range report.Files {
+		got[filepath.Base(f.Path)] = f.Class
+	}
+	want := map[string]Classification{
+		"AGENTS.md":      ClassSkipAgentsMD,
+		"deleted.md":     ClassSkipDeleted,
+		"ready.md":       ClassReady,
+		"conflict.md":    ClassHaltConflict,
+		"unexpected.md":  ClassHaltUnexpected,
+		"unreachable.md": ClassHaltUnreachable,
+	}
+	for name, wantClass := range want {
+		if got[name] != wantClass {
+			t.Errorf("%s: got class %v, want %v", name, got[name], wantClass)
+		}
+	}
+}
+
+// n22b — every file is skip or ready, zero halts → gate clears, Halted=false.
+// This is the only path that lets the run proceed to phase 3 (push).
+func TestValidate_n22b_NoHaltsMakesReportNotHalted(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	files := map[string]string{
+		"AGENTS.md":  "# guide\n",
+		"deleted.md": "---\nnotion-id: page-deleted\nnotion-deleted: true\n---\n",
+		"ready-1.md": "---\nnotion-id: page-1\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n",
+		"ready-2.md": "---\nnotion-id: page-2\nnotion-last-edited: 2024-01-01T00:00:00Z\n---\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := newMockClient()
+	client.pages["page-1"] = &notion.Page{ID: "page-1", LastEditedTime: "2024-01-01T00:00:00Z"}
+	client.pages["page-2"] = &notion.Page{ID: "page-2", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.Halted {
+		t.Fatal("zero halts must leave Halted=false (gate clears, run proceeds)")
+	}
+	if len(report.Files) != 4 {
+		t.Errorf("expected 4 classifications, got %d", len(report.Files))
+	}
+	for _, f := range report.Files {
+		if f.Class == ClassHaltConflict || f.Class == ClassHaltUnexpected || f.Class == ClassHaltUnreachable {
+			t.Errorf("%s: unexpected halt class %v", f.Path, f.Class)
+		}
+	}
+}

--- a/internal/sync/validation_test.go
+++ b/internal/sync/validation_test.go
@@ -351,6 +351,49 @@ func TestValidate_n21g_MalformedYAMLClassifiedAsHaltMalformed(t *testing.T) {
 	}
 }
 
+// n21h — file present on disk but unreadable (permission denied, transient
+// FS issue). Validation must classify as halt rather than abort the whole
+// pass: surfaces the file in the halt list with a fixable reason instead of
+// dropping the entire validation report.
+func TestValidate_n21h_UnreadableFileClassifiedAsHaltUnreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses file-mode permissions; skipping unreadable-file test")
+	}
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	// chmod 0000 — even the owner can't read it. On Windows this is a no-op
+	// (file permissions don't work the same way), so the test is effectively
+	// a Unix-only guard. The classification path is identical for any IO error.
+	unreadable := filepath.Join(dir, "locked.md")
+	if err := os.WriteFile(unreadable, []byte("---\nnotion-id: x\n---\n"), 0000); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(unreadable, 0644) // ensure t.TempDir cleanup can remove it
+	if _, err := os.ReadFile(unreadable); err == nil {
+		t.Skip("filesystem allows reading 0000-mode file (likely Windows or root); skipping")
+	}
+
+	client := newMockClient()
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unreadable file must surface via classification, not err: %v", err)
+	}
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	got := report.Files[0]
+	if got.Class != ClassHaltUnreadable {
+		t.Errorf("expected ClassHaltUnreadable, got %v", got.Class)
+	}
+	if got.Reason == "" {
+		t.Error("unreadable halt must populate Reason")
+	}
+	if !report.Halted {
+		t.Error("an unreadable file must flip Halted=true")
+	}
+}
+
 // Defensive case-insensitive AGENTS.md match: on Windows / default-config
 // macOS the file may land as agents.md or Agents.md. Misclassifying it as
 // a stray would halt the run for filesystem casing alone.

--- a/internal/sync/validation_test.go
+++ b/internal/sync/validation_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ran-codes/notion-sync/internal/notion"
@@ -306,8 +307,73 @@ func TestValidate_n22b_NoHaltsMakesReportNotHalted(t *testing.T) {
 		t.Errorf("expected 4 classifications, got %d", len(report.Files))
 	}
 	for _, f := range report.Files {
-		if f.Class == ClassHaltConflict || f.Class == ClassHaltUnexpected || f.Class == ClassHaltUnreachable {
+		if f.Class.IsHalt() {
 			t.Errorf("%s: unexpected halt class %v", f.Path, f.Class)
 		}
+	}
+}
+
+// n21g — corrupt YAML frontmatter is a halt (not silent skip): the user
+// almost certainly has a hand-edit they need to fix, and pushing past it
+// would bypass property changes they intended. Reason must explicitly
+// mention YAML so the user isn't sent hunting for a stray file.
+func TestValidate_n21g_MalformedYAMLClassifiedAsHaltMalformed(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	// Unclosed quoted string — yaml.Unmarshal errors out.
+	bad := "---\nnotion-id: \"unclosed\nStatus: Done\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "broken.md"), []byte(bad), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("malformed YAML must surface via classification, not err: %v", err)
+	}
+
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	got := report.Files[0]
+	if got.Class != ClassHaltMalformed {
+		t.Errorf("expected ClassHaltMalformed, got %v", got.Class)
+	}
+	if got.Reason == "" {
+		t.Error("malformed halt must populate Reason")
+	}
+	if !strings.Contains(strings.ToLower(got.Reason), "yaml") {
+		t.Errorf("reason must mention YAML so user knows to fix frontmatter, got %q", got.Reason)
+	}
+	if !report.Halted {
+		t.Error("malformed YAML must flip Halted=true")
+	}
+}
+
+// Defensive case-insensitive AGENTS.md match: on Windows / default-config
+// macOS the file may land as agents.md or Agents.md. Misclassifying it as
+// a stray would halt the run for filesystem casing alone.
+func TestValidate_n21a_AgentsMDMatchIsCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	if err := os.WriteFile(filepath.Join(dir, "agents.md"), []byte("# guide\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	report, err := ValidatePushQueue(client, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classified file, got %d", len(report.Files))
+	}
+	if report.Files[0].Class != ClassSkipAgentsMD {
+		t.Errorf("agents.md (lowercase) must classify as ClassSkipAgentsMD, got %v", report.Files[0].Class)
+	}
+	if report.Halted {
+		t.Error("lowercased agents.md must not halt the run")
 	}
 }


### PR DESCRIPTION
## Context
- Phase 2 of #55 (v1.4.0 push redesign). Stacks on the phase-1 confirmation gate (#77).
- Spec: [`.context/features/push/dag-v1.4.0.mmd`](https://github.com/Drexel-UHC/notion-sync/blob/64441d8be6645d33faf253ab37520bab7a92c2b8/.context/features/push/dag-v1.4.0.mmd) nodes `n21`, `n21a–h`, `n22`, `n22a`, `n22b`.
- Pure read+classify pass — defines the *halted (validation)* exit path. Sets up the all-or-nothing contract phase 3 (cell-level push) builds on.

## Changes

### New: `internal/sync/validation.go`
`ValidatePushQueue(client, folderPath) -> (*ValidationReport, error)` classifies every `.md` against eight DAG-spec'd outcomes:

| Node | Class | Outcome |
|---|---|---|
| n21a | `ClassSkipAgentsMD` | skip — generated guide, not a row |
| n21b | `ClassSkipDeleted` | skip — `notion-deleted: true` |
| n21c | `ClassReady` | linked + Notion `last_edited_time` == local `notion-last-edited` |
| n21d | `ClassHaltConflict` | linked + timestamps differ |
| n21e | `ClassHaltUnexpected` | unlinked, not AGENTS.md |
| n21f | `ClassHaltUnreachable` | GetPage failed during validation read |
| n21g | `ClassHaltMalformed` | YAML frontmatter could not be parsed |
| n21h | `ClassHaltUnreadable` | file could not be read from disk (permission denied, FS hiccup) |

`Halted` is **derived** from the classifications (`Classification.IsHalt()`), not maintained inline at every halt site — single source of truth, can't silently bypass.

### Wiring into `PushDatabase`
Gate runs after schema fetch, before the per-row loop. On halt: populate `PushResult.Halts`, set `Halted=true`, return without any `UpdatePage` call. `--force` bypasses the **entire** gate (every halt class, not just conflicts) — help text and flag descriptions updated to advertise the expanded escape-hatch semantics.

### Tests cite DAG node IDs
Ten unit tests + two integration tests, names map test → DAG:
- `TestValidate_n21a_AgentsMDClassifiedAsSkip`
- `TestValidate_n21a_AgentsMDMatchIsCaseInsensitive`
- `TestValidate_n21b_DeletedClassifiedAsSkip`
- `TestValidate_n21c_MatchedTimestampsClassifiedAsReady`
- `TestValidate_n21d_MismatchedTimestampsClassifiedAsHaltConflict`
- `TestValidate_n21e_StrayMDClassifiedAsHaltUnexpected`
- `TestValidate_n21f_GetPageErrorClassifiedAsHaltUnreachable`
- `TestValidate_n21g_MalformedYAMLClassifiedAsHaltMalformed`
- `TestValidate_n21h_UnreadableFileClassifiedAsHaltUnreadable`
- `TestValidate_n22a_AnyHaltMakesReportHalted_AllHaltsEnumerated`
- `TestValidate_n22b_NoHaltsMakesReportNotHalted`
- `TestPushDatabase_ValidationHaltAbortsRun_NoUpdatePageCalls`
- `TestPushDatabase_ForceBypassesAllHaltClasses` (pins the expanded `--force` semantics)

## ⚠️ Behavior change

A single conflicting row used to be counted but other rows still pushed (best-effort). New contract per spec `n22a`: any halt halts the **entire** run, nothing pushed. `TestPushDatabase_DetectsConflict` updated to assert the new contract; `TestBuildPushQueue_AndPushDatabase_AgreeOnFileSet` lost its `no-notion-id.md` fixture (it now triggers n21e halt — covered by the new integration test instead).

`--force` now bypasses every halt class, not just conflicts. Help text updated.

Related to #55

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)