### PR TITLE
feat(push): validate select/status/multi_select against schema options

### DIFF
--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -347,12 +347,13 @@ func TestRenderHaltedResult_FormatsHeaderAndPerHaltLines(t *testing.T) {
 	halts := []sync.FileClassification{
 		{Path: "/tmp/folder/page-2.md", Class: sync.ClassHaltConflict, Reason: "row changed on Notion since last sync"},
 		{Path: "/tmp/folder/stray.md", Class: sync.ClassHaltUnexpected, Reason: "no notion-id in frontmatter"},
+		{Path: "/tmp/folder/badopt.md", Class: sync.ClassHaltInvalidOption, Reason: `"Doen" is not a valid option for "Status" (allowed: To Do, Doing, Done)`},
 	}
 	// Total intentionally != len(Halts): pins that the header reads from
 	// result.Total (full inspected count), not from len(Halts).
 	result := &sync.PushResult{
 		Title:  "Test DB",
-		Total:  4,
+		Total:  5,
 		Halted: true,
 		Halts:  halts,
 	}
@@ -365,10 +366,10 @@ func TestRenderHaltedResult_FormatsHeaderAndPerHaltLines(t *testing.T) {
 	if !strings.Contains(out, `Halted: "Test DB"`) {
 		t.Errorf("expected quoted title in 'Halted:' header, got:\n%s", out)
 	}
-	if !strings.Contains(out, "Inspected: 4") {
-		t.Errorf("expected 'Inspected: 4' (from result.Total), got:\n%s", out)
+	if !strings.Contains(out, "Inspected: 5") {
+		t.Errorf("expected 'Inspected: 5' (from result.Total), got:\n%s", out)
 	}
-	if !strings.Contains(out, "Halts:     2 (nothing pushed") {
+	if !strings.Contains(out, "Halts:     3 (nothing pushed") {
 		t.Errorf("expected halts count + 'nothing pushed' hint, got:\n%s", out)
 	}
 
@@ -381,7 +382,7 @@ func TestRenderHaltedResult_FormatsHeaderAndPerHaltLines(t *testing.T) {
 	// to return "halt" for every class, both the rendered line and the expectation
 	// would read [halt] and still match. Literal labels make a broken
 	// haltClassLabel switch actually trip this test.
-	wantLabels := []string{"conflict", "stray"} // halts[0]=ClassHaltConflict, halts[1]=ClassHaltUnexpected
+	wantLabels := []string{"conflict", "stray", "invalid-option"} // matches halts[] classes in order
 	for i, h := range halts {
 		want := fmt.Sprintf("%s [%s] — %s", filepath.Base(h.Path), wantLabels[i], h.Reason)
 		if !strings.Contains(out, want) {

--- a/cmd/notion-sync/push.go
+++ b/cmd/notion-sync/push.go
@@ -84,6 +84,7 @@ func runPush(args []string) error {
 	dryRun := fs.Bool("dry-run", false, "Show what would be pushed without writing to Notion")
 	yes := fs.Bool("yes", false, "Skip the confirmation prompt (required for non-interactive runs)")
 	yesShort := fs.Bool("y", false, "Skip the confirmation prompt (shorthand)")
+	allowNewOptions := fs.Bool("allow-new-options", false, "Let unknown select/multi_select values auto-create options in Notion (status values are always validated)")
 
 	if err := fs.Parse(reorderArgs(args)); err != nil {
 		return err
@@ -91,7 +92,7 @@ func runPush(args []string) error {
 
 	if fs.NArg() == 0 {
 		return fmt.Errorf("missing folder path\n" +
-			"Usage: notion-sync push <folder> [--force] [--dry-run] [--yes] [--api-key <key>]\n" +
+			"Usage: notion-sync push <folder> [--force] [--dry-run] [--yes] [--allow-new-options] [--api-key <key>]\n" +
 			"Example: notion-sync push ./notion/My\\ Database")
 	}
 
@@ -141,10 +142,11 @@ func runPush(args []string) error {
 	var dbTitle string
 
 	result, err := sync.PushDatabase(sync.PushOptions{
-		Client:     client,
-		FolderPath: folderPath,
-		Force:      forceFlag,
-		DryRun:     *dryRun,
+		Client:          client,
+		FolderPath:      folderPath,
+		Force:           forceFlag,
+		DryRun:          *dryRun,
+		AllowNewOptions: *allowNewOptions,
 	}, func(p sync.ProgressPhase) {
 		if p.Phase == sync.PhasePushing {
 			dbTitle = p.Title
@@ -232,6 +234,8 @@ func haltClassLabel(c sync.Classification) string {
 		return "malformed"
 	case sync.ClassHaltUnreadable:
 		return "unreadable"
+	case sync.ClassHaltInvalidOption:
+		return "invalid-option"
 	default:
 		return "halt"
 	}

--- a/cmd/notion-sync/usage.go
+++ b/cmd/notion-sync/usage.go
@@ -8,7 +8,7 @@ var usage = `notion-sync — Sync Notion databases and pages to Markdown (v` + v
 Usage:
   notion-sync import <database-or-page-id> [--output <folder>] [--api-key <key>] [--keep-presigned-params]
   notion-sync refresh <folder> [--ids id1,id2] [--force] [--api-key <key>] [--keep-presigned-params]
-  notion-sync push <folder> [--force] [--dry-run] [--yes] [--api-key <key>]
+  notion-sync push <folder> [--force] [--dry-run] [--yes] [--allow-new-options] [--api-key <key>]
   notion-sync list [<output-folder>]
   notion-sync clean <folder> [--dry-run]
   notion-sync agents-md <folder>
@@ -27,12 +27,16 @@ Commands:
             Previews the push queue and prompts y/N before any API write (TTY only).
             Non-interactive runs (CI / pipes) must pass --yes; otherwise the run is cancelled.
             Runs a validation gate before any write: stray .md, malformed YAML, conflicting
-            timestamps, or unreachable rows halt the entire run (all-or-nothing).
+            timestamps, unreachable rows, or invalid select/status/multi_select options halt
+            the entire run (all-or-nothing).
             --force, -f    Skip the validation gate entirely. Pushes despite conflicts,
                            strays, malformed YAML, unreadable files, or unreachable rows.
                            Use only after manual review — overwrites Notion-side changes.
             --dry-run      Show what would be pushed without writing to Notion (still reads from Notion for conflict detection)
             --yes, -y      Skip the confirmation prompt (required in non-interactive runs)
+            --allow-new-options  Let unknown select/multi_select values auto-create options in
+                                 Notion's shared schema. Unknown status values still halt (the
+                                 API cannot create status options). Default: unknown options halt.
   list      List all synced databases and pages in a folder
   clean     Strip AWS S3 pre-signed query strings from existing .md files in a folder.
             Useful one-time backfill after upgrading. No API calls.

--- a/internal/notion/types.go
+++ b/internal/notion/types.go
@@ -15,10 +15,24 @@ type Database struct {
 }
 
 // DatabaseProperty represents a property schema entry in a database.
+//
+// Select / MultiSelect / Status carry the schema's allowed-option lists so push
+// can validate pushed values against them before any write (issue #90). Notion
+// returns these on GET /data_sources/{id}; they're nil for any other type.
 type DatabaseProperty struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Type        string        `json:"type"`
+	Select      *SelectConfig `json:"select,omitempty"`
+	MultiSelect *SelectConfig `json:"multi_select,omitempty"`
+	Status      *SelectConfig `json:"status,omitempty"`
+}
+
+// SelectConfig holds the allowed-option list for a select / multi_select /
+// status property's schema. Reuses SelectValue for each option (id, name,
+// color match the schema's option shape).
+type SelectConfig struct {
+	Options []SelectValue `json:"options"`
 }
 
 // DataSource represents a data source reference within a database.

--- a/internal/notion/types_test.go
+++ b/internal/notion/types_test.go
@@ -1,0 +1,112 @@
+package notion
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Issue #90 prerequisite: DatabaseProperty must parse the allowed-option lists
+// that Notion returns on GET /data_sources/{id} for select / multi_select /
+// status properties. This pins the JSON contract (field names + nesting) the
+// validation gate relies on to compare pushed values against the schema.
+func TestDatabaseProperty_ParsesSelectStatusMultiSelectOptions(t *testing.T) {
+	// Trimmed shape of a real /data_sources/{id} properties payload.
+	raw := `{
+		"Status": {
+			"id": "abc",
+			"name": "Status",
+			"type": "status",
+			"status": {
+				"options": [
+					{"id": "1", "name": "To Do", "color": "gray"},
+					{"id": "2", "name": "Doing", "color": "blue"},
+					{"id": "3", "name": "Done", "color": "green"}
+				]
+			}
+		},
+		"Priority": {
+			"id": "def",
+			"name": "Priority",
+			"type": "select",
+			"select": {
+				"options": [
+					{"id": "4", "name": "Low"},
+					{"id": "5", "name": "High"}
+				]
+			}
+		},
+		"Tags": {
+			"id": "ghi",
+			"name": "Tags",
+			"type": "multi_select",
+			"multi_select": {
+				"options": [
+					{"id": "6", "name": "urgent"},
+					{"id": "7", "name": "backlog"}
+				]
+			}
+		},
+		"Notes": {
+			"id": "jkl",
+			"name": "Notes",
+			"type": "rich_text"
+		}
+	}`
+
+	var props map[string]DatabaseProperty
+	if err := json.Unmarshal([]byte(raw), &props); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	status := props["Status"]
+	if status.Status == nil {
+		t.Fatal("Status.Status (option config) was not parsed")
+	}
+	gotStatus := optionNames(status.Status.Options)
+	wantStatus := []string{"To Do", "Doing", "Done"}
+	if !equalSlice(gotStatus, wantStatus) {
+		t.Errorf("status options: got %v, want %v", gotStatus, wantStatus)
+	}
+
+	sel := props["Priority"]
+	if sel.Select == nil {
+		t.Fatal("Priority.Select (option config) was not parsed")
+	}
+	if got := optionNames(sel.Select.Options); !equalSlice(got, []string{"Low", "High"}) {
+		t.Errorf("select options: got %v", got)
+	}
+
+	multi := props["Tags"]
+	if multi.MultiSelect == nil {
+		t.Fatal("Tags.MultiSelect (option config) was not parsed")
+	}
+	if got := optionNames(multi.MultiSelect.Options); !equalSlice(got, []string{"urgent", "backlog"}) {
+		t.Errorf("multi_select options: got %v", got)
+	}
+
+	// A non-option property carries nil configs (no spurious empty structs).
+	notes := props["Notes"]
+	if notes.Select != nil || notes.MultiSelect != nil || notes.Status != nil {
+		t.Errorf("rich_text property should have nil option configs, got %+v", notes)
+	}
+}
+
+func optionNames(options []SelectValue) []string {
+	names := make([]string, 0, len(options))
+	for _, o := range options {
+		names = append(names, o.Name)
+	}
+	return names
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -45,9 +45,10 @@ func BuildPushQueue(folderPath string) (*PushPreview, error) {
 	if metadata == nil {
 		return nil, fmt.Errorf("no %s found in %s. Use 'import' to import the database first", DatabaseMetadataFile, folderPath)
 	}
-	// nil client → network-free local classification. Conflict / Unreachable
-	// can't surface here (they need a GetPage); they wait for the gate.
-	report, err := classifyFolder(folderPath, nil)
+	// nil client + nil schema → network-free local classification. Conflict /
+	// Unreachable / InvalidOption can't surface here (they need a GetPage or the
+	// fetched schema); they wait for the gate.
+	report, err := classifyFolder(folderPath, nil, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -109,10 +110,12 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 	// skipped entirely (existing escape hatch). Both the halt list and the
 	// push queue derive from this one report — no second folder walk.
 	gateClient := opts.Client
+	gateSchema := schema
 	if opts.Force {
 		gateClient = nil
+		gateSchema = nil
 	}
-	report, err := classifyFolder(opts.FolderPath, gateClient)
+	report, err := classifyFolder(opts.FolderPath, gateClient, gateSchema, opts.AllowNewOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -1155,6 +1155,274 @@ func TestPushDatabase_ForceBypassesAllHaltClasses(t *testing.T) {
 	}
 }
 
+// --- Option validation gate (issue #90) ---
+
+// Acceptance: a typo'd select value (which would otherwise make Notion
+// auto-create a junk option in the shared schema) halts the whole run, writes
+// nothing, and surfaces the file in result.Halts with the allowed-options reason.
+func TestPushDatabase_TypoSelectHaltsRun(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Doen\n" + // typo of "Done"
+		"---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": optionProp("select", "To Do", "Doing", "Done"),
+		},
+	}
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatalf("invalid option is surfaced via result.Halted, not err: %v", err)
+	}
+	if !result.Halted {
+		t.Fatal("expected result.Halted=true for typo'd select option")
+	}
+	if len(client.updateRequests) != 0 {
+		t.Errorf("expected 0 UpdatePage calls when halted, got %d", len(client.updateRequests))
+	}
+	if len(result.Halts) != 1 || result.Halts[0].Class != ClassHaltInvalidOption {
+		t.Fatalf("expected 1 ClassHaltInvalidOption halt, got %v", result.Halts)
+	}
+	reason := result.Halts[0].Reason
+	if !strings.Contains(reason, "Doen") || !strings.Contains(reason, "Status") || !strings.Contains(reason, "To Do, Doing, Done") {
+		t.Errorf("halt reason must name the bad value, property, and allowed options, got %q", reason)
+	}
+}
+
+// Acceptance: an unknown status value halts (no 422 ever reaches Notion). Status
+// options cannot be created via API, so there is no opt-in.
+func TestPushDatabase_UnknownStatusHaltsRun(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Stage: Shppd\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Stage": optionProp("status", "Backlog", "In Progress", "Shipped"),
+		},
+	}
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	// Even with --allow-new-options, status must still halt.
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, AllowNewOptions: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Halted {
+		t.Fatal("expected halt on unknown status even with AllowNewOptions=true")
+	}
+	if len(client.updateRequests) != 0 {
+		t.Errorf("expected 0 UpdatePage calls, got %d", len(client.updateRequests))
+	}
+	if len(result.Halts) != 1 || result.Halts[0].Class != ClassHaltInvalidOption {
+		t.Errorf("expected 1 ClassHaltInvalidOption, got %v", result.Halts)
+	}
+}
+
+// Acceptance: --allow-new-options lets an unknown select value through so Notion
+// auto-creates the option on write.
+func TestPushDatabase_AllowNewOptionsPassesUnknownSelect(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Brand New Category\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": optionProp("select", "To Do", "Done"),
+		},
+	}
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, AllowNewOptions: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Halted {
+		t.Fatal("AllowNewOptions must not halt on unknown select")
+	}
+	if result.Pushed != 1 {
+		t.Errorf("expected 1 pushed, got %d (errors=%v)", result.Pushed, result.Errors)
+	}
+	if len(client.updateRequests) != 1 {
+		t.Fatalf("expected 1 UpdatePage call, got %d", len(client.updateRequests))
+	}
+	sel := client.updateRequests[0].Properties["Status"].(map[string]interface{})["select"].(map[string]interface{})
+	if sel["name"] != "Brand New Category" {
+		t.Errorf("expected new option name passed through, got %v", sel["name"])
+	}
+}
+
+// Valid select / status / multi_select values push unchanged through the gate.
+func TestPushDatabase_ValidOptionsPushUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Done\n" +
+		"Stage: Shipped\n" +
+		"Tags:\n  - urgent\n  - backlog\n" +
+		"---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": optionProp("select", "To Do", "Doing", "Done"),
+			"Stage":  optionProp("status", "Backlog", "Shipped"),
+			"Tags":   optionProp("multi_select", "urgent", "backlog", "later"),
+		},
+	}
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Halted {
+		t.Fatalf("valid options must not halt, got halts %v", result.Halts)
+	}
+	if result.Pushed != 1 {
+		t.Errorf("expected 1 pushed, got %d (errors=%v)", result.Pushed, result.Errors)
+	}
+}
+
+// All-or-nothing: one invalid option blocks the whole run, including a sibling
+// row whose options are all valid — nothing is written.
+func TestPushDatabase_OneInvalidOptionBlocksValidSibling(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	files := map[string]string{
+		"good.md": "---\nnotion-id: page-good\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Done\n---\n",
+		"bad.md":  "---\nnotion-id: page-bad\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Doen\n---\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": optionProp("select", "To Do", "Doing", "Done"),
+		},
+	}
+	client.pages["page-good"] = &notion.Page{ID: "page-good", LastEditedTime: "2024-01-01T00:00:00Z"}
+	client.pages["page-bad"] = &notion.Page{ID: "page-bad", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Halted {
+		t.Fatal("one invalid option must halt the whole run")
+	}
+	if len(client.updateRequests) != 0 {
+		t.Errorf("expected 0 UpdatePage calls (no partial push), got %d", len(client.updateRequests))
+	}
+}
+
+// Option validation works when the schema is sourced from the data source
+// endpoint (the production multi-data-source path), not just GetDatabase.
+func TestPushDatabase_InvalidOptionFromDataSourceSchema(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMetaWithDataSource(t, dir, "db-001", "ds-001")
+
+	md := "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Doen\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.dataSources["ds-001"] = &notion.DataSourceDetail{
+		ID: "ds-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": optionProp("select", "To Do", "Done"),
+		},
+	}
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Halted || len(result.Halts) != 1 || result.Halts[0].Class != ClassHaltInvalidOption {
+		t.Errorf("expected ClassHaltInvalidOption from data-source schema, got halted=%v halts=%v", result.Halted, result.Halts)
+	}
+}
+
+// --force bypasses the option gate too (yolo escape hatch): an invalid option
+// is not caught and the write is attempted. Pins that --force skips option
+// validation alongside the other halt classes.
+func TestPushDatabase_ForceBypassesOptionGate(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Doen\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status": optionProp("select", "To Do", "Done"),
+		},
+	}
+	client.pages["page-001"] = &notion.Page{ID: "page-001", LastEditedTime: "2024-01-01T00:00:00Z"}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir, Force: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Halted {
+		t.Error("--force must skip the option gate (Halted=false)")
+	}
+	if len(client.updateRequests) != 1 {
+		t.Errorf("expected 1 UpdatePage call under --force, got %d", len(client.updateRequests))
+	}
+}
+
 // writeDatabaseMeta writes a minimal _database.json for tests.
 func writeDatabaseMeta(t *testing.T, dir, dbID string) {
 	t.Helper()

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -70,10 +70,11 @@ const (
 
 // PushOptions contains options for pushing local frontmatter changes to Notion.
 type PushOptions struct {
-	Client     NotionClient
-	FolderPath string
-	Force      bool // skip conflict check
-	DryRun     bool // report planned changes without writing
+	Client          NotionClient
+	FolderPath      string
+	Force           bool // skip conflict check
+	DryRun          bool // report planned changes without writing
+	AllowNewOptions bool // let unknown select/multi_select values auto-create options in Notion (status still validated)
 }
 
 // PushPreview is what the phase-1 confirmation gate displays to the user

--- a/internal/sync/validation.go
+++ b/internal/sync/validation.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/ran-codes/notion-sync/internal/frontmatter"
+	"github.com/ran-codes/notion-sync/internal/notion"
 )
 
 // Classification is a single file's outcome from the validation pass (DAG n21).
@@ -14,14 +16,15 @@ import (
 type Classification int
 
 const (
-	ClassSkipAgentsMD    Classification = iota // n21a — generated guide, not a row
-	ClassSkipDeleted                           // n21b — already soft-deleted
-	ClassReady                                 // n21c — linked, timestamps match
-	ClassHaltConflict                          // n21d — Notion edited since last sync
-	ClassHaltUnexpected                        // n21e — unlinked, not AGENTS.md
-	ClassHaltUnreachable                       // n21f — Notion unreachable during read
-	ClassHaltMalformed                         // n21g — YAML frontmatter could not be parsed
-	ClassHaltUnreadable                        // n21h — file could not be read from disk
+	ClassSkipAgentsMD      Classification = iota // n21a — generated guide, not a row
+	ClassSkipDeleted                             // n21b — already soft-deleted
+	ClassReady                                   // n21c — linked, timestamps match
+	ClassHaltConflict                            // n21d — Notion edited since last sync
+	ClassHaltUnexpected                          // n21e — unlinked, not AGENTS.md
+	ClassHaltUnreachable                         // n21f — Notion unreachable during read
+	ClassHaltMalformed                           // n21g — YAML frontmatter could not be parsed
+	ClassHaltUnreadable                          // n21h — file could not be read from disk
+	ClassHaltInvalidOption                       // n21i — select/status/multi_select value not in schema options
 )
 
 // IsHalt returns true for any halt-class value.
@@ -30,7 +33,8 @@ func (c Classification) IsHalt() bool {
 		c == ClassHaltUnexpected ||
 		c == ClassHaltUnreachable ||
 		c == ClassHaltMalformed ||
-		c == ClassHaltUnreadable
+		c == ClassHaltUnreadable ||
+		c == ClassHaltInvalidOption
 }
 
 // isLocalHalt reports whether a halt class is detectable from disk alone,
@@ -85,7 +89,7 @@ type ValidationReport struct {
 // Thin wrapper over classifyFolder — the single walk that also backs
 // BuildPushQueue (preview) and the per-row push queue (#80).
 func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationReport, error) {
-	return classifyFolder(folderPath, client)
+	return classifyFolder(folderPath, client, nil, false)
 }
 
 // classifyFolder is the single classifier walk behind every push folder scan
@@ -105,9 +109,18 @@ func ValidatePushQueue(client NotionClient, folderPath string) (*ValidationRepor
 //     timestamps), Conflict (Notion moved ahead), or Unreachable (GetPage
 //     failed).
 //
+// When schema is non-nil (the gate path) each linked row's select/status/
+// multi_select values are checked against the schema's allowed options before
+// the conflict GetPage — an unknown value halts the run (ClassHaltInvalidOption)
+// before any write, preventing typo-driven schema pollution and mid-run 422s
+// (issue #90). Network-free callers (preview, --force) pass a nil schema and
+// skip the check. allowNewOptions relaxes select/multi_select (Notion will
+// auto-create the option on push); status always validates (the API can't
+// create status options).
+//
 // Halted flips on any halt-class outcome, in lockstep with the appends, so it
 // can never drift out of sync with the underlying classifications.
-func classifyFolder(folderPath string, client NotionClient) (*ValidationReport, error) {
+func classifyFolder(folderPath string, client NotionClient, schema map[string]notion.DatabaseProperty, allowNewOptions bool) (*ValidationReport, error) {
 	dirEntries, err := os.ReadDir(folderPath)
 	if err != nil {
 		return nil, fmt.Errorf("read folder: %w", err)
@@ -185,6 +198,25 @@ func classifyFolder(folderPath string, client NotionClient) (*ValidationReport, 
 			continue
 		}
 
+		// Schema-based option validation (issue #90). An unknown select/
+		// multi_select value would silently auto-create a junk option in the
+		// shared schema; an unknown status value would 422 mid-run. Catch both
+		// here — local string compare against the fetched schema, before the
+		// conflict GetPage — so the whole run halts before any write. Only the
+		// gate supplies a schema; preview / --force pass nil and skip it.
+		if schema != nil {
+			if reason, ok := validateRowOptions(fm, schema, allowNewOptions); !ok {
+				add(FileClassification{
+					Path:     fullPath,
+					Class:    ClassHaltInvalidOption,
+					NotionID: notionID,
+					fm:       fm,
+					Reason:   reason,
+				})
+				continue
+			}
+		}
+
 		// Linked, not deleted, parseable. Network-free callers (preview,
 		// --force) stop here: the row is ready as far as disk can tell. The
 		// gate will resolve conflicts when a client is supplied.
@@ -232,4 +264,88 @@ func classifyFolder(folderPath string, client NotionClient) (*ValidationReport, 
 		})
 	}
 	return report, nil
+}
+
+// validateRowOptions checks every select / status / multi_select value in a
+// row's frontmatter against the schema's allowed options (issue #90). It
+// returns ok=false plus a user-facing reason listing all violations in the row
+// (sorted for deterministic output) when any value is unknown.
+//
+// The select/status asymmetry mirrors Notion's API: select and multi_select
+// options can be auto-created on write, so allowNewOptions lets a genuinely-new
+// category through; status options cannot be created via API, so an unknown
+// status always halts regardless of the flag.
+//
+// Empty/nil scalar values mean "clear the property" and are never invalid.
+func validateRowOptions(fm map[string]interface{}, schema map[string]notion.DatabaseProperty, allowNewOptions bool) (string, bool) {
+	var violations []string
+	for key, prop := range schema {
+		val, present := fm[key]
+		if !present {
+			continue
+		}
+		switch prop.Type {
+		case "select":
+			if allowNewOptions || prop.Select == nil {
+				continue
+			}
+			name := coerceString(val)
+			if name == "" {
+				continue
+			}
+			if !optionAllowed(prop.Select.Options, name) {
+				violations = append(violations, invalidOptionReason(key, name, prop.Select.Options))
+			}
+		case "status":
+			// No opt-in: Notion's API cannot create status options.
+			if prop.Status == nil {
+				continue
+			}
+			name := coerceString(val)
+			if name == "" {
+				continue
+			}
+			if !optionAllowed(prop.Status.Options, name) {
+				violations = append(violations, invalidOptionReason(key, name, prop.Status.Options))
+			}
+		case "multi_select":
+			if allowNewOptions || prop.MultiSelect == nil {
+				continue
+			}
+			for _, name := range coerceStringSlice(val) {
+				if name == "" {
+					continue
+				}
+				if !optionAllowed(prop.MultiSelect.Options, name) {
+					violations = append(violations, invalidOptionReason(key, name, prop.MultiSelect.Options))
+				}
+			}
+		}
+	}
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		return strings.Join(violations, "; "), false
+	}
+	return "", true
+}
+
+// optionAllowed reports whether name exactly matches one of the schema options.
+// Match is case-sensitive: Notion treats "Done" and "done" as distinct options.
+func optionAllowed(options []notion.SelectValue, name string) bool {
+	for _, o := range options {
+		if o.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// invalidOptionReason formats the halt reason for an unknown option value,
+// listing the allowed options in schema (Notion display) order.
+func invalidOptionReason(prop, value string, options []notion.SelectValue) string {
+	names := make([]string, 0, len(options))
+	for _, o := range options {
+		names = append(names, o.Name)
+	}
+	return fmt.Sprintf("%q is not a valid option for %q (allowed: %s)", value, prop, strings.Join(names, ", "))
 }

--- a/internal/sync/validation_options_test.go
+++ b/internal/sync/validation_options_test.go
@@ -1,0 +1,221 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ran-codes/notion-sync/internal/notion"
+)
+
+// selectProp builds a select/multi_select/status schema property with the given
+// option names. propType picks which option config field is populated.
+func optionProp(propType string, names ...string) notion.DatabaseProperty {
+	opts := make([]notion.SelectValue, 0, len(names))
+	for _, n := range names {
+		opts = append(opts, notion.SelectValue{Name: n})
+	}
+	cfg := &notion.SelectConfig{Options: opts}
+	p := notion.DatabaseProperty{Type: propType}
+	switch propType {
+	case "select":
+		p.Select = cfg
+	case "multi_select":
+		p.MultiSelect = cfg
+	case "status":
+		p.Status = cfg
+	}
+	return p
+}
+
+// --- validateRowOptions unit tests (issue #90) ---
+
+func TestValidateRowOptions_ValidSelectPasses(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Status": optionProp("select", "To Do", "Doing", "Done"),
+	}
+	fm := map[string]interface{}{"Status": "Done"}
+	if reason, ok := validateRowOptions(fm, schema, false); !ok {
+		t.Errorf("expected valid select to pass, got reason %q", reason)
+	}
+}
+
+func TestValidateRowOptions_InvalidSelectHaltsWithClearReason(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Status": optionProp("select", "To Do", "Doing", "Done"),
+	}
+	fm := map[string]interface{}{"Status": "Doen"}
+	reason, ok := validateRowOptions(fm, schema, false)
+	if ok {
+		t.Fatal("expected typo'd select value to fail validation")
+	}
+	// Acceptance criterion: exact reason shape.
+	want := `"Doen" is not a valid option for "Status" (allowed: To Do, Doing, Done)`
+	if reason != want {
+		t.Errorf("reason mismatch:\n got: %s\nwant: %s", reason, want)
+	}
+}
+
+func TestValidateRowOptions_ValidStatusPasses(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Stage": optionProp("status", "Backlog", "In Progress", "Shipped"),
+	}
+	fm := map[string]interface{}{"Stage": "In Progress"}
+	if reason, ok := validateRowOptions(fm, schema, false); !ok {
+		t.Errorf("expected valid status to pass, got reason %q", reason)
+	}
+}
+
+func TestValidateRowOptions_InvalidStatusHalts(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Stage": optionProp("status", "Backlog", "In Progress", "Shipped"),
+	}
+	fm := map[string]interface{}{"Stage": "Shppd"}
+	if _, ok := validateRowOptions(fm, schema, false); ok {
+		t.Error("expected unknown status value to fail validation")
+	}
+}
+
+// status has no opt-in: even with --allow-new-options, an unknown status value
+// halts (Notion's API cannot create status options).
+func TestValidateRowOptions_AllowNewOptionsStillHaltsStatus(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Stage": optionProp("status", "Backlog", "Shipped"),
+	}
+	fm := map[string]interface{}{"Stage": "Brand New"}
+	if _, ok := validateRowOptions(fm, schema, true); ok {
+		t.Error("unknown status must halt even with allowNewOptions=true")
+	}
+}
+
+// select/multi_select opt-in: --allow-new-options lets an unknown value through
+// (Notion auto-creates the option on push).
+func TestValidateRowOptions_AllowNewOptionsPassesSelectAndMultiSelect(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Priority": optionProp("select", "Low", "High"),
+		"Tags":     optionProp("multi_select", "urgent"),
+	}
+	fm := map[string]interface{}{
+		"Priority": "Critical",                         // not in options
+		"Tags":     []interface{}{"urgent", "new-tag"}, // new-tag not in options
+	}
+	if reason, ok := validateRowOptions(fm, schema, true); !ok {
+		t.Errorf("allowNewOptions must pass unknown select/multi_select, got reason %q", reason)
+	}
+}
+
+func TestValidateRowOptions_ValidMultiSelectPasses(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Tags": optionProp("multi_select", "a", "b", "c"),
+	}
+	fm := map[string]interface{}{"Tags": []interface{}{"a", "c"}}
+	if reason, ok := validateRowOptions(fm, schema, false); !ok {
+		t.Errorf("expected valid multi_select to pass, got reason %q", reason)
+	}
+}
+
+func TestValidateRowOptions_InvalidMultiSelectMemberHalts(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Tags": optionProp("multi_select", "a", "b"),
+	}
+	fm := map[string]interface{}{"Tags": []interface{}{"a", "z"}}
+	reason, ok := validateRowOptions(fm, schema, false)
+	if ok {
+		t.Fatal("expected unknown multi_select member to fail validation")
+	}
+	if !strings.Contains(reason, `"z"`) || !strings.Contains(reason, "Tags") {
+		t.Errorf("reason should name the bad value and property, got %q", reason)
+	}
+}
+
+// Empty/nil scalar means "clear the property" — never an invalid option.
+func TestValidateRowOptions_EmptyAndNilAreClears(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Status": optionProp("select", "Done"),
+		"Stage":  optionProp("status", "Shipped"),
+	}
+	for _, val := range []interface{}{"", nil} {
+		fm := map[string]interface{}{"Status": val, "Stage": val}
+		if reason, ok := validateRowOptions(fm, schema, false); !ok {
+			t.Errorf("clearing value %v must pass, got reason %q", val, reason)
+		}
+	}
+}
+
+// A schema property the row doesn't set is never validated.
+func TestValidateRowOptions_AbsentPropertyIgnored(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Status": optionProp("select", "Done"),
+	}
+	fm := map[string]interface{}{"OtherField": "whatever"}
+	if reason, ok := validateRowOptions(fm, schema, false); !ok {
+		t.Errorf("absent option property must not be validated, got reason %q", reason)
+	}
+}
+
+// Multiple violations in one row are collected and joined deterministically
+// (sorted) so the user fixes the whole row in one pass — no within-file fix loop.
+func TestValidateRowOptions_CollectsAllViolationsSorted(t *testing.T) {
+	schema := map[string]notion.DatabaseProperty{
+		"Status":   optionProp("select", "Done"),
+		"Priority": optionProp("select", "High"),
+	}
+	fm := map[string]interface{}{"Status": "Doen", "Priority": "Hihg"}
+	reason, ok := validateRowOptions(fm, schema, false)
+	if ok {
+		t.Fatal("expected two violations to fail validation")
+	}
+	if !strings.Contains(reason, "Priority") || !strings.Contains(reason, "Status") {
+		t.Errorf("expected both violations in reason, got %q", reason)
+	}
+	if !strings.Contains(reason, "; ") {
+		t.Errorf("expected violations joined by '; ', got %q", reason)
+	}
+	// Sorted: the Priority violation (`"Hihg"...`) sorts before Status (`"Doen"`...)?
+	// Sort is lexicographic on the full violation string; pin determinism by
+	// running twice and comparing.
+	reason2, _ := validateRowOptions(fm, schema, false)
+	if reason != reason2 {
+		t.Errorf("violation order must be deterministic: %q vs %q", reason, reason2)
+	}
+}
+
+// classifyFolder integration: a row with an invalid option under the gate
+// (schema supplied) classifies as ClassHaltInvalidOption and flips Halted —
+// without ever calling GetPage (local check runs before the conflict probe).
+func TestClassifyFolder_InvalidOptionHaltsBeforeConflictProbe(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-001\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Doen\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock has no page-001 → a GetPage would classify Unreachable. We expect
+	// InvalidOption instead, proving the option check short-circuits before the
+	// network probe.
+	client := newMockClient()
+	schema := map[string]notion.DatabaseProperty{
+		"Status": optionProp("select", "To Do", "Doing", "Done"),
+	}
+
+	report, err := classifyFolder(dir, client, schema, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(report.Files) != 1 {
+		t.Fatalf("expected 1 classification, got %d", len(report.Files))
+	}
+	got := report.Files[0]
+	if got.Class != ClassHaltInvalidOption {
+		t.Errorf("expected ClassHaltInvalidOption, got %v", got.Class)
+	}
+	if !report.Halted {
+		t.Error("invalid option must flip Halted=true")
+	}
+	if got.Reason == "" {
+		t.Error("invalid-option halt must populate Reason")
+	}
+}

--- a/internal/sync/validation_test.go
+++ b/internal/sync/validation_test.go
@@ -419,7 +419,7 @@ func TestClassifyFolder_NilClient_LinkedRowsReadyWithoutNetwork(t *testing.T) {
 	}
 
 	// Nil client: a GetPage would panic, so a passing run proves none happened.
-	report, err := classifyFolder(dir, nil)
+	report, err := classifyFolder(dir, nil, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Context

- Addressess #90 
- push validaitona for multi-/select propeorty to prevent introducing new optiosn

## Action Items

- [x] Development
- [x] Coder review
- [x] User Testing