### PR TITLE
feat(push): structured JSON run summary — single agent-readable sink (Phase 4, n41, #55)

### DIFF
--- a/.claude/skills/test-push/SKILL.md
+++ b/.claude/skills/test-push/SKILL.md
@@ -30,7 +30,7 @@ Step-group letters map to the four-phase v1.4.0 push DAG. Each phase PR appends 
 | 2: Validation halts | n21 series → n22a/b | **V** | ✅ included |
 | 3a: Per-cell diff + skip no-op rows | n31 → n32a/b/c | **C** | ✅ included (PR #97) |
 | 3b/3c: Per-field payload + store-verify + restamp + auth halt | n33 → n34d/e → n35a/n36a; n34h | **C** | ✅ included (PR #98) |
-| 4: Run summary JSON | n41 | **S** | ⏳ TODO |
+| 4: Run summary JSON | n41 | **S** | ✅ included (PR #101) |
 
 When adding a phase: append a new `## Phase N — <name>` section with new step IDs (`V1`, `V2`, ... or `C1`, ...). Don't modify existing G/V/C/S blocks unless the phase explicitly redefines that contract.
 
@@ -487,13 +487,66 @@ When the token exists:
 > - **`Pushed before halt: N>0`** — a static read-only token 403s from row 1, so partial progress before an auth halt can't be staged live. Unit-covered.
 > - **Empty-payload → `Skipped`** (`push.go:214`) — needs a changed field whose `buildPropertyValue` returns nil; narrow, unit territory.
 
-## Phase 4 — Run summary JSON (TODO — added by phase 4 PR)
+## Phase 4 — Run summary JSON (DAG n41)
 
-Steps `S1`...`Sn`. Expected coverage:
-- JSON schema matches `dag-v1.4.0.mmd` header comment.
-- `status` enum: `clean` / `partial` / `halted` / `cancelled`.
-- Exit code matrix: `0` for clean/cancelled, `1` for partial/halted.
-- Per-row `pushed` / `skippedNoOp` / `skippedNonRow` / `failed` / `halted` arrays populated correctly.
+Phase 4 emits a machine-readable JSON `RunSummary` as the **leading object on stdout** of every push (cancel, dry-run, halt included). Banners, the `\r` progress line, the queue preview, and the final error all moved to **stderr**. So this phase is a **sanity overlay**, not new pushes: it re-runs a few representative G/V/C steps with the streams split and eyeballs the leading JSON. No formal assertions, no new fixtures.
+
+The summary contract is already unit/CLI tested (mock client, in `summary_test.go` / `push_test.go`). These `S` steps add **real-Notion** confidence that live pushes produce the right `status` / arrays / exit — a sanity pass, not the source of truth.
+
+### How to capture (per step)
+
+Run the step's existing push with the two streams teed to files (PowerShell shown; `$LASTEXITCODE` is the exit code — don't trust `$?` for native-exe exit):
+
+```powershell
+./notion-sync.exe push "<folder>" [flags] 1>summary.txt 2>progress.txt
+"exit=$LASTEXITCODE"
+```
+
+- `summary.txt` (stdout) leads with the JSON object, then the `─────` divider, then the human counts.
+- `progress.txt` (stderr) holds banners + the `\r` progress line + the queue preview + the final halt/error line.
+- **The summary is the first complete `{...}` object.** It's pretty-printed (multi-line), so read down to the divider line, not just line 1. The structural check is "first non-space byte of stdout is `{`".
+- Splitting the streams means the existing G/V/C "combined output contains X" assertions now live across **both** files — check the right stream (preview/banners/halt line in `progress.txt`, JSON + human counts in `summary.txt`).
+
+### Scenario → expected summary
+
+| Rides on step | `status` | Key array content | exit |
+|---|---|---|---|
+| **G1** cancel (non-TTY, no `--yes`) | `cancelled` | **all arrays `[]`** — cancel emits the summary from an empty result *before* any classify, so even `skippedNonRow` is empty | 0 |
+| **G2** `--yes`, Score edited | `clean` | `pushed:[{file:"<canary>.md", fields:["Score"]}]`, `skippedNonRow:[{file:"AGENTS.md", reason:"AGENTS.md"}]` | 0 |
+| **C1** `--dry-run`, fresh import | `clean` | `pushed:[]`, `skippedNoOp` lists all 7 rows, `skippedNonRow:[{AGENTS.md}]` (dry-run still classifies) | 0 |
+| **V2** multi-halt | `halted` | `halted[]` = 3 × `{phase:"validation", file, reason, fix}` (2 conflict + 1 stray), `pushed:[]`, `skippedNonRow:[{AGENTS.md}]` | 1 |
+| **V3** soft-deleted | `clean` | `skippedNonRow` includes Page 6 `{reason:"notion-deleted"}` | 0 |
+| **V5 / C6** `--force` | `clean` | `pushed[].fields` = full **sorted payload keys** (force has no per-cell diff → not just the edited field) | 0 |
+
+**`skippedNonRow` appears on every path that reaches the validation classifier — normal, halt, `--force`, dry-run — but NOT cancel** (cancel short-circuits before the classifier runs).
+
+### Step S1 — `clean` + per-field `fields` (rides G2)
+Capture G2's `push --yes` stdout.
+- **Pass:** leading byte `{`; `status:"clean"`; `pushed` has the canary with `fields:["Score"]` (only the edited field — n33 cell-scoped, not the whole payload); `skippedNonRow:[{AGENTS.md}]`; `failed`/`halted`/`skippedNoOp` empty; exit 0.
+
+### Step S2 — `cancelled` + empty arrays (rides G1)
+Capture G1's gated (no-`--yes`) stdout.
+- **Pass:** `status:"cancelled"`; **every** array `[]` (incl. `skippedNonRow` — classifier never ran); exit 0. The queue preview + `Cancelled` line are in `progress.txt`, not the summary.
+
+### Step S3 — `clean` dry-run, all-no-op arrays (rides C1)
+Capture C1's `push --dry-run` stdout.
+- **Pass:** `status:"clean"`; `pushed:[]`; `skippedNoOp` lists all 7 basenames; `skippedNonRow:[{AGENTS.md}]`; exit 0. Proves dry-run classifies and reports would-skip rows without a write.
+
+### Step S4 — `halted` with per-halt entries (rides V2)
+Capture V2's `push --yes` stdout.
+- **Pass:** leading byte `{`; `status:"halted"`; `halted[]` has 3 entries, each `phase:"validation"` with non-empty `file`/`reason`/`fix` (Page 2 + Page 3 conflict, `random-stray.md` stray); `pushed:[]`; `skippedNonRow:[{AGENTS.md}]`; exit 1. The JSON precedes the human halt list on stdout; `push halted by validation gate` is in `progress.txt`.
+
+### Step S5 — `skippedNonRow` soft-delete reason (rides V3)
+Capture V3's `push --yes` stdout.
+- **Pass:** `skippedNonRow` includes Page 6 with `reason:"notion-deleted"` (alongside `{AGENTS.md}`); `status:"clean"`; exit 0. (Don't pin Page 5's bucket — post-3a an unedited Page 5 diffs to a no-op and lands in `skippedNoOp`, not `pushed`.)
+
+### Step S6 — `--force` `fields` fallback (rides V5 or C6)
+Capture the `--force` push stdout from V5 (Pages 2+3) or C6 (Page 5).
+- **Pass:** `pushed[].fields` is the full **sorted** set of pushable keys for the row (not just the edited field) — force has no snapshot to diff, so it overwrites blind; **no `skippedNoOp`**; `status:"clean"`; exit 0.
+
+> **Unit-only — NOT checked live (recorded so the gap is explicit):**
+> - **`status:"partial"` / `failed[]`** — every live route to a per-row failure is either a network artifact (re-fetch fail), an unscriptable mid-run race (n32c), a read-back mismatch the gate pre-empts (n34e), or a 4xx the validation gate already turns into a *halt*. No G/V/C step produces `partial`; it stays unit-tested in `push_test.go` / `summary_test.go`. **Don't hunt for it live.**
+> - **Auth halt `{phase:"auth"}`** — only reachable with a read-only token (see **C9**, skipped by default). When C9 runs, also confirm its summary's `halted:[{phase:"auth", file:"", reason, fix}]` and exit 1.
 
 ---
 
@@ -566,6 +619,12 @@ Print a summary table:
 | C7   | Scalar edit on Page 4 keeps rich text   | PASS   |
 | C8   | Restamp aligns local; re-push no conflict | PASS  |
 | C9   | Auth 403 halts once, writes nothing     | SKIP   |
+| S1   | clean + per-field fields (rides G2)     | PASS   |
+| S2   | cancelled + empty arrays (rides G1)     | PASS   |
+| S3   | dry-run all-no-op arrays (rides C1)     | PASS   |
+| S4   | halted entries, exit 1 (rides V2)       | PASS   |
+| S5   | skippedNonRow soft-delete (rides V3)    | PASS   |
+| S6   | --force fields fallback (rides V5/C6)   | PASS   |
 | F1   | Final state matches canonical (1–7)     | PASS   |
 | F2   | Cleanup                                 | PASS   |
 ```

--- a/cmd/notion-sync/main_test.go
+++ b/cmd/notion-sync/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -420,6 +421,49 @@ func TestRenderAuthHaltedResult_ShowsErrorAndPartialProgress(t *testing.T) {
 	}
 	if !strings.Contains(out, "authentication failed") {
 		t.Errorf("expected the auth error reason+fix in the output, got:\n%s", out)
+	}
+}
+
+// Phase 4 (DAG n41): the run summary prints the machine-readable JSON object
+// FIRST (so an agent piping stdout parses the leading complete object — Option
+// A), then a divider rule, leaving the human-readable counts to print after.
+// Uses json.Decoder.Decode, which reads exactly the first JSON value from the
+// stream — the precise contract an agent consumer relies on.
+func TestRenderRunSummary_n41_JSONFirstThenDivider(t *testing.T) {
+	summary := sync.RunSummary{
+		Status:        "partial",
+		Pushed:        []sync.PushedEntry{{File: "a.md", Fields: []string{"title"}}},
+		SkippedNoOp:   []string{},
+		SkippedNonRow: []sync.SkippedNonRowEntry{},
+		Failed:        []sync.FailedEntry{{File: "b.md", Reason: "x", Fix: "y"}},
+		Halted:        []sync.HaltedEntry{},
+	}
+
+	var buf bytes.Buffer
+	if err := renderRunSummary(summary, &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := buf.String()
+
+	// Leading content is the JSON object — first non-space byte is '{'.
+	if !strings.HasPrefix(strings.TrimLeft(out, " \t\r\n"), "{") {
+		t.Errorf("expected output to lead with a JSON object, got:\n%s", out)
+	}
+	// The leading complete JSON object decodes and round-trips the status.
+	var got sync.RunSummary
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("leading JSON object did not decode: %v\n%s", err, out)
+	}
+	if got.Status != "partial" {
+		t.Errorf("decoded status = %q, want partial", got.Status)
+	}
+	if len(got.Failed) != 1 || got.Failed[0].File != "b.md" {
+		t.Errorf("decoded failed = %+v, want one entry for b.md", got.Failed)
+	}
+	// A divider rule follows the JSON, separating it from the human counts the
+	// caller prints next.
+	if !strings.Contains(out, "─") {
+		t.Errorf("expected a divider rule after the JSON, got:\n%s", out)
 	}
 }
 

--- a/cmd/notion-sync/push.go
+++ b/cmd/notion-sync/push.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -15,6 +16,27 @@ import (
 	"github.com/ran-codes/notion-sync/internal/notion"
 	"github.com/ran-codes/notion-sync/internal/sync"
 )
+
+// summaryDivider separates the machine-readable JSON run summary from the
+// human-readable counts that follow it. Decorative only — the JSON above is a
+// single complete object an agent parses on its own (Option A), so a change to
+// this rule never affects parsing.
+const summaryDivider = "─────────────────────────────────────────"
+
+// renderRunSummary writes the agent-readable JSON run summary (DAG n41) FIRST,
+// then the divider, leaving the caller to print the human-readable counts after
+// (so a terminal user sees the human summary at the bottom while an agent
+// piping stdout parses the leading JSON object). The JSON is pretty-printed —
+// still a single valid leading object under the "parse first {...}" contract.
+func renderRunSummary(summary sync.RunSummary, w io.Writer) error {
+	b, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(w, string(b))
+	fmt.Fprintln(w, summaryDivider)
+	return nil
+}
 
 // confirmPush previews the push queue to stderr and gates execution on user
 // consent. Returns true if push should proceed, false to cancel cleanly
@@ -126,16 +148,22 @@ func runPush(args []string) error {
 			return nil
 		}
 		if !confirmPush(preview, yesFlag, isStdinTTY(), os.Stdin, os.Stderr) {
+			// DAG n13a: the run summary is emitted on every terminal path —
+			// cancel included — so an agent piping stdout always gets a status.
+			_ = renderRunSummary((&sync.PushResult{Cancelled: true}).Summary(), os.Stdout)
 			return nil
 		}
 	}
 
+	// Progress chatter goes to stderr so stdout leads with the JSON run summary
+	// (DAG n41): an agent piping stdout parses the first complete JSON object
+	// without tripping over banners or the \r progress line.
 	if *dryRun {
-		fmt.Println("Pushing properties (dry run)...")
+		fmt.Fprintln(os.Stderr, "Pushing properties (dry run)...")
 	} else if forceFlag {
-		fmt.Println("Force pushing properties (ignoring conflicts)...")
+		fmt.Fprintln(os.Stderr, "Force pushing properties (ignoring conflicts)...")
 	} else {
-		fmt.Println("Pushing properties to Notion...")
+		fmt.Fprintln(os.Stderr, "Pushing properties to Notion...")
 	}
 
 	client := notion.NewClient(key)
@@ -151,15 +179,23 @@ func runPush(args []string) error {
 		if p.Phase == sync.PhasePushing {
 			dbTitle = p.Title
 		}
-		fmt.Printf("\r%-60s", formatPushProgress(p, dbTitle))
+		fmt.Fprintf(os.Stderr, "\r%-60s", formatPushProgress(p, dbTitle))
 	})
 
 	if err != nil {
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
 		return err
 	}
 
-	fmt.Println()
+	fmt.Fprintln(os.Stderr)
+
+	// DAG n41: emit the machine-readable run summary FIRST (the single sink every
+	// terminal path drains into), then the human-readable blocks below the
+	// divider. The human blocks stay on stdout so a terminal user sees them at
+	// the bottom while an agent reads the leading JSON object.
+	if err := renderRunSummary(result.Summary(), os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not render run summary JSON: %v\n", err)
+	}
 
 	// Validation halted (DAG n22a) — print the enumerated halt list and
 	// exit non-zero so scripts/CI can detect the abort. No "Done"

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -67,6 +67,24 @@ func BuildPushQueue(folderPath string) (*PushPreview, error) {
 	return preview, nil
 }
 
+// pushedFields is the field list recorded in a row's PushedEntry (DAG n41).
+// On the gate path changedFields is the authoritative re-diff, so it's used
+// verbatim (preserving its order). Under --force changedFields is nil — the
+// blind-overwrite path sends every pushable field — so the payload's keys
+// (sorted, deterministic) stand in. Never returns nil: an empty payload can't
+// reach here (it's filtered to skippedNoOp upstream), so Fields is non-null.
+func pushedFields(changedFields []string, properties map[string]interface{}) []string {
+	if len(changedFields) > 0 {
+		return changedFields
+	}
+	keys := make([]string, 0, len(properties))
+	for k := range properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // PushDatabase pushes local frontmatter property changes back to Notion.
 // Only page properties are updated; page body content is never modified.
 func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, error) {
@@ -123,6 +141,19 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		return nil, err
 	}
 
+	// Phase 4 (DAG n41): record the deliberately-ignored files — AGENTS.md and
+	// soft-deleted rows — for the summary's skippedNonRow[]. Read off the same
+	// classifier report that feeds the gate, so it's populated on every path
+	// (halt, --force, normal) without a second folder walk.
+	for _, f := range report.Files {
+		switch f.Class {
+		case ClassSkipAgentsMD:
+			result.SkippedNonRow = append(result.SkippedNonRow, SkippedNonRowEntry{File: filepath.Base(f.Path), Reason: "AGENTS.md"})
+		case ClassSkipDeleted:
+			result.SkippedNonRow = append(result.SkippedNonRow, SkippedNonRowEntry{File: filepath.Base(f.Path), Reason: "notion-deleted"})
+		}
+	}
+
 	// Validation gate (DAG n21+n22). All-or-nothing: any halt-class file
 	// across the whole folder aborts before any Notion write. --force ran the
 	// walk network-free, so report.Halted is false and this branch is skipped.
@@ -153,6 +184,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		}
 
 		notionID := f.NotionID
+		base := filepath.Base(f.Path)
 		localLastEdited, _ := f.fm["notion-last-edited"].(string)
 
 		// Per-cell diff (DAG n31/n32): compare local frontmatter to the snapshot
@@ -169,6 +201,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		if !opts.Force {
 			if len(diffRow(f.fm, f.page, schema)) == 0 {
 				result.SkippedNoOp++
+				result.SkippedNoOpFiles = append(result.SkippedNoOpFiles, base)
 				continue
 			}
 
@@ -179,12 +212,24 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 			page, err := opts.Client.GetPage(notionID)
 			if err != nil {
 				result.Failed++
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.Path), err))
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", base, err))
+				result.FailedRows = append(result.FailedRows, FailedEntry{
+					File:   base,
+					Reason: fmt.Sprintf("could not re-fetch the row before writing: %v", err),
+					Fix:    "check network / Notion availability, then re-run",
+				})
 				continue
 			}
 			if !timestampsEqual(localLastEdited, page.LastEditedTime) {
+				// n32c mid-run race: continue-class, same as n34c. Counted as a
+				// conflict for the human view and as a failed row for the summary.
 				result.Conflicts++
-				result.ConflictFiles = append(result.ConflictFiles, filepath.Base(f.Path))
+				result.ConflictFiles = append(result.ConflictFiles, base)
+				result.FailedRows = append(result.FailedRows, FailedEntry{
+					File:   base,
+					Reason: fmt.Sprintf("row changed in Notion mid-run (local %s, Notion %s)", localLastEdited, page.LastEditedTime),
+					Fix:    "run `notion-sync refresh` to reconcile, then push again",
+				})
 				continue
 			}
 			notionPage = page
@@ -195,6 +240,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 			changedFields = diffRow(f.fm, page, schema)
 			if len(changedFields) == 0 {
 				result.SkippedNoOp++
+				result.SkippedNoOpFiles = append(result.SkippedNoOpFiles, base)
 				continue
 			}
 		}
@@ -205,20 +251,28 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		if len(validationErrs) > 0 {
 			result.Failed++
 			for _, e := range validationErrs {
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", filepath.Base(f.Path), e))
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", base, e))
 			}
+			result.FailedRows = append(result.FailedRows, FailedEntry{
+				File:   base,
+				Reason: strings.Join(validationErrs, "; "),
+				Fix:    "fix the field value(s) to match the schema, then re-run",
+			})
 			continue
 		}
 		// With the payload narrowed to changedFields, an empty payload means the
 		// only changed field can't be expressed as a write (e.g. a buildPropertyValue
-		// that returns nil) — count it Skipped rather than push an empty PATCH.
+		// that returns nil) — count it Skipped rather than push an empty PATCH. For
+		// the summary this is a no-op outcome (nothing reached Notion).
 		if len(properties) == 0 {
 			result.Skipped++
+			result.SkippedNoOpFiles = append(result.SkippedNoOpFiles, base)
 			continue
 		}
 
 		if opts.DryRun {
 			result.Pushed++
+			result.PushedRows = append(result.PushedRows, PushedEntry{File: base, Fields: pushedFields(changedFields, properties)})
 			continue
 		}
 
@@ -234,7 +288,12 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 			}
 			// n34c: per-row 4xx / exhausted-transient — loud-fail, keep going.
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", filepath.Base(f.Path), err))
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", base, err))
+			result.FailedRows = append(result.FailedRows, FailedEntry{
+				File:   base,
+				Reason: err.Error(),
+				Fix:    "review Notion's error, fix the field or token permissions, then re-push",
+			})
 			continue
 		}
 
@@ -260,7 +319,12 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 				for _, m := range mismatches {
 					parts = append(parts, fmt.Sprintf("%s (sent %q, stored %q)", m.Field, m.Sent, m.Stored))
 				}
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: Notion stored %s differently than sent — not restamped; re-check and re-push", filepath.Base(f.Path), strings.Join(parts, ", ")))
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: Notion stored %s differently than sent — not restamped; re-check and re-push", base, strings.Join(parts, ", ")))
+				result.FailedRows = append(result.FailedRows, FailedEntry{
+					File:   base,
+					Reason: fmt.Sprintf("Notion stored %s differently than sent", strings.Join(parts, ", ")),
+					Fix:    "re-check the field value and re-push",
+				})
 				continue
 			}
 		}
@@ -273,7 +337,7 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 				// Non-fatal: push succeeded; we just couldn't refetch the precise
 				// timestamp. Surface it so silent failures don't quietly reintroduce
 				// the quantized-timestamp bug this code exists to avoid.
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: refetch precise timestamp: %v", filepath.Base(f.Path), refetchErr))
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: refetch precise timestamp: %v", base, refetchErr))
 			}
 			if updated != nil && updated.LastEditedTime != "" {
 				newLastEdited = updated.LastEditedTime
@@ -285,10 +349,11 @@ func PushDatabase(opts PushOptions, onProgress ProgressCallback) (*PushResult, e
 		pushedAt := time.Now().UTC().Format(time.RFC3339)
 		if err := updateAfterPush(f.Path, newLastEdited, pushedAt); err != nil {
 			// Non-fatal: push succeeded, just couldn't update local timestamps.
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: update timestamps: %v", filepath.Base(f.Path), err))
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: update timestamps: %v", base, err))
 		}
 
 		result.Pushed++
+		result.PushedRows = append(result.PushedRows, PushedEntry{File: base, Fields: pushedFields(changedFields, properties)})
 	}
 
 	if onProgress != nil {

--- a/internal/sync/push_test.go
+++ b/internal/sync/push_test.go
@@ -2125,3 +2125,139 @@ func TestPushDatabase_DataSourceWithEmptySchemaErrors(t *testing.T) {
 		t.Errorf("expected error to mention missing schema, got: %v", err)
 	}
 }
+
+// --- Phase 4 (DAG n41): PushDatabase populates the structured run-summary detail ---
+
+// A successful push records a PushedRows entry naming the file (basename) and
+// the exact fields that were sent — the per-row detail the JSON summary needs.
+func TestPushDatabase_n41_RecordsPushedFields(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\n" +
+		"notion-id: page-001\n" +
+		"notion-last-edited: 2024-01-01T00:00:00Z\n" +
+		"Status: Done\n" + // unchanged vs snapshot
+		"Priority: 5\n" + // changed (snapshot has 2)
+		"---\n# Content\n"
+	if err := os.WriteFile(filepath.Join(dir, "page-001.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID: "db-001",
+		Properties: map[string]notion.DatabaseProperty{
+			"Status":   {Type: "select"},
+			"Priority": {Type: "number"},
+		},
+	}
+	prio := 2.0
+	client.pages["page-001"] = &notion.Page{
+		ID:             "page-001",
+		LastEditedTime: "2024-01-01T00:00:00Z",
+		Properties: map[string]notion.Property{
+			"Status":   {Type: "select", Select: &notion.SelectValue{Name: "Done"}},
+			"Priority": {Type: "number", Number: &prio},
+		},
+	}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.PushedRows) != 1 {
+		t.Fatalf("expected 1 PushedRows entry, got %d (%+v)", len(result.PushedRows), result.PushedRows)
+	}
+	entry := result.PushedRows[0]
+	if entry.File != "page-001.md" {
+		t.Errorf("PushedRows file = %q, want basename page-001.md", entry.File)
+	}
+	if len(entry.Fields) != 1 || entry.Fields[0] != "Priority" {
+		t.Errorf("PushedRows fields = %v, want only the changed field [Priority]", entry.Fields)
+	}
+}
+
+// AGENTS.md and soft-deleted files are intentionally not rows — push records
+// them in SkippedNonRow with the right reason so the summary distinguishes
+// "deliberately ignored" from "nothing changed".
+func TestPushDatabase_n41_RecordsSkippedNonRow(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	files := map[string]string{
+		"AGENTS.md": "# generated guide\n",
+		"gone.md": "---\nnotion-id: page-gone\nnotion-last-edited: 2024-01-01T00:00:00Z\n" +
+			"notion-deleted: true\nStatus: Done\n---\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reasons := map[string]string{}
+	for _, e := range result.SkippedNonRow {
+		reasons[e.File] = e.Reason
+	}
+	if reasons["AGENTS.md"] != "AGENTS.md" {
+		t.Errorf("expected AGENTS.md skipped with reason AGENTS.md, got %+v", result.SkippedNonRow)
+	}
+	if reasons["gone.md"] != "notion-deleted" {
+		t.Errorf("expected gone.md skipped with reason notion-deleted, got %+v", result.SkippedNonRow)
+	}
+}
+
+// A per-row 4xx records a FailedRows entry with file, reason, and a non-empty
+// fix — the actionable triad the summary's failed[] array carries.
+func TestPushDatabase_n41_RecordsFailedWithReasonAndFix(t *testing.T) {
+	dir := t.TempDir()
+	writeDatabaseMeta(t, dir, "db-001")
+
+	md := "---\nnotion-id: page-bad\nnotion-last-edited: 2024-01-01T00:00:00Z\nStatus: Blocked\n---\n"
+	if err := os.WriteFile(filepath.Join(dir, "bad.md"), []byte(md), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newMockClient()
+	client.databases["db-001"] = &notion.Database{
+		ID:         "db-001",
+		Properties: map[string]notion.DatabaseProperty{"Status": {Type: "select"}},
+	}
+	client.pages["page-bad"] = &notion.Page{
+		ID: "page-bad", LastEditedTime: "2024-01-01T00:00:00Z",
+		Properties: map[string]notion.Property{"Status": {Type: "select", Select: &notion.SelectValue{Name: "To Do"}}},
+	}
+	client.updateErrors["page-bad"] = &notion.ErrorResponse{
+		Status: 400, Code: "validation_error", Message: "body failed validation",
+	}
+
+	result, err := PushDatabase(PushOptions{Client: client, FolderPath: dir}, nil)
+	if err != nil {
+		t.Fatalf("a per-row 4xx must not be a run-level error: %v", err)
+	}
+	if len(result.FailedRows) != 1 {
+		t.Fatalf("expected 1 FailedRows entry, got %d (%+v)", len(result.FailedRows), result.FailedRows)
+	}
+	f := result.FailedRows[0]
+	if f.File != "bad.md" {
+		t.Errorf("FailedRows file = %q, want bad.md", f.File)
+	}
+	if !strings.Contains(f.Reason, "validation") {
+		t.Errorf("FailedRows reason = %q, want it to carry Notion's message", f.Reason)
+	}
+	if f.Fix == "" {
+		t.Error("FailedRows entry must carry a non-empty fix")
+	}
+}

--- a/internal/sync/summary.go
+++ b/internal/sync/summary.go
@@ -1,0 +1,131 @@
+package sync
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// RunSummary is the agent-readable structured output emitted at the end of a
+// push run (DAG n41). It is the single sink every terminal path drains into:
+// agents parse it to decide their next action. The JSON shape is the contract
+// pinned in dag-v1.4.0.mmd. Every slice is non-nil so it marshals as [] rather
+// than null — agents can index without a presence check.
+type RunSummary struct {
+	Status        string               `json:"status"` // clean | partial | halted | cancelled
+	Pushed        []PushedEntry        `json:"pushed"`
+	SkippedNoOp   []string             `json:"skippedNoOp"`
+	SkippedNonRow []SkippedNonRowEntry `json:"skippedNonRow"`
+	Failed        []FailedEntry        `json:"failed"`
+	Halted        []HaltedEntry        `json:"halted"`
+}
+
+// PushedEntry is one row that was written to Notion, plus the fields sent.
+type PushedEntry struct {
+	File   string   `json:"file"`
+	Fields []string `json:"fields"`
+}
+
+// SkippedNonRowEntry is a file the push intentionally ignored because it isn't a
+// synced row. Reason is "AGENTS.md" or "notion-deleted".
+type SkippedNonRowEntry struct {
+	File   string `json:"file"`
+	Reason string `json:"reason"`
+}
+
+// FailedEntry is a per-row failure that did not halt the run (continue-class).
+type FailedEntry struct {
+	File   string `json:"file"`
+	Reason string `json:"reason"`
+	Fix    string `json:"fix"`
+}
+
+// HaltedEntry is a halt that aborted (validation) or stopped (auth) the run.
+// Phase is "validation" or "auth".
+type HaltedEntry struct {
+	File   string `json:"file"`
+	Reason string `json:"reason"`
+	Fix    string `json:"fix"`
+	Phase  string `json:"phase"`
+}
+
+// Summary maps the accumulated PushResult into the RunSummary contract,
+// computing status per the DAG header rules. Slices are initialized empty so
+// the JSON never emits null arrays.
+func (r *PushResult) Summary() RunSummary {
+	s := RunSummary{
+		Status:        r.status(),
+		Pushed:        append([]PushedEntry{}, r.PushedRows...),
+		SkippedNoOp:   append([]string{}, r.SkippedNoOpFiles...),
+		SkippedNonRow: append([]SkippedNonRowEntry{}, r.SkippedNonRow...),
+		Failed:        append([]FailedEntry{}, r.FailedRows...),
+		Halted:        []HaltedEntry{},
+	}
+	// Validation-gate halts (DAG n22a): one entry per halt-class file, tagged
+	// phase "validation". Basename only — the contract never leaks abs paths.
+	for _, h := range r.Halts {
+		s.Halted = append(s.Halted, HaltedEntry{
+			File:   filepath.Base(h.Path),
+			Reason: h.Reason,
+			Fix:    haltFix(h.Class),
+			Phase:  "validation",
+		})
+	}
+	// Auth halt (DAG n34h): run-wide, so no single file owns it (File empty).
+	// AuthError packs reason and fix as "reason — fix"; split so the agent gets
+	// the actionable half separately.
+	if r.AuthHalted {
+		reason, fix := splitReasonFix(r.AuthError)
+		s.Halted = append(s.Halted, HaltedEntry{
+			Reason: reason,
+			Fix:    fix,
+			Phase:  "auth",
+		})
+	}
+	return s
+}
+
+// splitReasonFix splits a "reason — fix" message into its two halves. Falls
+// back to (whole, generic) when there's no em-dash separator.
+func splitReasonFix(msg string) (reason, fix string) {
+	if i := strings.Index(msg, " — "); i != -1 {
+		return msg[:i], msg[i+len(" — "):]
+	}
+	return msg, "fix the issue, then re-run"
+}
+
+// haltFix returns the one-line remediation for a halt class — the actionable
+// half of a halted entry, kept distinct from the diagnostic Reason so an agent
+// can surface "what to do" without parsing prose.
+func haltFix(c Classification) string {
+	switch c {
+	case ClassHaltConflict:
+		return "run `notion-sync refresh` to pull Notion's version, reconcile, then push again"
+	case ClassHaltUnexpected:
+		return "remove the file or add a valid notion-id, then re-run"
+	case ClassHaltUnreachable:
+		return "check network / Notion availability, then re-run"
+	case ClassHaltMalformed:
+		return "fix the YAML frontmatter, then re-run"
+	case ClassHaltUnreadable:
+		return "fix the file's permissions, then re-run"
+	case ClassHaltInvalidOption:
+		return "use an existing option (or pass --allow-new-options for select/multi_select), then re-run"
+	default:
+		return "fix the issue, then re-run"
+	}
+}
+
+// status applies the DAG status rules. Order matters: cancelled and halted are
+// checked before partial so a halted-and-failed run reports "halted".
+func (r *PushResult) status() string {
+	switch {
+	case r.Cancelled:
+		return "cancelled"
+	case len(r.Halts) > 0 || r.AuthHalted:
+		return "halted"
+	case len(r.FailedRows) > 0:
+		return "partial"
+	default:
+		return "clean"
+	}
+}

--- a/internal/sync/summary_test.go
+++ b/internal/sync/summary_test.go
@@ -1,0 +1,195 @@
+package sync
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Phase 4 (DAG n41) — the run summary is the single agent-readable sink every
+// terminal path drains into. These tests pin the status rules (clean / partial
+// / halted / cancelled) and the JSON shape from dag-v1.4.0.mmd. Status rules
+// (DAG header): clean = no failed AND no halted; partial = failed, no halted;
+// halted = any halt (validation or auth); cancelled = user declined.
+
+// Tracer: a run where every queued row pushed and nothing failed or halted is
+// "clean", and the pushed rows carry their file + the fields that were sent.
+func TestRunSummary_n41_CleanStatusWhenAllPushed(t *testing.T) {
+	result := &PushResult{
+		PushedRows: []PushedEntry{
+			{File: "alpha.md", Fields: []string{"title", "Status"}},
+		},
+	}
+
+	s := result.Summary()
+
+	if s.Status != "clean" {
+		t.Errorf("status = %q, want clean", s.Status)
+	}
+	if len(s.Pushed) != 1 || s.Pushed[0].File != "alpha.md" {
+		t.Fatalf("pushed = %+v, want one entry for alpha.md", s.Pushed)
+	}
+	if got := s.Pushed[0].Fields; len(got) != 2 || got[0] != "title" || got[1] != "Status" {
+		t.Errorf("pushed fields = %v, want [title Status]", got)
+	}
+	// JSON marshals cleanly (sanity that the contract serializes at all).
+	if _, err := json.Marshal(s); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}
+
+// A run with at least one continue-class failure and no halt is "partial", and
+// each failure carries file + reason + fix for the agent to act on.
+func TestRunSummary_n41_PartialStatusWhenAnyFailed(t *testing.T) {
+	result := &PushResult{
+		PushedRows: []PushedEntry{{File: "ok.md", Fields: []string{"title"}}},
+		FailedRows: []FailedEntry{
+			{File: "bad.md", Reason: "Notion rejected the title", Fix: "shorten it and re-push"},
+		},
+	}
+
+	s := result.Summary()
+
+	if s.Status != "partial" {
+		t.Errorf("status = %q, want partial", s.Status)
+	}
+	if len(s.Failed) != 1 {
+		t.Fatalf("failed = %+v, want one entry", s.Failed)
+	}
+	f := s.Failed[0]
+	if f.File != "bad.md" || f.Reason == "" || f.Fix == "" {
+		t.Errorf("failed entry = %+v, want file+reason+fix populated", f)
+	}
+}
+
+// A validation-gate halt makes the run "halted", and every halt-class file maps
+// to a halted entry tagged phase "validation" with a basename, reason, and fix.
+func TestRunSummary_n41_HaltedStatusFromValidation(t *testing.T) {
+	result := &PushResult{
+		Halted: true,
+		Halts: []FileClassification{
+			{Path: "/abs/folder/stray.md", Class: ClassHaltUnexpected, Reason: "no notion-id"},
+			{Path: "/abs/folder/conflict.md", Class: ClassHaltConflict, Reason: "Notion moved ahead"},
+		},
+	}
+
+	s := result.Summary()
+
+	if s.Status != "halted" {
+		t.Errorf("status = %q, want halted", s.Status)
+	}
+	if len(s.Halted) != 2 {
+		t.Fatalf("halted = %+v, want 2 entries", s.Halted)
+	}
+	for _, h := range s.Halted {
+		if h.Phase != "validation" {
+			t.Errorf("phase = %q, want validation, entry %+v", h.Phase, h)
+		}
+		if h.File == "" || h.Reason == "" || h.Fix == "" {
+			t.Errorf("halted entry missing file/reason/fix: %+v", h)
+		}
+	}
+	// Basename only — no leaking the user's absolute paths into the contract.
+	if s.Halted[0].File != "stray.md" {
+		t.Errorf("file = %q, want basename stray.md", s.Halted[0].File)
+	}
+}
+
+// A run-wide auth failure (401/403, DAG n34h) is "halted" with a single halted
+// entry tagged phase "auth" carrying the auth reason.
+func TestRunSummary_n41_HaltedStatusFromAuth(t *testing.T) {
+	result := &PushResult{
+		Pushed:     1,
+		AuthHalted: true,
+		AuthError:  "authentication failed (token invalid) — check the API key has write access",
+	}
+
+	s := result.Summary()
+
+	if s.Status != "halted" {
+		t.Errorf("status = %q, want halted", s.Status)
+	}
+	if len(s.Halted) != 1 {
+		t.Fatalf("halted = %+v, want one auth entry", s.Halted)
+	}
+	h := s.Halted[0]
+	if h.Phase != "auth" {
+		t.Errorf("phase = %q, want auth", h.Phase)
+	}
+	if h.Reason == "" || h.Fix == "" {
+		t.Errorf("auth halted entry missing reason/fix: %+v", h)
+	}
+}
+
+// A run the user declined at the confirmation gate is "cancelled" with every
+// array empty — nothing was inspected or pushed.
+func TestRunSummary_n41_CancelledStatus(t *testing.T) {
+	s := (&PushResult{Cancelled: true}).Summary()
+
+	if s.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", s.Status)
+	}
+	if len(s.Pushed) != 0 || len(s.SkippedNoOp) != 0 || len(s.SkippedNonRow) != 0 ||
+		len(s.Failed) != 0 || len(s.Halted) != 0 {
+		t.Errorf("cancelled summary should have all-empty arrays, got %+v", s)
+	}
+}
+
+// When a run both fails some rows AND halts, "halted" wins — the halt is the
+// headline the agent must act on first (DAG: halted = any halt, regardless of
+// failures).
+func TestRunSummary_n41_HaltedTakesPrecedenceOverFailed(t *testing.T) {
+	result := &PushResult{
+		FailedRows: []FailedEntry{{File: "bad.md", Reason: "x", Fix: "y"}},
+		Halted:     true,
+		Halts:      []FileClassification{{Path: "conflict.md", Class: ClassHaltConflict, Reason: "moved"}},
+	}
+
+	if s := result.Summary(); s.Status != "halted" {
+		t.Errorf("status = %q, want halted (precedence over partial)", s.Status)
+	}
+}
+
+// skippedNoOp (no-op rows) and skippedNonRow (AGENTS.md / deleted) map straight
+// through with their respective shapes.
+func TestRunSummary_n41_SkippedNoOpAndNonRowPopulated(t *testing.T) {
+	result := &PushResult{
+		SkippedNoOpFiles: []string{"unchanged.md"},
+		SkippedNonRow: []SkippedNonRowEntry{
+			{File: "AGENTS.md", Reason: "AGENTS.md"},
+			{File: "gone.md", Reason: "notion-deleted"},
+		},
+	}
+
+	s := result.Summary()
+
+	if s.Status != "clean" {
+		t.Errorf("status = %q, want clean (skips are not failures)", s.Status)
+	}
+	if len(s.SkippedNoOp) != 1 || s.SkippedNoOp[0] != "unchanged.md" {
+		t.Errorf("skippedNoOp = %v, want [unchanged.md]", s.SkippedNoOp)
+	}
+	if len(s.SkippedNonRow) != 2 {
+		t.Fatalf("skippedNonRow = %+v, want 2 entries", s.SkippedNonRow)
+	}
+	if s.SkippedNonRow[0].Reason != "AGENTS.md" || s.SkippedNonRow[1].Reason != "notion-deleted" {
+		t.Errorf("skippedNonRow reasons = %+v, want AGENTS.md + notion-deleted", s.SkippedNonRow)
+	}
+}
+
+// Agent-critical: empty result serializes arrays as [] not null, so consumers
+// can index without a nil check.
+func TestRunSummary_n41_EmptyArraysSerializeAsBracketsNotNull(t *testing.T) {
+	b, err := json.Marshal((&PushResult{}).Summary())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, key := range []string{
+		`"pushed":[]`, `"skippedNoOp":[]`, `"skippedNonRow":[]`, `"failed":[]`, `"halted":[]`,
+	} {
+		if !strings.Contains(got, key) {
+			t.Errorf("expected %s in JSON, got:\n%s", key, got)
+		}
+	}
+}

--- a/internal/sync/types.go
+++ b/internal/sync/types.go
@@ -114,4 +114,15 @@ type PushResult struct {
 	// the one-line reason+fix surfaced once, instead of once per remaining row.
 	AuthHalted bool
 	AuthError  string
+
+	// Phase 4 (DAG n41) structured detail backing the JSON run summary. These
+	// are populated in lockstep with the count fields above at each terminal
+	// site — the same discipline classifyFolder uses to keep Halted in step
+	// with its appends. The counts drive the human-readable renderer; these
+	// slices drive Summary()'s machine-readable contract.
+	Cancelled        bool                 // user declined at the confirmation gate (DAG n13a)
+	PushedRows       []PushedEntry        // one per Pushed row, with the fields sent
+	SkippedNoOpFiles []string             // basenames of rows skipped as no-ops
+	SkippedNonRow    []SkippedNonRowEntry // AGENTS.md / notion-deleted files
+	FailedRows       []FailedEntry        // continue-class per-row failures
 }


### PR DESCRIPTION
## Context

- Addresess #55 
- Adds printed sumarmy of push work afte rpsuh process  (Phase 4)

## ACtion Items

- [x] Devleopment
- [x] Code Review
- [x] User Testing
