### PR TITLE
feat(push): harden rich-text parser + un-skip rich_text on push (#95, #55)

### DIFF
--- a/internal/markdown/richtext_parser.go
+++ b/internal/markdown/richtext_parser.go
@@ -27,43 +27,235 @@ import (
 // flat rich-text model. Color/`@user` mention identity are intentionally NOT
 // handled — they are lost on import (Gap 1) and documented as not round-tripped.
 //
-// Known limitation — unbalanced markers corrupt content. The parser uses a flat
-// toggle model with NO balance checking, so any lone "*", "==", "`", "~~", or
-// "<u>" in ordinary cell text is treated as a formatting toggle. This is not mere
-// imprecise round-tripping: on valid input the parser actively FABRICATES
-// formatting and DROPS the orphan delimiter, e.g.
+// Marker balancing (the fix that made this parser push-safe). The naive toggle
+// model treats every lone "*", "==", "`", "~~", or "<u>" as a formatting marker,
+// which FABRICATES formatting and DROPS the delimiter on perfectly ordinary cell
+// values — "2 * 3 = 6", "5 * 4 * 3", "100% == done", a stray backtick. That is
+// exactly the corruption #95 set out to kill, so it must not reach Notion on push.
 //
-//	"2 * 3 = 6"     → " 3 = 6" emitted italic; the literal "*" is dropped
-//	"100% == done"  → " done" gets a phantom yellow_background highlight
-//	"a*b*c*d"       → alternating italic runs; all three "*" deleted
+// Instead the parser tokenizes first, then resolves which delimiters are real:
 //
-// Links share the defect through a different mechanism: tryLink matches the
-// FIRST ")" (and the first "]"), so a URL or bracketed text that itself contains
-// those characters is silently mis-parsed, e.g.
-//
-//	"[x](https://en.wikipedia.org/wiki/Foo_(bar))"
-//	    → URL truncated to ".../Foo_(bar" plus a phantom ")" text segment
-//
-// Here the Markdown STRING still round-trips (so a fixed-point test stays blind),
-// but the rich-text STRUCTURE sent to Notion is wrong — wrong URL, extra run.
-//
-// Multiplication, globs, footnote asterisks, "100% ==", and parenthesized URLs
-// (Wikipedia and friends) are real database cell values, so this MUST be fixed —
-// balance the markers (track open delimiter positions; treat a marker left
-// unclosed at EOF as literal text) and match link delimiters with nesting/escape
-// awareness — BEFORE this parser is wired into push, or it reintroduces the cell
-// corruption #95 set out to fix. It is unwired today — ParseRichText has zero
-// production callers (wiring is deferred to epic #55) — so the corruption is
-// latent, not live.
+//   - Toggle markers (** * ~~ ==) obey CommonMark-style flanking: a marker with
+//     whitespace immediately after it cannot open, and one with whitespace
+//     immediately before it cannot close. A marker that can neither open nor close
+//     — typically because it is surrounded by spaces, like the "*" in "2 * 3" or
+//     the "==" in "100% == done" — is demoted to literal text. Surviving markers
+//     are matched open→close; any opener left unclosed at end of input is also
+//     literal. So "2 * 3" and "5 * 4 * 3" keep their asterisks, "x == y == z"
+//     keeps its "==", and "a*b*c*d" yields one italic run plus a literal tail
+//     rather than deleting every marker.
+//   - <u>/</u> are matched as an explicit open/close pair via a stack; an
+//     unmatched <u> or </u> is literal.
+//   - Code spans take content literally up to the next backtick; an unterminated
+//     backtick is literal, not a code span swallowing the rest of the line.
+//   - Links match their delimiters with nesting awareness: the text's "]" is the
+//     bracket-balanced close and the URL's ")" is the paren-balanced close, so a
+//     parenthesized URL such as
+//     "[x](https://en.wikipedia.org/wiki/Foo_(bar))" keeps its full URL instead
+//     of truncating at "Foo_(bar" and emitting a phantom ")" segment.
 //
 // Pure function — no push wiring lives here.
 func ParseRichText(md string) []notion.RichText {
-	p := &inlineParser{src: md}
-	p.run()
+	toks := tokenize(md)
+	resolveActive(toks)
+	p := &inlineParser{}
+	p.emit(toks)
 	if len(p.out) == 0 {
 		return nil
 	}
 	return p.out
+}
+
+// tokKind classifies a lexed token. Delimiter kinds carry their literal source in
+// token.text so an unresolved (orphan) delimiter can be re-emitted verbatim.
+type tokKind int
+
+const (
+	tkText      tokKind = iota // literal text run
+	tkBold                     // **
+	tkItalic                   // *
+	tkStrike                   // ~~
+	tkHighlight                // ==
+	tkUOpen                    // <u>
+	tkUClose                   // </u>
+	tkCode                     // `...` (text = literal content)
+	tkLink                     // [text](url)
+)
+
+// token is one lexed unit. For delimiter kinds, text holds the literal marker so
+// an inactive (unpaired) delimiter falls back to plain text. canOpen/canClose are
+// the flanking flags for toggle markers; active is filled in by resolveActive:
+// true means the delimiter acts as formatting, false means it is emitted literally.
+type token struct {
+	kind              tokKind
+	text              string // literal text, code content, link text, or raw delimiter
+	url               string // link URL (tkLink only)
+	canOpen, canClose bool   // flanking: may this toggle marker open / close emphasis?
+	active            bool   // delimiter resolved to real formatting (pass 2)
+}
+
+// tokenize lexes the input into text and delimiter tokens. Code spans and links
+// are lexed greedily (their inner markers are literal); a "[" that does not form a
+// valid link and an unterminated backtick fall back to literal text. Toggle
+// markers record their flanking so resolveActive can pair them.
+func tokenize(src string) []token {
+	var toks []token
+	appendText := func(s string) {
+		if n := len(toks); n > 0 && toks[n-1].kind == tkText {
+			toks[n-1].text += s
+		} else {
+			toks = append(toks, token{kind: tkText, text: s})
+		}
+	}
+	toggle := func(i, length int, kind tokKind, lit string) token {
+		open, close := flanking(src, i, length)
+		return token{kind: kind, text: lit, canOpen: open, canClose: close}
+	}
+	i := 0
+	for i < len(src) {
+		rest := src[i:]
+		switch {
+		case strings.HasPrefix(rest, "`"):
+			if content, n, ok := scanCode(rest); ok {
+				toks = append(toks, token{kind: tkCode, text: content})
+				i += n
+			} else {
+				appendText("`")
+				i++
+			}
+		case strings.HasPrefix(rest, "["):
+			if text, url, n, ok := scanLink(rest); ok {
+				toks = append(toks, token{kind: tkLink, text: text, url: url})
+				i += n
+			} else {
+				appendText("[")
+				i++
+			}
+		case strings.HasPrefix(rest, "<u>"):
+			toks = append(toks, token{kind: tkUOpen, text: "<u>"})
+			i += 3
+		case strings.HasPrefix(rest, "</u>"):
+			toks = append(toks, token{kind: tkUClose, text: "</u>"})
+			i += 4
+		case strings.HasPrefix(rest, "**"):
+			toks = append(toks, toggle(i, 2, tkBold, "**"))
+			i += 2
+		case strings.HasPrefix(rest, "~~"):
+			toks = append(toks, toggle(i, 2, tkStrike, "~~"))
+			i += 2
+		case strings.HasPrefix(rest, "=="):
+			toks = append(toks, toggle(i, 2, tkHighlight, "=="))
+			i += 2
+		case strings.HasPrefix(rest, "*"):
+			toks = append(toks, toggle(i, 1, tkItalic, "*"))
+			i++
+		default:
+			appendText(src[i : i+1])
+			i++
+		}
+	}
+	return toks
+}
+
+// flanking reports whether a toggle marker of the given length at position i may
+// open and/or close emphasis (CommonMark-simplified): a marker may open only if
+// the character immediately after it is not whitespace, and may close only if the
+// character immediately before it is not whitespace.
+func flanking(src string, i, length int) (canOpen, canClose bool) {
+	if i+length < len(src) {
+		canOpen = !isInlineSpace(src[i+length])
+	}
+	if i > 0 {
+		canClose = !isInlineSpace(src[i-1])
+	}
+	return
+}
+
+func isInlineSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// scanCode reads a code span starting at a backtick. The content is everything up
+// to the next backtick (markers inside are literal). Returns ok=false for an
+// unterminated span so the caller emits the backtick as literal text.
+func scanCode(rest string) (content string, n int, ok bool) {
+	end := strings.IndexByte(rest[1:], '`')
+	if end < 0 {
+		return "", 0, false
+	}
+	return rest[1 : 1+end], 1 + end + 1, true
+}
+
+// scanLink parses "[text](url)" with nesting-aware delimiter matching: the text's
+// closing "]" is bracket-balanced and the URL's closing ")" is paren-balanced, so
+// a parenthesized URL is not truncated. Returns ok=false if the syntax does not
+// match so the caller falls back to treating "[" as literal text.
+func scanLink(rest string) (text, url string, n int, ok bool) {
+	closeText := matchDelim(rest, 0, '[', ']')
+	if closeText < 0 || closeText+1 >= len(rest) || rest[closeText+1] != '(' {
+		return "", "", 0, false
+	}
+	closeURL := matchDelim(rest, closeText+1, '(', ')')
+	if closeURL < 0 {
+		return "", "", 0, false
+	}
+	return rest[1:closeText], rest[closeText+2 : closeURL], closeURL + 1, true
+}
+
+// matchDelim returns the index of the close delimiter that balances the open
+// delimiter at position start, or -1 if unbalanced. s[start] must equal open.
+func matchDelim(s string, start int, open, close byte) int {
+	depth := 0
+	for j := start; j < len(s); j++ {
+		switch s[j] {
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return j
+			}
+		}
+	}
+	return -1
+}
+
+// resolveActive marks which delimiter tokens are real formatting (matched) versus
+// lone markers (emitted literally). Toggle kinds are paired open→close per type
+// using flanking: a closer pops the nearest open opener; an opener left unmatched
+// at end of input stays inactive. <u>/</u> match as an explicit open/close pair.
+func resolveActive(toks []token) {
+	for _, kind := range []tokKind{tkBold, tkItalic, tkStrike, tkHighlight} {
+		var open []int
+		for i := range toks {
+			if toks[i].kind != kind {
+				continue
+			}
+			switch {
+			case toks[i].canClose && len(open) > 0:
+				o := open[len(open)-1]
+				open = open[:len(open)-1]
+				toks[o].active = true
+				toks[i].active = true
+			case toks[i].canOpen:
+				open = append(open, i)
+			}
+		}
+	}
+	var stack []int
+	for i := range toks {
+		switch toks[i].kind {
+		case tkUOpen:
+			stack = append(stack, i)
+		case tkUClose:
+			if len(stack) > 0 {
+				o := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				toks[o].active = true
+				toks[i].active = true
+			}
+		}
+	}
 }
 
 // inlineState is the set of annotations currently active at the scan position.
@@ -74,62 +266,65 @@ type inlineState struct {
 }
 
 type inlineParser struct {
-	src string
-	pos int
 	buf strings.Builder
 	st  inlineState
 	out []notion.RichText
 }
 
-func (p *inlineParser) run() {
-	for p.pos < len(p.src) {
-		switch {
-		case p.consume("`"):
+// emit walks the resolved tokens, flipping annotation state on active delimiters,
+// buffering text (and inactive delimiters' literal markers), and flushing a
+// segment whenever the state changes or a code/link token is reached.
+func (p *inlineParser) emit(toks []token) {
+	for _, t := range toks {
+		switch t.kind {
+		case tkText:
+			p.buf.WriteString(t.text)
+		case tkBold:
+			p.toggle(t, &p.st.bold)
+		case tkItalic:
+			p.toggle(t, &p.st.italic)
+		case tkStrike:
+			p.toggle(t, &p.st.strike)
+		case tkHighlight:
+			p.toggle(t, &p.st.highlight)
+		case tkUOpen:
+			p.set(t, &p.st.underline, true)
+		case tkUClose:
+			p.set(t, &p.st.underline, false)
+		case tkCode:
 			p.flush()
-			p.emitCode()
-		case p.startsWith("["):
-			if !p.tryLink() {
-				p.buf.WriteByte(p.src[p.pos])
-				p.pos++
-			}
-		case p.consume("<u>"):
+			rt := p.segment(t.text, nil)
+			rt.Annotations.Code = true
+			p.out = append(p.out, rt)
+		case tkLink:
 			p.flush()
-			p.st.underline = true
-		case p.consume("</u>"):
-			p.flush()
-			p.st.underline = false
-		case p.consume("**"):
-			p.flush()
-			p.st.bold = !p.st.bold
-		case p.consume("~~"):
-			p.flush()
-			p.st.strike = !p.st.strike
-		case p.consume("=="):
-			p.flush()
-			p.st.highlight = !p.st.highlight
-		case p.consume("*"):
-			p.flush()
-			p.st.italic = !p.st.italic
-		default:
-			p.buf.WriteByte(p.src[p.pos])
-			p.pos++
+			url := t.url
+			p.out = append(p.out, p.segment(t.text, &url))
 		}
 	}
 	p.flush()
 }
 
-// startsWith reports whether the remaining input begins with s.
-func (p *inlineParser) startsWith(s string) bool {
-	return strings.HasPrefix(p.src[p.pos:], s)
+// toggle flips a boolean annotation for an active delimiter (flushing the segment
+// before the boundary); an inactive (lone) delimiter is emitted as literal text.
+func (p *inlineParser) toggle(t token, flag *bool) {
+	if !t.active {
+		p.buf.WriteString(t.text)
+		return
+	}
+	p.flush()
+	*flag = !*flag
 }
 
-// consume advances past s and returns true if the remaining input begins with it.
-func (p *inlineParser) consume(s string) bool {
-	if p.startsWith(s) {
-		p.pos += len(s)
-		return true
+// set assigns a boolean annotation for an active open/close delimiter (flushing
+// first); an inactive delimiter is emitted as literal text.
+func (p *inlineParser) set(t token, flag *bool, v bool) {
+	if !t.active {
+		p.buf.WriteString(t.text)
+		return
 	}
-	return false
+	p.flush()
+	*flag = v
 }
 
 // flush emits the buffered text (if any) as a segment carrying the current
@@ -140,50 +335,6 @@ func (p *inlineParser) flush() {
 	}
 	p.out = append(p.out, p.segment(p.buf.String(), nil))
 	p.buf.Reset()
-}
-
-// emitCode reads a code span: everything up to the next backtick is literal
-// content (no nested markers), emitted as one segment with Code set.
-func (p *inlineParser) emitCode() {
-	end := strings.IndexByte(p.src[p.pos:], '`')
-	if end < 0 {
-		// Unterminated code span: treat the rest as literal code content.
-		end = len(p.src) - p.pos
-	}
-	content := p.src[p.pos : p.pos+end]
-	rt := p.segment(content, nil)
-	rt.Annotations.Code = true
-	p.out = append(p.out, rt)
-	p.pos += end
-	if p.pos < len(p.src) {
-		p.pos++ // skip closing backtick
-	}
-}
-
-// tryLink parses "[text](url)" at the current position. The bracketed text is
-// treated as literal (the renderer never nests markers inside the brackets).
-// Returns false if the syntax doesn't match so the caller can fall back to
-// treating "[" as plain text.
-func (p *inlineParser) tryLink() bool {
-	rest := p.src[p.pos:]
-	if !strings.HasPrefix(rest, "[") {
-		return false
-	}
-	closeText := strings.IndexByte(rest, ']')
-	if closeText < 0 || closeText+1 >= len(rest) || rest[closeText+1] != '(' {
-		return false
-	}
-	closeURL := strings.IndexByte(rest[closeText+2:], ')')
-	if closeURL < 0 {
-		return false
-	}
-	text := rest[1:closeText]
-	url := rest[closeText+2 : closeText+2+closeURL]
-	p.flush()
-	rt := p.segment(text, &url)
-	p.out = append(p.out, rt)
-	p.pos += closeText + 2 + closeURL + 1
-	return true
 }
 
 // segment builds a rich-text segment for content under the current annotation

--- a/internal/markdown/richtext_parser_test.go
+++ b/internal/markdown/richtext_parser_test.go
@@ -123,6 +123,130 @@ func TestParseRichText(t *testing.T) {
 	}
 }
 
+// TestParseRichText_MarkerBalancing is the parser-hardening contract (issue #95):
+// stray, space-flanked, or unpaired markers in ordinary cell values must be
+// emitted as literal text, never consumed as formatting. Before this fix the
+// naive toggle model fabricated formatting and dropped the delimiter — e.g.
+// "2 * 3" became " 3" italic with the "*" deleted — reintroducing the very
+// corruption the parser exists to prevent.
+func TestParseRichText_MarkerBalancing(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []notion.RichText
+	}{
+		{
+			name:  "space-flanked asterisk is literal (multiplication)",
+			input: "2 * 3 = 6",
+			want: []notion.RichText{
+				txt("2 * 3 = 6", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "two space-flanked asterisks stay literal (chained multiply)",
+			input: "5 * 4 * 3",
+			want: []notion.RichText{
+				txt("5 * 4 * 3", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "space-flanked highlight markers are literal",
+			input: "100% == done",
+			want: []notion.RichText{
+				txt("100% == done", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "space-flanked highlight comparison stays literal",
+			input: "x == y == z",
+			want: []notion.RichText{
+				txt("x == y == z", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "odd asterisk run pairs once, trailing marker is literal",
+			input: "a*b*c*d",
+			want: []notion.RichText{
+				txt("a", notion.Annotations{Color: "default"}),
+				txt("b", notion.Annotations{Italic: true, Color: "default"}),
+				txt("c*d", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "lone asterisk is literal",
+			input: "*",
+			want: []notion.RichText{
+				txt("*", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "unterminated backtick is literal, not a code span",
+			input: "use `ls here",
+			want: []notion.RichText{
+				txt("use `ls here", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "unmatched closing underline tag is literal",
+			input: "a</u>b",
+			want: []notion.RichText{
+				txt("a</u>b", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "unmatched opening underline tag is literal",
+			input: "a<u>b",
+			want: []notion.RichText{
+				txt("a<u>b", notion.Annotations{Color: "default"}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseRichText(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseRichText(%q):\n got = %s\nwant = %s", tt.input, dump(got), dump(tt.want))
+			}
+		})
+	}
+}
+
+// TestParseRichText_NestedLinkDelimiters is the link-hardening contract (issue
+// #95): a URL containing parentheses (Wikipedia and friends) must keep its full
+// URL. The naive "first )" match truncated it and emitted a phantom ")" segment —
+// the Markdown string still round-tripped, hiding the structural corruption, so
+// this asserts the parsed structure directly.
+func TestParseRichText_NestedLinkDelimiters(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []notion.RichText
+	}{
+		{
+			name:  "parenthesized URL keeps balanced closing paren",
+			input: "[x](https://en.wikipedia.org/wiki/Foo_(bar))",
+			want: []notion.RichText{
+				link("x", "https://en.wikipedia.org/wiki/Foo_(bar)", notion.Annotations{Color: "default"}),
+			},
+		},
+		{
+			name:  "plain link is unaffected",
+			input: "[a](https://example.com)",
+			want: []notion.RichText{
+				link("a", "https://example.com", notion.Annotations{Color: "default"}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseRichText(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseRichText(%q):\n got = %s\nwant = %s", tt.input, dump(got), dump(tt.want))
+			}
+		})
+	}
+}
+
 // txt builds a plain "text" rich-text segment with the given content and annotations.
 func txt(content string, a notion.Annotations) notion.RichText {
 	return notion.RichText{
@@ -151,6 +275,13 @@ func TestParseRichText_RoundTrip(t *testing.T) {
 		"**bold *and italic* bold**",
 		"**[text](https://example.com)**",
 		"plain `inline code` and **bold** mixed",
+		// Adversarial: ordinary cell values whose stray markers must survive as
+		// literals rather than be consumed as formatting (issue #95, parser hardening).
+		"2 * 3 = 6",
+		"5 * 4 * 3",
+		"100% == done",
+		"a*b*c*d",
+		"[x](https://en.wikipedia.org/wiki/Foo_(bar))",
 	}
 	for _, s := range cases {
 		t.Run(s, func(t *testing.T) {

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ran-codes/notion-sync/internal/markdown"
 	"github.com/ran-codes/notion-sync/internal/notion"
 )
 
@@ -302,11 +303,11 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 //
 // It mirrors buildPropertyPayload's iteration (same notion-key / read-only-type
 // skips) so the diff can never flag a field the push wouldn't actually send.
-// rich_text is additionally skipped — the deliberate "3a skip" (issue #55):
-// pushing rich_text as literal plain text corrupts formatting, so until #95's
-// parser is wired a rich-text-only edit must not count as a change. The snapshot
-// is decoded with mapPropertiesToFrontmatter so both sides are compared in the
-// same frontmatter representation they were imported in.
+// rich_text now participates: the 3a skip (issue #55) is reversed because #95's
+// parser lets rich_text round-trip with formatting intact, so a rich-text edit is
+// a real change again. The snapshot is decoded with mapPropertiesToFrontmatter so
+// both sides are compared in the same frontmatter representation they were
+// imported in — rich_text on both sides is the rendered Markdown string.
 func diffRow(fm map[string]interface{}, snapshot *notion.Page, schema map[string]notion.DatabaseProperty) []string {
 	remote := map[string]interface{}{}
 	if snapshot != nil {
@@ -316,12 +317,6 @@ func diffRow(fm map[string]interface{}, snapshot *notion.Page, schema map[string
 	for key, localVal := range fm {
 		prop, ok := pushableField(key, schema)
 		if !ok {
-			continue
-		}
-		// The deliberate "3a skip": rich_text is excluded from the diff (but not
-		// from buildPropertyPayload's send) until #95's parser lands, so a
-		// rich_text-only edit is a no-op instead of a formatting-corrupting push.
-		if prop.Type == "rich_text" {
 			continue
 		}
 		if !valuesEqual(prop.Type, localVal, remote[key]) {
@@ -344,11 +339,11 @@ type fieldMismatch struct {
 // verifyStoredFields re-decodes the row Notion stored after a push and returns a
 // mismatch for each changed field whose stored value does not match what we sent
 // (DAG n34d). A non-empty result is a read-back mismatch (n34e). It compares only
-// the fields the push actually sent (changedFields) and, like diffRow, skips
-// rich_text — rich_text is never sent (the 3a skip), so it can be neither
-// verified nor blamed. mapPropertiesToFrontmatter + valuesEqual decode and
-// compare both sides in the same representation the diff used, so verify can't
-// disagree with diff.
+// the fields the push actually sent (changedFields). rich_text now participates
+// (the 3a skip is reversed, #95): it is sent through the parser and read back as
+// rendered Markdown, so a formatting round-trip failure surfaces here like any
+// other field. mapPropertiesToFrontmatter + valuesEqual decode and compare both
+// sides in the same representation the diff used, so verify can't disagree with diff.
 func verifyStoredFields(fm map[string]interface{}, stored *notion.Page, schema map[string]notion.DatabaseProperty, changedFields []string) []fieldMismatch {
 	remote := map[string]interface{}{}
 	if stored != nil {
@@ -358,9 +353,6 @@ func verifyStoredFields(fm map[string]interface{}, stored *notion.Page, schema m
 	for _, key := range changedFields {
 		prop, ok := pushableField(key, schema)
 		if !ok {
-			continue
-		}
-		if prop.Type == "rich_text" {
 			continue
 		}
 		if !valuesEqual(prop.Type, fm[key], remote[key]) {
@@ -398,9 +390,11 @@ func pushableField(key string, schema map[string]notion.DatabaseProperty) (notio
 // snapshot value represent the same stored property, using type-aware equality.
 func valuesEqual(propType string, local, remote interface{}) bool {
 	switch propType {
-	case "title", "select", "status", "url", "email", "phone_number":
-		// Scalar strings: a cleared value is nil from Notion's decode but may be
-		// "" locally. coerceString folds nil→"" so they compare equal.
+	case "title", "rich_text", "select", "status", "url", "email", "phone_number":
+		// Scalar / rendered-Markdown strings: a cleared value is nil from Notion's
+		// decode but may be "" locally. coerceString folds nil→"" so they compare
+		// equal. rich_text compares as the Markdown string ConvertRichText renders
+		// on both sides, so the diff is invariant to re-segmentation.
 		return coerceString(local) == coerceString(remote)
 	case "multi_select":
 		// Unordered set in Notion — a reorder is not a change.
@@ -496,9 +490,9 @@ func buildPropertyPayload(fm map[string]interface{}, schema map[string]notion.Da
 // buildPropertyPayloadFor is buildPropertyPayload restricted to a set of keys.
 // A nil `only` means "every pushable field" (the --force overwrite-blind path);
 // a non-nil `only` restricts the payload to exactly those keys — the changed-
-// field set from the diff (DAG n33). Restricting to changed fields also means a
-// rich_text field that the diff skips never reaches the payload on a mixed edit,
-// so a scalar change can't drag a formatting-corrupting rich_text push along.
+// field set from the diff (DAG n33). rich_text now diffs and sends like any other
+// field (#95 un-skip): an unchanged rich_text cell is simply absent from the
+// changed set, so it never reaches the payload on a mixed edit.
 func buildPropertyPayloadFor(fm map[string]interface{}, schema map[string]notion.DatabaseProperty, only []string) (map[string]interface{}, []string) {
 	var onlySet map[string]bool
 	if only != nil {
@@ -534,14 +528,12 @@ func buildPropertyPayloadFor(fm map[string]interface{}, schema map[string]notion
 func buildPropertyValue(propType string, val interface{}) interface{} {
 	switch propType {
 	case "title", "rich_text":
+		// Deserialize the Markdown back into a Notion rich-text array (#95 Gap 2)
+		// so inline formatting round-trips instead of landing as literal markers.
+		// An empty value yields an empty array, which clears the cell.
 		s := coerceString(val)
 		return map[string]interface{}{
-			propType: []interface{}{
-				map[string]interface{}{
-					"type": "text",
-					"text": map[string]interface{}{"content": s},
-				},
-			},
+			propType: richTextPayload(markdown.ParseRichText(s)),
 		}
 
 	case "number":
@@ -623,6 +615,49 @@ func buildPropertyValue(propType string, val interface{}) interface{} {
 		return map[string]interface{}{"relation": rels}
 	}
 	return nil
+}
+
+// richTextPayload converts parsed rich-text segments (#95) into the Notion API
+// array form for a title/rich_text property update. An empty slice yields an
+// empty array, which clears the property in Notion.
+func richTextPayload(segs []notion.RichText) []interface{} {
+	out := make([]interface{}, 0, len(segs))
+	for _, s := range segs {
+		text := map[string]interface{}{"content": ""}
+		if s.Text != nil {
+			text["content"] = s.Text.Content
+			if s.Text.Link != nil {
+				text["link"] = map[string]interface{}{"url": s.Text.Link.URL}
+			}
+		}
+		seg := map[string]interface{}{"type": "text", "text": text}
+		if ann := annotationsPayload(s.Annotations); ann != nil {
+			seg["annotations"] = ann
+		}
+		out = append(out, seg)
+	}
+	return out
+}
+
+// annotationsPayload returns the Notion annotations object for a segment, or nil
+// when every annotation is at its default — plain text then sends no annotations
+// object, matching the minimal payload the pre-#95 plain-text push produced.
+func annotationsPayload(a notion.Annotations) map[string]interface{} {
+	color := a.Color
+	if color == "" {
+		color = "default"
+	}
+	if !a.Bold && !a.Italic && !a.Strikethrough && !a.Underline && !a.Code && color == "default" {
+		return nil
+	}
+	return map[string]interface{}{
+		"bold":          a.Bold,
+		"italic":        a.Italic,
+		"strikethrough": a.Strikethrough,
+		"underline":     a.Underline,
+		"code":          a.Code,
+		"color":         color,
+	}
 }
 
 func parseDatePayload(s string) interface{} {

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -118,9 +118,39 @@ func TestBuildPropertyValue_RichText(t *testing.T) {
 	if len(rt) != 1 {
 		t.Fatalf("expected 1 rich_text item, got %d", len(rt))
 	}
-	text := rt[0].(map[string]interface{})["text"].(map[string]interface{})["content"]
+	item := rt[0].(map[string]interface{})
+	text := item["text"].(map[string]interface{})["content"]
 	if text != "hello world" {
 		t.Errorf("expected 'hello world', got %v", text)
+	}
+	// Plain text carries no annotations object (minimal payload).
+	if _, ok := item["annotations"]; ok {
+		t.Errorf("expected no annotations for plain text, got %v", item["annotations"])
+	}
+}
+
+// #95 wiring: a rich_text value with inline Markdown is deserialized into
+// formatted segments (not sent as literal markers). "a **b** c" → three segments
+// with the middle one bold.
+func TestBuildPropertyValue_RichTextFormattingPreserved(t *testing.T) {
+	got := buildPropertyValue("rich_text", "a **b** c")
+	rt := got.(map[string]interface{})["rich_text"].([]interface{})
+	if len(rt) != 3 {
+		t.Fatalf("expected 3 segments for 'a **b** c', got %d: %v", len(rt), rt)
+	}
+	mid := rt[1].(map[string]interface{})
+	if c := mid["text"].(map[string]interface{})["content"]; c != "b" {
+		t.Errorf("expected middle segment content 'b', got %q", c)
+	}
+	ann, ok := mid["annotations"].(map[string]interface{})
+	if !ok || ann["bold"] != true {
+		t.Errorf("expected middle segment to be bold, got annotations %v", mid["annotations"])
+	}
+	// The bold markers must not survive as literal text in any segment.
+	for _, item := range rt {
+		if c := item.(map[string]interface{})["text"].(map[string]interface{})["content"].(string); strings.Contains(c, "**") {
+			t.Errorf("expected no literal '**' markers, found in %q", c)
+		}
 	}
 }
 
@@ -136,23 +166,19 @@ func TestBuildPropertyValue_Title(t *testing.T) {
 	}
 }
 
-// Empty string in the title frontmatter key is intentionally pushed as a
-// single empty rich-text item, mirroring rich_text behavior. Locks in this
-// choice so it doesn't silently drift to {"title": []} (Notion's "clear").
+// Empty string clears the cell: the parser (#95) returns no segments for "", so
+// the title is pushed as an empty rich-text array ({"title": []}) — Notion's
+// "clear". (Reverses the pre-#95 choice of a single empty item.)
 func TestBuildPropertyValue_TitleEmptyString(t *testing.T) {
 	got := buildPropertyValue("title", "")
 	tt := got.(map[string]interface{})["title"].([]interface{})
-	if len(tt) != 1 {
-		t.Fatalf("expected 1 title item for empty string, got %d", len(tt))
-	}
-	text := tt[0].(map[string]interface{})["text"].(map[string]interface{})["content"]
-	if text != "" {
-		t.Errorf("expected empty content, got %q", text)
+	if len(tt) != 0 {
+		t.Fatalf("expected empty title array for empty string, got %d items", len(tt))
 	}
 }
 
-// Nil flows through coerceString → "" and is pushed as an empty title item,
-// same as rich_text. Locks in the behavior.
+// Nil flows through coerceString → "" → the parser yields no segments, so the
+// title is pushed as an empty array (Notion's "clear"). Still present in the payload.
 func TestBuildPropertyPayload_TitleNilCoercesToEmpty(t *testing.T) {
 	schema := map[string]notion.DatabaseProperty{"Metric Name": {Type: "title"}}
 	fm := map[string]interface{}{"Metric Name": nil}
@@ -162,30 +188,47 @@ func TestBuildPropertyPayload_TitleNilCoercesToEmpty(t *testing.T) {
 	}
 	payload, ok := got["Metric Name"]
 	if !ok {
-		t.Fatalf("expected 'Metric Name' in payload (nil → empty), got %v", got)
+		t.Fatalf("expected 'Metric Name' in payload (nil → empty array), got %v", got)
 	}
 	tt := payload.(map[string]interface{})["title"].([]interface{})
-	text := tt[0].(map[string]interface{})["text"].(map[string]interface{})["content"]
-	if text != "" {
-		t.Errorf("expected empty content for nil title, got %q", text)
+	if len(tt) != 0 {
+		t.Fatalf("expected empty title array for nil, got %d items", len(tt))
 	}
 }
 
-// Known limitation: imported titles encode formatting (bold, links, mentions)
-// as literal markdown via ConvertRichText. Push sends that string as plain
-// text content with no parsing — so a roundtripped title loses its formatting
-// and gains visible asterisks/brackets in Notion. This test pins the current
-// behavior so a regression (or a future fix) is loud.
-func TestBuildPropertyValue_TitleMarkdownIsLiteral(t *testing.T) {
+// Imported titles/rich_text encode formatting as Markdown via ConvertRichText.
+// Push now deserializes that Markdown back into a Notion rich-text array
+// (#95 Gap 2), so bold/links round-trip instead of landing as literal markers.
+// Mentions ([[notion-id: ...]]) are intentionally NOT parsed and stay literal.
+func TestBuildPropertyValue_TitleMarkdownIsParsed(t *testing.T) {
 	in := "**Bold** with [link](https://example.com) and [[notion-id: abc]]"
 	got := buildPropertyValue("title", in)
 	tt := got.(map[string]interface{})["title"].([]interface{})
-	if len(tt) != 1 {
-		t.Fatalf("expected 1 title item, got %d", len(tt))
+
+	// First segment is bold "Bold".
+	first := tt[0].(map[string]interface{})
+	if c := first["text"].(map[string]interface{})["content"]; c != "Bold" {
+		t.Errorf("expected first segment content 'Bold', got %q", c)
 	}
-	text := tt[0].(map[string]interface{})["text"].(map[string]interface{})["content"]
-	if text != in {
-		t.Errorf("expected markdown to be sent verbatim as plain text\n  want: %q\n   got: %q", in, text)
+	if ann, _ := first["annotations"].(map[string]interface{}); ann == nil || ann["bold"] != true {
+		t.Errorf("expected first segment to be bold, got annotations %v", first["annotations"])
+	}
+
+	// A link segment carries the URL; the mention stays literal text.
+	var linkURL string
+	var joined strings.Builder
+	for _, item := range tt {
+		txt := item.(map[string]interface{})["text"].(map[string]interface{})
+		joined.WriteString(txt["content"].(string))
+		if l, ok := txt["link"].(map[string]interface{}); ok {
+			linkURL = l["url"].(string)
+		}
+	}
+	if linkURL != "https://example.com" {
+		t.Errorf("expected a link segment with the URL, got %q", linkURL)
+	}
+	if !strings.Contains(joined.String(), "[[notion-id: abc]]") {
+		t.Errorf("expected the mention to stay literal, joined content = %q", joined.String())
 	}
 }
 
@@ -434,10 +477,10 @@ func TestDiffRow_n31_DateMidnightNormalizationIsNoChange(t *testing.T) {
 	}
 }
 
-// n31: the deliberate "3a skip" — rich_text is excluded from the diff until
-// #95's parser lands. Even a genuine rich_text edit must not count as a change,
-// so it never triggers the formatting-corrupting literal-plain push.
-func TestDiffRow_n31_RichTextExcludedFromDiff(t *testing.T) {
+// n31: the 3a skip is reversed (#95) — rich_text now participates in the diff
+// because the parser lets it round-trip with formatting intact. A genuine
+// rich_text edit is a real change again.
+func TestDiffRow_n31_RichTextChangeDetected(t *testing.T) {
 	snapshot := &notion.Page{
 		Properties: map[string]notion.Property{
 			"Notes": {Type: "rich_text", RichText: []notion.RichText{
@@ -449,8 +492,28 @@ func TestDiffRow_n31_RichTextExcludedFromDiff(t *testing.T) {
 	fm := map[string]interface{}{"Notes": "new text"} // changed locally
 
 	got := diffRow(fm, snapshot, schema)
+	if len(got) != 1 || got[0] != "Notes" {
+		t.Errorf("expected [Notes] (rich_text edit detected), got %v", got)
+	}
+}
+
+// n31: an unchanged rich_text cell — local Markdown equals the snapshot rendered
+// by ConvertRichText — is not flagged, so a no-op edit never reaches the push.
+func TestDiffRow_n31_RichTextUnchangedIsNoOp(t *testing.T) {
+	snapshot := &notion.Page{
+		Properties: map[string]notion.Property{
+			"Notes": {Type: "rich_text", RichText: []notion.RichText{
+				{Type: "text", PlainText: "bold", Text: &notion.TextContent{Content: "bold"},
+					Annotations: notion.Annotations{Bold: true, Color: "default"}},
+			}},
+		},
+	}
+	schema := map[string]notion.DatabaseProperty{"Notes": {Type: "rich_text"}}
+	fm := map[string]interface{}{"Notes": "**bold**"} // matches the rendered snapshot
+
+	got := diffRow(fm, snapshot, schema)
 	if len(got) != 0 {
-		t.Errorf("expected rich_text to be excluded from diff, got %v", got)
+		t.Errorf("expected no change for matching rich_text, got %v", got)
 	}
 }
 
@@ -527,8 +590,8 @@ func TestPushDatabase_n32a_UnchangedRowSkippedNoOp_NoUpdatePageCall(t *testing.T
 // n33: the push must send ONLY the fields the diff flagged as changed, not the
 // whole pushable set. Here Status matches the snapshot and only Priority moved —
 // the UpdatePage payload must carry Priority alone. Sending the untouched Status
-// is wasteful and, for a mixed rich_text+scalar edit, would re-send (and corrupt)
-// the rich_text the diff deliberately skipped.
+// is wasteful and, for a mixed rich_text+scalar edit, would needlessly re-send an
+// unchanged rich_text cell the diff (correctly) left out of the changed set.
 func TestPushDatabase_n33_SendsOnlyChangedFields(t *testing.T) {
 	dir := t.TempDir()
 	writeDatabaseMeta(t, dir, "db-001")


### PR DESCRIPTION
## Context

- Addresess #55 
- Makes rich text paeserialiaiotn robsut and wires up to push funcitonality


## Action Items

- [x] Developemnt
- [x] Code Review 
- [x] User Testing
