### PR TITLE
refactor(push): unify scanPushable / scanLocalHalts / ValidatePushQueue into one classifier

### DIFF
--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -7,69 +7,36 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ran-codes/notion-sync/internal/frontmatter"
 	"github.com/ran-codes/notion-sync/internal/notion"
 )
 
-// pushableFile is a folder entry the push pipeline will act on: a .md file
-// linked to Notion (`notion-id` present) and not soft-deleted.
-type pushableFile struct {
-	path string
-	fm   map[string]interface{}
-}
-
-// scanPushable is the single source of truth for "what counts as pushable" —
-// both BuildPushQueue (preview) and PushDatabase (action) call it so the
-// confirmation gate's preview-equals-action contract holds by construction,
-// not by hand-keeping two filter loops in sync.
-func scanPushable(folderPath string) ([]pushableFile, error) {
-	dirEntries, err := os.ReadDir(folderPath)
-	if err != nil {
-		return nil, fmt.Errorf("read folder: %w", err)
+// readyQueue extracts the ClassReady rows from a classifier report (#80) —
+// the files PushDatabase will attempt to push. Deriving the queue from the
+// same report that produces the halts is what makes the preview-equals-action
+// contract hold by construction rather than by hand-keeping parallel filter
+// loops in sync.
+func readyQueue(report *ValidationReport) []FileClassification {
+	queue := make([]FileClassification, 0, len(report.Files))
+	for _, f := range report.Files {
+		if f.Class == ClassReady {
+			queue = append(queue, f)
+		}
 	}
-	var files []pushableFile
-	for _, entry := range dirEntries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
-			continue
-		}
-		filePath := filepath.Join(folderPath, entry.Name())
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			// Silent skip is correct here: the validation gate
-			// (ValidatePushQueue) and the preview's scanLocalHalts both
-			// classify unreadable files as ClassHaltUnreadable, so the user
-			// sees them in the halt list. Erroring here would short-circuit
-			// BuildPushQueue before scanLocalHalts runs and turn a nice halt
-			// list into a raw "read foo.md: permission denied" error.
-			// Under --force the gate is skipped — silent drop matches the
-			// rest of yolo mode (strays, malformed YAML also silently skip).
-			continue
-		}
-		fm, err := frontmatter.Parse(string(content))
-		if err != nil || fm == nil {
-			continue
-		}
-		if _, ok := fm["notion-id"].(string); !ok {
-			continue
-		}
-		if deleted, ok := fm["notion-deleted"].(bool); ok && deleted {
-			continue
-		}
-		files = append(files, pushableFile{path: filePath, fm: fm})
-	}
-	return files, nil
+	return queue
 }
 
 // BuildPushQueue returns the phase-1 confirmation preview: the .md files
 // PushDatabase would attempt to push, plus any halts detectable from disk
-// alone (stray .md, malformed YAML). Used by the confirmation gate (DAG
-// n12b) before any Notion API call.
+// alone (stray .md, malformed YAML, unreadable). Used by the confirmation
+// gate (DAG n12b) before any Notion API call.
 //
 // Errors if folderPath isn't a synced database so the user sees "not a
-// sync folder" rather than a misleading "nothing to push". Surfacing
-// LocalHalts here keeps the preview honest with the validation gate: if
-// strays exist, the user sees them at consent time instead of confirming
-// a queue and then getting halted on a file they were never shown.
+// sync folder" rather than a misleading "nothing to push". Both Queue and
+// LocalHalts come from one network-free classifyFolder walk: the queue is
+// its ClassReady rows, the halts are its locally-detectable halt rows. That
+// keeps the preview honest with the validation gate — if strays exist, the
+// user sees them at consent time instead of confirming a queue and then
+// getting halted on a file they were never shown.
 func BuildPushQueue(folderPath string) (*PushPreview, error) {
 	metadata, err := ReadDatabaseMetadata(folderPath)
 	if err != nil {
@@ -78,19 +45,22 @@ func BuildPushQueue(folderPath string) (*PushPreview, error) {
 	if metadata == nil {
 		return nil, fmt.Errorf("no %s found in %s. Use 'import' to import the database first", DatabaseMetadataFile, folderPath)
 	}
-	files, err := scanPushable(folderPath)
+	// nil client → network-free local classification. Conflict / Unreachable
+	// can't surface here (they need a GetPage); they wait for the gate.
+	report, err := classifyFolder(folderPath, nil)
 	if err != nil {
 		return nil, err
 	}
-	queue := make([]string, 0, len(files))
-	for _, f := range files {
-		queue = append(queue, f.path)
+	preview := &PushPreview{Queue: make([]string, 0, len(report.Files))}
+	for _, f := range report.Files {
+		switch {
+		case f.Class == ClassReady:
+			preview.Queue = append(preview.Queue, f.Path)
+		case f.Class.isLocalHalt():
+			preview.LocalHalts = append(preview.LocalHalts, f)
+		}
 	}
-	localHalts, err := scanLocalHalts(folderPath)
-	if err != nil {
-		return nil, err
-	}
-	return &PushPreview{Queue: queue, LocalHalts: localHalts}, nil
+	return preview, nil
 }
 
 // PushDatabase pushes local frontmatter property changes back to Notion.
@@ -134,36 +104,40 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		onProgress(ProgressPhase{Phase: PhasePushScanning})
 	}
 
-	// Validation gate (DAG n21+n22). All-or-nothing: any halt-class file
-	// across the whole folder aborts before any Notion write. --force skips
-	// the gate entirely (existing escape hatch, matches phase-1 behavior).
-	if !opts.Force {
-		report, err := ValidatePushQueue(opts.Client, opts.FolderPath)
-		if err != nil {
-			return nil, err
-		}
-		if report.Halted {
-			for _, f := range report.Files {
-				if f.Class.IsHalt() {
-					result.Halts = append(result.Halts, f)
-				}
-			}
-			result.Halted = true
-			// Total reflects everything classified, not just halts — gives
-			// the CLI summary "halted: 3 of 9 inspected" instead of the
-			// useless "Total: 0".
-			result.Total = len(report.Files)
-			if onProgress != nil {
-				onProgress(ProgressPhase{Phase: PhaseComplete})
-			}
-			return result, nil
-		}
+	// Single classifier walk (#80). Under the gate (!Force) the client
+	// resolves conflicts; under --force we run network-free so the gate is
+	// skipped entirely (existing escape hatch). Both the halt list and the
+	// push queue derive from this one report — no second folder walk.
+	gateClient := opts.Client
+	if opts.Force {
+		gateClient = nil
 	}
-
-	files, err := scanPushable(opts.FolderPath)
+	report, err := classifyFolder(opts.FolderPath, gateClient)
 	if err != nil {
 		return nil, err
 	}
+
+	// Validation gate (DAG n21+n22). All-or-nothing: any halt-class file
+	// across the whole folder aborts before any Notion write. --force ran the
+	// walk network-free, so report.Halted is false and this branch is skipped.
+	if !opts.Force && report.Halted {
+		for _, f := range report.Files {
+			if f.Class.IsHalt() {
+				result.Halts = append(result.Halts, f)
+			}
+		}
+		result.Halted = true
+		// Total reflects everything classified, not just halts — gives
+		// the CLI summary "halted: 3 of 9 inspected" instead of the
+		// useless "Total: 0".
+		result.Total = len(report.Files)
+		if onProgress != nil {
+			onProgress(ProgressPhase{Phase: PhaseComplete})
+		}
+		return result, nil
+	}
+
+	files := readyQueue(report)
 
 	result.Total = len(files)
 
@@ -172,7 +146,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 			onProgress(ProgressPhase{Phase: PhasePushing, Current: i + 1, Total: result.Total, Title: metadata.Title})
 		}
 
-		notionID := f.fm["notion-id"].(string)
+		notionID := f.NotionID
 		localLastEdited, _ := f.fm["notion-last-edited"].(string)
 
 		// TOCTOU defense: the validation gate already covered the !Force
@@ -185,12 +159,12 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 			page, err := opts.Client.GetPage(notionID)
 			if err != nil {
 				result.Failed++
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.path), err))
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.Path), err))
 				continue
 			}
 			if !timestampsEqual(localLastEdited, page.LastEditedTime) {
 				result.Conflicts++
-				result.ConflictFiles = append(result.ConflictFiles, filepath.Base(f.path))
+				result.ConflictFiles = append(result.ConflictFiles, filepath.Base(f.Path))
 				continue
 			}
 			notionPage = page
@@ -200,7 +174,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		if len(validationErrs) > 0 {
 			result.Failed++
 			for _, e := range validationErrs {
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", filepath.Base(f.path), e))
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", filepath.Base(f.Path), e))
 			}
 			continue
 		}
@@ -217,7 +191,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		updated, err := opts.Client.UpdatePage(notionID, properties)
 		if err != nil {
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.path), err))
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.Path), err))
 			continue
 		}
 
@@ -234,7 +208,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 				// Non-fatal: push succeeded; we just couldn't refetch the precise
 				// timestamp. Surface it so silent failures don't quietly reintroduce
 				// the quantized-timestamp bug this code exists to avoid.
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: refetch precise timestamp: %v", filepath.Base(f.path), refetchErr))
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: refetch precise timestamp: %v", filepath.Base(f.Path), refetchErr))
 			}
 			if updated != nil && updated.LastEditedTime != "" {
 				newLastEdited = updated.LastEditedTime
@@ -244,9 +218,9 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		}
 
 		pushedAt := time.Now().UTC().Format(time.RFC3339)
-		if err := updateAfterPush(f.path, newLastEdited, pushedAt); err != nil {
+		if err := updateAfterPush(f.Path, newLastEdited, pushedAt); err != nil {
 			// Non-fatal: push succeeded, just couldn't update local timestamps.
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: update timestamps: %v", filepath.Base(f.path), err))
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: update timestamps: %v", filepath.Base(f.Path), err))
 		}
 
 		result.Pushed++

--- a/internal/sync/validation.go
+++ b/internal/sync/validation.go
@@ -33,6 +33,17 @@ func (c Classification) IsHalt() bool {
 		c == ClassHaltUnreadable
 }
 
+// isLocalHalt reports whether a halt class is detectable from disk alone,
+// with no Notion API call. Conflict and Unreachable both require a GetPage,
+// so the preview (BuildPushQueue) can't predict them — they're excluded.
+// This is the filter that turns the single classifier walk's report into
+// PushPreview.LocalHalts.
+func (c Classification) isLocalHalt() bool {
+	return c == ClassHaltUnexpected ||
+		c == ClassHaltMalformed ||
+		c == ClassHaltUnreadable
+}
+
 // FileClassification is one file's row in the validation report.
 //
 // NotionID is populated whenever the file declares one in frontmatter
@@ -45,6 +56,14 @@ type FileClassification struct {
 	Class    Classification
 	Reason   string // populated for halts; user-facing
 	NotionID string
+
+	// fm is the parsed frontmatter, carried so the push loop can build its
+	// property payload from a ClassReady row without re-reading and
+	// re-parsing the file. Unexported: an internal carry for the single-walk
+	// refactor (#80), not part of the report's public contract. Populated for
+	// the linked rows (Ready, Conflict, Unreachable, Deleted); nil for
+	// AGENTS.md, Unreadable, Malformed, and Unexpected.
+	fm map[string]interface{}
 }
 
 // ValidationReport is the result of n21+n22 across every file in folderPath.
@@ -62,17 +81,39 @@ type ValidationReport struct {
 // caller. PushDatabase does that check before invoking the gate; direct
 // callers must do the same or accept that the report says nothing about
 // whether the folder is a real synced database.
+//
+// Thin wrapper over classifyFolder — the single walk that also backs
+// BuildPushQueue (preview) and the per-row push queue (#80).
 func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationReport, error) {
+	return classifyFolder(folderPath, client)
+}
+
+// classifyFolder is the single classifier walk behind every push folder scan
+// (#80): the validation gate, the confirmation preview, and the per-row push
+// queue all derive from one report instead of three near-duplicate walks that
+// drifted apart on AGENTS.md casing, IO-error policy, and deleted ordering.
+//
+// It reads each .md once and applies the shared local filter: AGENTS.md skip,
+// IO error → Unreadable, parse error → Malformed, notion-deleted → Deleted,
+// missing notion-id → Unexpected. For a locally-clean linked row the behavior
+// forks on client:
+//
+//   - client == nil — the network-free view. The row is marked ClassReady
+//     without contacting Notion. BuildPushQueue uses this for its preview, and
+//     PushDatabase uses it under --force (which deliberately skips the gate).
+//   - client != nil — the gate. A GetPage resolves the row into Ready (matched
+//     timestamps), Conflict (Notion moved ahead), or Unreachable (GetPage
+//     failed).
+//
+// Halted flips on any halt-class outcome, in lockstep with the appends, so it
+// can never drift out of sync with the underlying classifications.
+func classifyFolder(folderPath string, client NotionClient) (*ValidationReport, error) {
 	dirEntries, err := os.ReadDir(folderPath)
 	if err != nil {
 		return nil, fmt.Errorf("read folder: %w", err)
 	}
 
 	report := &ValidationReport{}
-	// add appends a classification and flips Halted in lockstep, so Halted
-	// can never drift out of sync with the underlying classifications. The
-	// rule is centralized here (not at every call site) — one bug-fix
-	// surface, no missed assignments.
 	add := func(fc FileClassification) {
 		report.Files = append(report.Files, fc)
 		if fc.Class.IsHalt() {
@@ -129,6 +170,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 				Path:     fullPath,
 				Class:    ClassSkipDeleted,
 				NotionID: notionID,
+				fm:       fm,
 			})
 			continue
 		}
@@ -139,6 +181,19 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 				Path:   fullPath,
 				Class:  ClassHaltUnexpected,
 				Reason: "file has no notion-id and is not AGENTS.md — does not belong to this synced folder",
+			})
+			continue
+		}
+
+		// Linked, not deleted, parseable. Network-free callers (preview,
+		// --force) stop here: the row is ready as far as disk can tell. The
+		// gate will resolve conflicts when a client is supplied.
+		if client == nil {
+			add(FileClassification{
+				Path:     fullPath,
+				Class:    ClassReady,
+				NotionID: notionID,
+				fm:       fm,
 			})
 			continue
 		}
@@ -150,6 +205,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 				Path:     fullPath,
 				Class:    ClassHaltUnreachable,
 				NotionID: notionID,
+				fm:       fm,
 				Reason:   fmt.Sprintf("could not read Notion last_edited_time: %v", err),
 			})
 			continue
@@ -159,6 +215,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 				Path:     fullPath,
 				Class:    ClassReady,
 				NotionID: notionID,
+				fm:       fm,
 			})
 			continue
 		}
@@ -167,6 +224,7 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 			Path:     fullPath,
 			Class:    ClassHaltConflict,
 			NotionID: notionID,
+			fm:       fm,
 			Reason: fmt.Sprintf(
 				"Notion's row has changed since last sync (local %s, Notion %s) — refresh before pushing",
 				localLastEdited, page.LastEditedTime,
@@ -174,65 +232,4 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 		})
 	}
 	return report, nil
-}
-
-// scanLocalHalts walks folderPath and returns the halt-class files that
-// can be detected without any Notion API call: ClassHaltUnexpected (stray
-// .md missing notion-id) and ClassHaltMalformed (corrupt YAML frontmatter).
-//
-// Used by BuildPushQueue so the phase-1 confirmation preview can warn the
-// user about locally-detectable halts before they consent. Without this,
-// the user confirms a queue, validation halts on a stray they were never
-// shown, and they get the fix-loop UX phase 2's halt enumerator was meant
-// to avoid. Network-dependent halts (Conflict, Unreachable) still only
-// surface at the validation gate — by definition we can't predict them
-// from disk alone.
-func scanLocalHalts(folderPath string) ([]FileClassification, error) {
-	dirEntries, err := os.ReadDir(folderPath)
-	if err != nil {
-		return nil, fmt.Errorf("read folder: %w", err)
-	}
-	var halts []FileClassification
-	for _, entry := range dirEntries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
-			continue
-		}
-		if strings.EqualFold(entry.Name(), "AGENTS.md") {
-			continue
-		}
-		fullPath := filepath.Join(folderPath, entry.Name())
-		content, err := os.ReadFile(fullPath)
-		if err != nil {
-			halts = append(halts, FileClassification{
-				Path:   fullPath,
-				Class:  ClassHaltUnreadable,
-				Reason: fmt.Sprintf("could not read file: %v", err),
-			})
-			continue
-		}
-		fm, parseErr := frontmatter.Parse(string(content))
-		if parseErr != nil {
-			halts = append(halts, FileClassification{
-				Path:   fullPath,
-				Class:  ClassHaltMalformed,
-				Reason: fmt.Sprintf("could not parse YAML frontmatter: %v", parseErr),
-			})
-			continue
-		}
-		if fm == nil {
-			fm = map[string]interface{}{}
-		}
-		if deleted, _ := fm["notion-deleted"].(bool); deleted {
-			continue
-		}
-		notionID, hasID := fm["notion-id"].(string)
-		if !hasID || notionID == "" {
-			halts = append(halts, FileClassification{
-				Path:   fullPath,
-				Class:  ClassHaltUnexpected,
-				Reason: "file has no notion-id and is not AGENTS.md — does not belong to this synced folder",
-			})
-		}
-	}
-	return halts, nil
 }

--- a/internal/sync/validation_test.go
+++ b/internal/sync/validation_test.go
@@ -394,6 +394,77 @@ func TestValidate_n21h_UnreadableFileClassifiedAsHaltUnreadable(t *testing.T) {
 	}
 }
 
+// #80 — classifyFolder is the single walk behind the gate, the preview, and
+// the push queue. With a nil client it must run network-free: every locally
+// clean linked row classifies ClassReady WITHOUT a GetPage, even when Notion
+// would actually be a conflict. Passing a literal nil client proves there is
+// no network call — any GetPage would panic on the nil interface. This is the
+// view BuildPushQueue (preview) and PushDatabase (--force) both consume.
+func TestClassifyFolder_NilClient_LinkedRowsReadyWithoutNetwork(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	// One linked row, one stray, one malformed, one AGENTS.md, one deleted.
+	files := map[string]string{
+		"linked.md":    "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Done\n---\n",
+		"stray.md":     "---\ntitle: stray\n---\n",
+		"malformed.md": "---\nnotion-id: \"unclosed\nStatus: Done\n---\n",
+		"AGENTS.md":    "# guide\n",
+		"deleted.md":   "---\nnotion-id: page-del\nnotion-deleted: true\n---\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Nil client: a GetPage would panic, so a passing run proves none happened.
+	report, err := classifyFolder(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := map[string]FileClassification{}
+	for _, f := range report.Files {
+		got[filepath.Base(f.Path)] = f
+	}
+
+	// Linked row is Ready without any network check, and carries its parsed
+	// frontmatter so the push loop can build a payload from the same report.
+	linked := got["linked.md"]
+	if linked.Class != ClassReady {
+		t.Errorf("linked.md: expected ClassReady (network-free), got %v", linked.Class)
+	}
+	if linked.NotionID != "page-001" {
+		t.Errorf("linked.md: expected NotionID page-001, got %q", linked.NotionID)
+	}
+	if linked.fm["Status"] != "Done" {
+		t.Errorf("linked.md: expected carried frontmatter Status=Done, got %v", linked.fm["Status"])
+	}
+
+	// Local halts still classify; the deleted row and AGENTS.md still skip.
+	if got["stray.md"].Class != ClassHaltUnexpected {
+		t.Errorf("stray.md: expected ClassHaltUnexpected, got %v", got["stray.md"].Class)
+	}
+	if got["malformed.md"].Class != ClassHaltMalformed {
+		t.Errorf("malformed.md: expected ClassHaltMalformed, got %v", got["malformed.md"].Class)
+	}
+	if got["AGENTS.md"].Class != ClassSkipAgentsMD {
+		t.Errorf("AGENTS.md: expected ClassSkipAgentsMD, got %v", got["AGENTS.md"].Class)
+	}
+	if got["deleted.md"].Class != ClassSkipDeleted {
+		t.Errorf("deleted.md: expected ClassSkipDeleted, got %v", got["deleted.md"].Class)
+	}
+
+	// isLocalHalt feeds BuildPushQueue.LocalHalts — network halts are excluded.
+	if !ClassHaltUnexpected.isLocalHalt() || !ClassHaltMalformed.isLocalHalt() || !ClassHaltUnreadable.isLocalHalt() {
+		t.Error("Unexpected/Malformed/Unreadable must be local halts")
+	}
+	if ClassHaltConflict.isLocalHalt() || ClassHaltUnreachable.isLocalHalt() {
+		t.Error("Conflict/Unreachable require a network call — must not be local halts")
+	}
+}
+
 // Defensive case-insensitive AGENTS.md match: on Windows / default-config
 // macOS the file may land as agents.md or Agents.md. Misclassifying it as
 // a stray would halt the run for filesystem casing alone.


### PR DESCRIPTION
## Context

- Address issue - https://github.com/Drexel-UHC/notion-sync/issues/80
- Addressess Epic #55 
- clean up some debt introduced in phaes 2 before moving on to phase 3
- specificalyl: unify scan walks into one classifier (+ fix api-call-doubling)

## Action Items

- [x] Develop
- [ ] Code review
- [x] Testing
