### PR TITLE
refactor(agents): embed AGENTS.md template + force-upgrade on drift (#87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ CLI tool that syncs Notion databases to local Markdown files with YAML frontmatt
 | File | Audience | Lives at (source of truth) | Lives at (deployed bundle) |
 | --- | --- | --- | --- |
 | **`CLAUDE.md`** (this file) | Agents working **on** notion-sync's code | repo root — `./CLAUDE.md` | not deployed; dev-only |
-| **`AGENTS.md`** (generated) | Agents working **with** the synced output (downstream consumers) | source const in `internal/sync/agents.go` | written to the user's workspace root on every `import` / `refresh` (e.g. `./notion/AGENTS.md`) |
+| **`AGENTS.md`** (generated) | Agents working **with** the synced output (downstream consumers) | embedded template `internal/sync/agents.md.tmpl` | written to the user's workspace root on every `import` / `refresh` (e.g. `./notion/AGENTS.md`) |
 
-When the user says "the agent docs" or asks about downstream documentation, they almost always mean **`AGENTS.md`**. To change what downstream agents see, edit the `agentsMDContent` const in `internal/sync/agents.go` — it gets emitted by `WriteAgentsMD` (idempotent, never overwrites a user-edited copy).
+When the user says "the agent docs" or asks about downstream documentation, they almost always mean **`AGENTS.md`**. To change what downstream agents see, edit the embedded template `internal/sync/agents.md.tmpl` (pulled in via `//go:embed` as `agentsMDTemplate`) — it gets emitted by `syncAgentsMD` on every `import` / `refresh`. AGENTS.md is a tool-owned file: `syncAgentsMD` force-upgrades it on version-stamp drift, so local edits are intentionally discarded on the next sync.
 
 ## Rules
 

--- a/internal/sync/agents.go
+++ b/internal/sync/agents.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	_ "embed"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -21,6 +22,19 @@ func ParseAgentsMDVersion(content string) string {
 	return strings.TrimSpace(m[1])
 }
 
+// agentsMDTemplate is the AGENTS.md body written to the workspace root so that
+// any downstream LLM/agent that lands in a notion-sync output folder
+// understands the layout, conventions, and gotchas of the synced data. It is
+// embedded from agents.md.tmpl (edit that file, not a Go string) and contains a
+// single {{VERSION}} placeholder filled in by renderAgentsMD.
+//
+// AGENTS.md is the cross-vendor convention (Cursor, OpenAI's agents.md spec,
+// and others) for provider-neutral agent instructions. Claude Code reads it
+// alongside CLAUDE.md.
+//
+//go:embed agents.md.tmpl
+var agentsMDTemplate string
+
 // renderAgentsMD returns the AGENTS.md content with the current binary's
 // Version interpolated into the version stamp. If Version is unset (e.g. in
 // tests that don't wire it), the stamp value is empty.
@@ -28,216 +42,20 @@ func renderAgentsMD() string {
 	return strings.Replace(agentsMDTemplate, "{{VERSION}}", Version, 1)
 }
 
-// agentsMDContent is written to the workspace root as AGENTS.md so that any
-// downstream LLM/agent that lands in a notion-sync output folder understands
-// the layout, conventions, and gotchas of the synced data.
+// EnsureAgentsMDCurrent keeps the workspace-root AGENTS.md in lock-step with the
+// running binary. AGENTS.md is a generated, tool-owned file — not a
+// user-editable one — so the rules are:
 //
-// AGENTS.md is the cross-vendor convention (Cursor, OpenAI's agents.md spec,
-// and others) for provider-neutral agent instructions. Claude Code reads it
-// alongside CLAUDE.md.
-const agentsMDTemplate = `<!-- notion-sync-version: {{VERSION}} -->
-# notion-sync workspace
-
-This folder contains data synced from Notion using [notion-sync](https://github.com/ran-codes/notion-sync).
-This file (AGENTS.md) tells downstream LLM/agent tools how to interpret the contents.
-
-## What is here
-
-- One subfolder per synced Notion **database**, containing markdown files (one per page) and a ` + "`_database.json`" + ` metadata file.
-- A ` + "`pages/`" + ` subfolder containing one folder per synced **standalone page** (page imported by URL, not part of a database). Each has a ` + "`_page.json`" + ` and one ` + "`.md`" + ` file.
-
-` + "```" + `
-<workspace-root>/
-├── AGENTS.md                      <-- this file
-├── <Database Title>/
-│   ├── _database.json
-│   └── <notion-id>.md             (one per database entry)
-├── <Multi-Source Database>/
-│   ├── _database.json             (top-level, no dataSourceId)
-│   ├── <Source 1 Title>/
-│   │   ├── _database.json         (with dataSourceId)
-│   │   └── <notion-id>.md
-│   └── <Source 2 Title>/
-│       └── ...
-└── pages/
-    └── <Page Title>_<short-id>/
-        ├── _page.json
-        └── <Page Title>.md
-` + "```" + `
-
-## Filenames
-
-- **Database entries**: ` + "`{notion-id}.md`" + ` (UUID-based). Stable — renaming the page in Notion does not change the local filename. The page title lives in the ` + "`title`" + ` (or named title property) of the frontmatter.
-- **Standalone pages**: title-based filename inside a folder named ` + "`<sanitized-title>_<8-char-id>/`" + `.
-
-## Frontmatter format
-
-Every ` + "`.md`" + ` file starts with YAML frontmatter. The first block is always notion-sync metadata; everything after is the Notion page's properties verbatim.
-
-` + "```" + `yaml
----
-notion-id: "<page-uuid>"
-notion-url: "https://app.notion.com/p/<page-id-32-hex>"
-notion-last-edited: "<RFC 3339 — Notion's last_edited_time>"
-notion-database-id: "<database-uuid>"   # only present for database entries
-# notion-deleted: true                  # only present if the entry was removed in Notion (soft delete)
-# notion-last-pushed: "<RFC 3339>"      # only present after a push — when properties were last written back
-
-# ... all Notion properties below ...
-Title Property: "Page Name"
-Status: "In Progress"
-Tags: [a, b, c]
-PDF:
-  - "https://prod-files-secure.s3.us-west-2.amazonaws.com/<bucket>/<uuid>/file.pdf"
----
-` + "```" + `
-
-### Property → frontmatter mapping
-
-| Notion type                     | Frontmatter value                          | Pushable? |
-| ------------------------------- | ------------------------------------------ | --------- |
-| ` + "`title`" + `                         | named title-property key in frontmatter (database entries); filename for standalone pages | yes — text only, see *Rich-text fidelity on push* |
-| ` + "`rich_text`" + `                     | plain markdown string                      | yes — text only, see *Rich-text fidelity on push* |
-| ` + "`number`" + `                        | number or ` + "`null`" + `                            | yes |
-| ` + "`select`" + `                        | option name or ` + "`null`" + `                       | yes |
-| ` + "`multi_select`" + `                  | array of option names                      | yes |
-| ` + "`status`" + `                        | status name or ` + "`null`" + `                       | yes |
-| ` + "`date`" + `                          | ` + "`start`" + ` or ` + "`start → end`" + `                     | yes |
-| ` + "`checkbox`" + `                      | ` + "`true`" + ` or ` + "`false`" + `                            | yes |
-| ` + "`url`" + ` / ` + "`email`" + ` / ` + "`phone_number`" + ` | string or ` + "`null`" + `                            | yes |
-| ` + "`relation`" + `                      | array of page IDs                          | yes |
-| ` + "`people`" + `                        | array of names (or IDs as fallback)        | no — Notion-managed |
-| ` + "`files`" + `                         | array of URLs (see "File URLs" below)      | no — Notion-managed |
-| ` + "`created_time`" + ` / ` + "`last_edited_time`" + ` | RFC 3339 timestamp                | no — read-only |
-| ` + "`unique_id`" + `                     | ` + "`PREFIX-N`" + ` or ` + "`N`" + `                            | no — read-only |
-| ` + "`created_by`" + ` / ` + "`last_edited_by`" + ` | user name (or ID as fallback)        | no — read-only |
-
-Skipped (not in frontmatter): ` + "`formula`" + `, ` + "`rollup`" + `, ` + "`button`" + `, ` + "`verification`" + ` — they're computed or non-portable.
-
-## File URLs (important for downstream consumers)
-
-URLs in ` + "`files`" + ` properties and in markdown body image/PDF/video/file/audio embeds may have had their **AWS S3 pre-signed query string stripped**:
-
-- **Original** (from Notion API): ` + "`https://prod-files-secure.s3.us-west-2.amazonaws.com/<bucket>/<uuid>/file.pdf?X-Amz-Algorithm=...&X-Amz-Signature=...&X-Amz-Date=...`" + `
-- **In this snapshot** (default behavior): ` + "`https://prod-files-secure.s3.us-west-2.amazonaws.com/<bucket>/<uuid>/file.pdf`" + `
-
-Why: Notion rotates the ` + "`X-Amz-Signature`" + ` query string every hour. Without stripping, every refresh produces a giant noisy diff even when nothing actually changed.
-
-What this means for you:
-
-- The path (including the file UUID and filename) **is stable** — use it as the file's identifier.
-- The stripped URL **will not return file bytes** if you GET it directly — the auth params have been removed and AWS rejects unsigned requests to ` + "`prod-files-secure`" + `.
-- To fetch the actual bytes, re-query the Notion API for the parent page and use the freshly-signed URL it returns.
-- If a snapshot was produced with ` + "`--keep-presigned-params`" + `, URLs include the auth string but the signature is **already expired** (1-hour TTL).
-
-External URLs (set by users in Notion as "external" file references, not uploaded into Notion) are never stripped — they pass through verbatim.
-
-## Soft deletes
-
-Pages removed from Notion are **not** deleted from disk on refresh. Instead, ` + "`notion-deleted: true`" + ` is added to the frontmatter. Treat any file with that key as historical.
-
-## Metadata files
-
-### ` + "`_database.json`" + ` (per database folder)
-
-` + "```" + `json
-{
-  "databaseId": "<uuid>",
-  "dataSourceId": "<uuid>",
-  "title": "Human Title",
-  "url": "https://app.notion.com/p/<database-id-32-hex>",
-  "folderPath": "<absolute path>",
-  "lastSyncedAt": "<RFC 3339>",
-  "entryCount": 42,
-  "syncVersion": "v0.5.0"
-}
-` + "```" + `
-
-For multi-source databases, the **top-level** ` + "`_database.json`" + ` has no ` + "`dataSourceId`" + `; each per-source subfolder has its own with ` + "`dataSourceId`" + ` set. ` + "`entryCount`" + ` at the top level is the total across all sources.
-
-### ` + "`_page.json`" + ` (per standalone-page folder)
-
-` + "```" + `json
-{
-  "pageId": "<uuid>",
-  "title": "Page Title",
-  "url": "https://app.notion.com/p/<page-id-32-hex>",
-  "folderPath": "<absolute path>",
-  "lastSyncedAt": "<RFC 3339>",
-  "syncVersion": "v0.5.0"
-}
-` + "```" + `
-
-## Refresh semantics (helpful when reasoning about diffs)
-
-- Default ` + "`refresh`" + ` is incremental: entries whose ` + "`notion-last-edited`" + ` matches the local copy are skipped.
-- ` + "`refresh --force`" + ` resyncs every entry regardless of timestamp.
-- ` + "`refresh --ids id1,id2`" + ` resyncs specific pages by ID.
-- ` + "`clean <folder>`" + ` performs in-place cleanups **without** any API call. Used as a one-time backfill after upgrading. Cleanups applied:
-  - strips Notion S3 presigned query strings from file URLs in ` + "`.md`" + ` content
-  - removes the deprecated ` + "`notion-frozen-at`" + ` frontmatter line
-  - canonicalizes legacy ` + "`www.notion.so/Title-{id}`" + ` URLs to ` + "`app.notion.com/p/{id}`" + ` in ` + "`.md`" + ` frontmatter and metadata JSON
-  - ensures trailing newlines on ` + "`.md`" + `/` + "`.json`" + ` files
-  - re-stamps ` + "`_database.json`" + ` / ` + "`_page.json`" + ` with the current ` + "`syncVersion`" + ` for any folder it modified
-  - regenerates ` + "`AGENTS.md`" + ` (this file) when its version stamp is older than the running binary
-- ` + "`agents-md <folder>`" + ` regenerates ` + "`AGENTS.md`" + ` from the running binary, **always overwriting** any existing copy. Use this when you want the latest doc unconditionally; ` + "`clean`" + ` is the safer default that only rewrites on stamp drift.
-
-## Push semantics (writing local changes back to Notion)
-
-` + "`notion-sync push <folder>`" + ` is the reverse direction: it reads frontmatter from local ` + "`.md`" + ` files and writes property changes back to Notion. **Page body content is never modified.**
-
-Key facts for downstream agents:
-
-- Only **pushable** properties (see table above) are written back. Notion-managed fields (` + "`people`" + `, ` + "`files`" + `, ` + "`created_time`" + `, etc.) are silently skipped even if present in frontmatter.
-- Title properties are pushable: editing the value of the named title-property in a database entry's frontmatter renames the page in Notion on the next push.
-- **Conflict detection**: before pushing, the tool compares the local ` + "`notion-last-edited`" + ` timestamp with Notion's current ` + "`last_edited_time`" + `. If they differ (someone edited in Notion since last sync), the file is skipped and reported as a conflict. Use ` + "`--force`" + ` to overwrite.
-- After a successful push, the tool writes ` + "`notion-last-pushed: <timestamp>`" + ` into the file's frontmatter and updates ` + "`notion-last-edited`" + ` to the post-push value returned by Notion.
-- Files with ` + "`notion-deleted: true`" + ` are never pushed.
-- ` + "`push --dry-run`" + ` reports what would be pushed without making any Notion API calls.
-
-### Rich-text fidelity on push
-
-` + "`title`" + ` and ` + "`rich_text`" + ` ("Text") values are stored in your ` + "`.md`" + ` as a **flat Markdown string** — on import Notion's structured formatting is *rendered* to Markdown syntax (e.g. ` + "`**bold**`" + `, ` + "`[text](url)`" + `). Inline formatting (bold, italic, code, strikethrough, highlight, underline, links) is preserved in the file as Markdown. On push these are reconstructed as real Notion formatting — bold, italic, inline code, strikethrough, highlight, underline, and links round-trip intact. Formatting and entities outside that set are written as literal characters; see the degraded attributes below.
-
-Two attributes are **lost at import and therefore can never be restored on push** — they are not in your ` + "`.md`" + ` at all, so no push can reconstruct them:
-
-- **Foreground (text) color** — only *background* highlight survives (as ` + "`==text==`" + `); a colored *text* run keeps its words but loses the color.
-- **` + "`@user`" + ` mention identity** — a user mention is rendered as ` + "`@name`" + `; the user's Notion ID is not retained, so push cannot re-link the mention.
-
-A third attribute degrades on push even though its characters survive:
-
-- **Inline equation** — an equation imports as the literal text "$expression$" and pushes back as those same characters, so in Notion it stops rendering as math (the characters survive, the equation *type* does not).
-
-Push does **not** claim to round-trip these. Don't expect a pushed cell to restore the original text color, re-link an ` + "`@user`" + ` mention, or re-render an inline equation. (Highlight color is also normalized — any background color round-trips as a single yellow highlight, not its original shade.)
-`
-
-// WriteAgentsMD writes the generated AGENTS.md to the workspace root.
-// It only writes if the file doesn't already exist (preserves user edits).
-func WriteAgentsMD(workspacePath string) error {
-	dest := filepath.Join(workspacePath, "AGENTS.md")
-	if _, err := os.Stat(dest); err == nil {
-		return nil // file exists, don't overwrite
-	}
-	return os.WriteFile(dest, []byte(renderAgentsMD()), 0644)
-}
-
-// RegenerateAgentsMD writes AGENTS.md to the workspace root, overwriting any
-// existing file. Used by `notion-sync agents-md` for explicit user-driven
-// refreshes — the command name is the consent.
-func RegenerateAgentsMD(workspacePath string) error {
-	dest := filepath.Join(workspacePath, "AGENTS.md")
-	return os.WriteFile(dest, []byte(renderAgentsMD()), 0644)
-}
-
-// EnsureAgentsMDCurrent writes AGENTS.md to the workspace root if it is
-// missing, or if its embedded version stamp does not match the current
-// binary's Version. Used by `clean` to keep the doc in sync with the binary
-// post-upgrade without clobbering an already-current file.
+//   - stamp != Version → force-overwrite (the doc upgrades on binary upgrade;
+//     any local edits are intentionally discarded)
+//   - stamp == Version → leave alone (already current)
+//   - missing          → write
 //
 // Returns true if a write happened (or, in dryRun, would have happened).
 //
-// If Version is unset (build-time -ldflags not wired), this is a no-op — we
-// have nothing meaningful to stamp. Mirrors the guard in bumpFolderMetadata.
+// If Version is unset (build-time -ldflags not wired) this is a no-op — we have
+// nothing meaningful to stamp or compare against. The fire-and-forget auto-path
+// (syncAgentsMD) layers a dev-build first-write on top of this for import.
 func EnsureAgentsMDCurrent(workspacePath string, dryRun bool) (bool, error) {
 	if Version == "" {
 		return false, nil
@@ -248,6 +66,7 @@ func EnsureAgentsMDCurrent(workspacePath string, dryRun bool) (bool, error) {
 		if ParseAgentsMDVersion(string(existing)) == Version {
 			return false, nil
 		}
+		// stamp drift → fall through to (over)write
 	} else if !os.IsNotExist(err) {
 		return false, err
 	}
@@ -258,4 +77,31 @@ func EnsureAgentsMDCurrent(workspacePath string, dryRun bool) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// syncAgentsMD is the fire-and-forget auto-path used by import and refresh:
+//   - missing            → write (even in a dev build with an empty stamp, so a
+//     first import always emits the doc)
+//   - present + drift    → force-upgrade via EnsureAgentsMDCurrent
+//   - present, Version="" → leave alone (dev build can't tell current from stale)
+//
+// Callers log (not fail) on error — a doc-write hiccup must never abort a sync.
+func syncAgentsMD(workspacePath string) error {
+	dest := filepath.Join(workspacePath, "AGENTS.md")
+	if _, err := os.Stat(dest); err != nil {
+		if os.IsNotExist(err) {
+			return os.WriteFile(dest, []byte(renderAgentsMD()), 0644)
+		}
+		return err
+	}
+	_, err := EnsureAgentsMDCurrent(workspacePath, false)
+	return err
+}
+
+// RegenerateAgentsMD writes AGENTS.md to the workspace root, overwriting any
+// existing file. Used by `notion-sync agents-md` for explicit user-driven
+// refreshes — the command name is the consent.
+func RegenerateAgentsMD(workspacePath string) error {
+	dest := filepath.Join(workspacePath, "AGENTS.md")
+	return os.WriteFile(dest, []byte(renderAgentsMD()), 0644)
 }

--- a/internal/sync/agents.md.tmpl
+++ b/internal/sync/agents.md.tmpl
@@ -1,0 +1,174 @@
+<!-- notion-sync-version: {{VERSION}} -->
+# notion-sync workspace
+
+This folder contains data synced from Notion using [notion-sync](https://github.com/ran-codes/notion-sync).
+This file (AGENTS.md) tells downstream LLM/agent tools how to interpret the contents.
+
+## What is here
+
+- One subfolder per synced Notion **database**, containing markdown files (one per page) and a `_database.json` metadata file.
+- A `pages/` subfolder containing one folder per synced **standalone page** (page imported by URL, not part of a database). Each has a `_page.json` and one `.md` file.
+
+```
+<workspace-root>/
+├── AGENTS.md                      <-- this file
+├── <Database Title>/
+│   ├── _database.json
+│   └── <notion-id>.md             (one per database entry)
+├── <Multi-Source Database>/
+│   ├── _database.json             (top-level, no dataSourceId)
+│   ├── <Source 1 Title>/
+│   │   ├── _database.json         (with dataSourceId)
+│   │   └── <notion-id>.md
+│   └── <Source 2 Title>/
+│       └── ...
+└── pages/
+    └── <Page Title>_<short-id>/
+        ├── _page.json
+        └── <Page Title>.md
+```
+
+## Filenames
+
+- **Database entries**: `{notion-id}.md` (UUID-based). Stable — renaming the page in Notion does not change the local filename. The page title lives in the `title` (or named title property) of the frontmatter.
+- **Standalone pages**: title-based filename inside a folder named `<sanitized-title>_<8-char-id>/`.
+
+## Frontmatter format
+
+Every `.md` file starts with YAML frontmatter. The first block is always notion-sync metadata; everything after is the Notion page's properties verbatim.
+
+```yaml
+---
+notion-id: "<page-uuid>"
+notion-url: "https://app.notion.com/p/<page-id-32-hex>"
+notion-last-edited: "<RFC 3339 — Notion's last_edited_time>"
+notion-database-id: "<database-uuid>"   # only present for database entries
+# notion-deleted: true                  # only present if the entry was removed in Notion (soft delete)
+# notion-last-pushed: "<RFC 3339>"      # only present after a push — when properties were last written back
+
+# ... all Notion properties below ...
+Title Property: "Page Name"
+Status: "In Progress"
+Tags: [a, b, c]
+PDF:
+  - "https://prod-files-secure.s3.us-west-2.amazonaws.com/<bucket>/<uuid>/file.pdf"
+---
+```
+
+### Property → frontmatter mapping
+
+| Notion type                     | Frontmatter value                          | Pushable? |
+| ------------------------------- | ------------------------------------------ | --------- |
+| `title`                         | named title-property key in frontmatter (database entries); filename for standalone pages | yes — text only, see *Rich-text fidelity on push* |
+| `rich_text`                     | plain markdown string                      | yes — text only, see *Rich-text fidelity on push* |
+| `number`                        | number or `null`                            | yes |
+| `select`                        | option name or `null`                       | yes |
+| `multi_select`                  | array of option names                      | yes |
+| `status`                        | status name or `null`                       | yes |
+| `date`                          | `start` or `start → end`                     | yes |
+| `checkbox`                      | `true` or `false`                            | yes |
+| `url` / `email` / `phone_number` | string or `null`                            | yes |
+| `relation`                      | array of page IDs                          | yes |
+| `people`                        | array of names (or IDs as fallback)        | no — Notion-managed |
+| `files`                         | array of URLs (see "File URLs" below)      | no — Notion-managed |
+| `created_time` / `last_edited_time` | RFC 3339 timestamp                | no — read-only |
+| `unique_id`                     | `PREFIX-N` or `N`                            | no — read-only |
+| `created_by` / `last_edited_by` | user name (or ID as fallback)        | no — read-only |
+
+Skipped (not in frontmatter): `formula`, `rollup`, `button`, `verification` — they're computed or non-portable.
+
+## File URLs (important for downstream consumers)
+
+URLs in `files` properties and in markdown body image/PDF/video/file/audio embeds may have had their **AWS S3 pre-signed query string stripped**:
+
+- **Original** (from Notion API): `https://prod-files-secure.s3.us-west-2.amazonaws.com/<bucket>/<uuid>/file.pdf?X-Amz-Algorithm=...&X-Amz-Signature=...&X-Amz-Date=...`
+- **In this snapshot** (default behavior): `https://prod-files-secure.s3.us-west-2.amazonaws.com/<bucket>/<uuid>/file.pdf`
+
+Why: Notion rotates the `X-Amz-Signature` query string every hour. Without stripping, every refresh produces a giant noisy diff even when nothing actually changed.
+
+What this means for you:
+
+- The path (including the file UUID and filename) **is stable** — use it as the file's identifier.
+- The stripped URL **will not return file bytes** if you GET it directly — the auth params have been removed and AWS rejects unsigned requests to `prod-files-secure`.
+- To fetch the actual bytes, re-query the Notion API for the parent page and use the freshly-signed URL it returns.
+- If a snapshot was produced with `--keep-presigned-params`, URLs include the auth string but the signature is **already expired** (1-hour TTL).
+
+External URLs (set by users in Notion as "external" file references, not uploaded into Notion) are never stripped — they pass through verbatim.
+
+## Soft deletes
+
+Pages removed from Notion are **not** deleted from disk on refresh. Instead, `notion-deleted: true` is added to the frontmatter. Treat any file with that key as historical.
+
+## Metadata files
+
+### `_database.json` (per database folder)
+
+```json
+{
+  "databaseId": "<uuid>",
+  "dataSourceId": "<uuid>",
+  "title": "Human Title",
+  "url": "https://app.notion.com/p/<database-id-32-hex>",
+  "folderPath": "<absolute path>",
+  "lastSyncedAt": "<RFC 3339>",
+  "entryCount": 42,
+  "syncVersion": "v0.5.0"
+}
+```
+
+For multi-source databases, the **top-level** `_database.json` has no `dataSourceId`; each per-source subfolder has its own with `dataSourceId` set. `entryCount` at the top level is the total across all sources.
+
+### `_page.json` (per standalone-page folder)
+
+```json
+{
+  "pageId": "<uuid>",
+  "title": "Page Title",
+  "url": "https://app.notion.com/p/<page-id-32-hex>",
+  "folderPath": "<absolute path>",
+  "lastSyncedAt": "<RFC 3339>",
+  "syncVersion": "v0.5.0"
+}
+```
+
+## Refresh semantics (helpful when reasoning about diffs)
+
+- Default `refresh` is incremental: entries whose `notion-last-edited` matches the local copy are skipped.
+- `refresh --force` resyncs every entry regardless of timestamp.
+- `refresh --ids id1,id2` resyncs specific pages by ID.
+- `clean <folder>` performs in-place cleanups **without** any API call. Used as a one-time backfill after upgrading. Cleanups applied:
+  - strips Notion S3 presigned query strings from file URLs in `.md` content
+  - removes the deprecated `notion-frozen-at` frontmatter line
+  - canonicalizes legacy `www.notion.so/Title-{id}` URLs to `app.notion.com/p/{id}` in `.md` frontmatter and metadata JSON
+  - ensures trailing newlines on `.md`/`.json` files
+  - re-stamps `_database.json` / `_page.json` with the current `syncVersion` for any folder it modified
+  - regenerates `AGENTS.md` (this file) when its version stamp is older than the running binary
+- `agents-md <folder>` regenerates `AGENTS.md` from the running binary, **always overwriting** any existing copy. Use this when you want the latest doc unconditionally; `clean` is the safer default that only rewrites on stamp drift.
+
+## Push semantics (writing local changes back to Notion)
+
+`notion-sync push <folder>` is the reverse direction: it reads frontmatter from local `.md` files and writes property changes back to Notion. **Page body content is never modified.**
+
+Key facts for downstream agents:
+
+- Only **pushable** properties (see table above) are written back. Notion-managed fields (`people`, `files`, `created_time`, etc.) are silently skipped even if present in frontmatter.
+- Title properties are pushable: editing the value of the named title-property in a database entry's frontmatter renames the page in Notion on the next push.
+- **Conflict detection**: before pushing, the tool compares the local `notion-last-edited` timestamp with Notion's current `last_edited_time`. If they differ (someone edited in Notion since last sync), the file is skipped and reported as a conflict. Use `--force` to overwrite.
+- After a successful push, the tool writes `notion-last-pushed: <timestamp>` into the file's frontmatter and updates `notion-last-edited` to the post-push value returned by Notion.
+- Files with `notion-deleted: true` are never pushed.
+- `push --dry-run` reports what would be pushed without making any Notion API calls.
+
+### Rich-text fidelity on push
+
+`title` and `rich_text` ("Text") values are stored in your `.md` as a **flat Markdown string** — on import Notion's structured formatting is *rendered* to Markdown syntax (e.g. `**bold**`, `[text](url)`). Inline formatting (bold, italic, code, strikethrough, highlight, underline, links) is preserved in the file as Markdown. On push these are reconstructed as real Notion formatting — bold, italic, inline code, strikethrough, highlight, underline, and links round-trip intact. Formatting and entities outside that set are written as literal characters; see the degraded attributes below.
+
+Two attributes are **lost at import and therefore can never be restored on push** — they are not in your `.md` at all, so no push can reconstruct them:
+
+- **Foreground (text) color** — only *background* highlight survives (as `==text==`); a colored *text* run keeps its words but loses the color.
+- **`@user` mention identity** — a user mention is rendered as `@name`; the user's Notion ID is not retained, so push cannot re-link the mention.
+
+A third attribute degrades on push even though its characters survive:
+
+- **Inline equation** — an equation imports as the literal text "$expression$" and pushes back as those same characters, so in Notion it stops rendering as math (the characters survive, the equation *type* does not).
+
+Push does **not** claim to round-trip these. Don't expect a pushed cell to restore the original text color, re-link an `@user` mention, or re-render an inline equation. (Highlight color is also normalized — any background color round-trips as a single yellow highlight, not its original shade.)

--- a/internal/sync/agents_test.go
+++ b/internal/sync/agents_test.go
@@ -180,6 +180,81 @@ func TestEnsureAgentsMDCurrent_NoVersion(t *testing.T) {
 	}
 }
 
+// syncAgentsMD is the import/refresh auto-path. A *missing* AGENTS.md is always
+// created — even in a dev build (Version unset) — so a first import emits the doc.
+func TestSyncAgentsMD_WritesIfMissingEvenWithoutVersion(t *testing.T) {
+	tmp := t.TempDir()
+
+	prev := Version
+	Version = ""
+	defer func() { Version = prev }()
+
+	if err := syncAgentsMD(tmp); err != nil {
+		t.Fatalf("syncAgentsMD: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "AGENTS.md")); err != nil {
+		t.Errorf("AGENTS.md was not created on first import: %v", err)
+	}
+}
+
+// syncAgentsMD force-upgrades an existing, stale-stamped AGENTS.md (tool-owned
+// file — local edits are intentionally discarded on version drift).
+func TestSyncAgentsMD_ForceUpgradesStale(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "v2.0.0"
+	defer func() { Version = prev }()
+
+	stale := "<!-- notion-sync-version: v1.0.0 -->\n# stale + hand-edited\n"
+	if err := os.WriteFile(dest, []byte(stale), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := syncAgentsMD(tmp); err != nil {
+		t.Fatalf("syncAgentsMD: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "<!-- notion-sync-version: v2.0.0 -->") {
+		t.Errorf("stale AGENTS.md was not force-upgraded:\n%s", got)
+	}
+	if strings.Contains(string(got), "stale + hand-edited") {
+		t.Errorf("force-upgrade kept stale content:\n%s", got)
+	}
+}
+
+// syncAgentsMD leaves a current-stamped file alone (no needless rewrite).
+func TestSyncAgentsMD_LeavesCurrentAlone(t *testing.T) {
+	tmp := t.TempDir()
+	dest := filepath.Join(tmp, "AGENTS.md")
+
+	prev := Version
+	Version = "v3.0.0"
+	defer func() { Version = prev }()
+
+	current := "<!-- notion-sync-version: v3.0.0 -->\n# whatever\n"
+	if err := os.WriteFile(dest, []byte(current), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := syncAgentsMD(tmp); err != nil {
+		t.Fatalf("syncAgentsMD: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != current {
+		t.Errorf("current AGENTS.md was needlessly rewritten")
+	}
+}
+
 func TestEnsureAgentsMDCurrent_WritesIfMissing(t *testing.T) {
 	tmp := t.TempDir()
 
@@ -251,43 +326,23 @@ func TestParseAgentsMDVersion_EmptyValue(t *testing.T) {
 	}
 }
 
-func TestWriteAgentsMD_PreservesExisting(t *testing.T) {
-	tmp := t.TempDir()
-	dest := filepath.Join(tmp, "AGENTS.md")
-	custom := "# my hand-edited AGENTS.md\n"
-	if err := os.WriteFile(dest, []byte(custom), 0644); err != nil {
-		t.Fatalf("seed: %v", err)
+// TestEmbeddedTemplateHasPlaceholder guards the embed refactor: the embedded
+// agents.md.tmpl must still carry the {{VERSION}} placeholder, and renderAgentsMD
+// must substitute it (not leave the literal placeholder behind).
+func TestEmbeddedTemplateHasPlaceholder(t *testing.T) {
+	if !strings.Contains(agentsMDTemplate, "{{VERSION}}") {
+		t.Fatalf("embedded template lost the {{VERSION}} placeholder")
 	}
-
-	if err := WriteAgentsMD(tmp); err != nil {
-		t.Fatalf("WriteAgentsMD: %v", err)
-	}
-
-	got, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if string(got) != custom {
-		t.Errorf("WriteAgentsMD overwrote existing file:\nwant: %q\ngot:  %q", custom, got)
-	}
-}
-
-func TestWriteAgentsMD_StampsVersion(t *testing.T) {
-	tmp := t.TempDir()
 
 	prev := Version
-	Version = "vTEST"
+	Version = "vEMBED"
 	defer func() { Version = prev }()
 
-	if err := WriteAgentsMD(tmp); err != nil {
-		t.Fatalf("WriteAgentsMD: %v", err)
+	got := renderAgentsMD()
+	if strings.Contains(got, "{{VERSION}}") {
+		t.Errorf("renderAgentsMD left the {{VERSION}} placeholder unsubstituted")
 	}
-
-	got, err := os.ReadFile(filepath.Join(tmp, "AGENTS.md"))
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if !strings.Contains(string(got), "<!-- notion-sync-version: vTEST -->") {
-		t.Errorf("AGENTS.md missing version stamp, got:\n%s", got)
+	if !strings.Contains(got, "<!-- notion-sync-version: vEMBED -->") {
+		t.Errorf("renderAgentsMD did not stamp the version, got head:\n%.80s", got)
 	}
 }

--- a/internal/sync/database.go
+++ b/internal/sync/database.go
@@ -149,8 +149,9 @@ func FreshDatabaseImport(opts DatabaseImportOptions, onProgress ProgressCallback
 		return nil, fmt.Errorf("write metadata: %w", err)
 	}
 
-	// Write AGENTS.md at workspace root (only on first import, won't overwrite)
-	if err := WriteAgentsMD(opts.OutputFolder); err != nil {
+	// Write AGENTS.md at workspace root (creates if missing, force-upgrades on
+	// version drift — it is a generated, tool-owned file).
+	if err := syncAgentsMD(opts.OutputFolder); err != nil {
 		log.Printf("warning: failed to write AGENTS.md: %v", err)
 	}
 

--- a/internal/sync/page.go
+++ b/internal/sync/page.go
@@ -199,8 +199,9 @@ func FreezeStandalonePage(opts StandalonePageImportOptions) (*PageFreezeResult, 
 		return nil, fmt.Errorf("write metadata: %w", err)
 	}
 
-	// Write AGENTS.md at workspace root
-	if err := WriteAgentsMD(opts.OutputFolder); err != nil {
+	// Write AGENTS.md at workspace root (creates if missing, force-upgrades on
+	// version drift).
+	if err := syncAgentsMD(opts.OutputFolder); err != nil {
 		log.Printf("warning: failed to write AGENTS.md: %v", err)
 	}
 
@@ -228,8 +229,8 @@ func RefreshStandalonePage(opts RefreshStandalonePageOptions) (*PageFreezeResult
 
 	workspacePath := filepath.Dir(filepath.Dir(opts.FolderPath)) // pages/<folder> → workspace
 
-	// Backfill AGENTS.md at workspace root
-	if err := WriteAgentsMD(workspacePath); err != nil {
+	// Backfill / upgrade AGENTS.md at workspace root.
+	if err := syncAgentsMD(workspacePath); err != nil {
 		log.Printf("warning: failed to write AGENTS.md: %v", err)
 	}
 

--- a/internal/sync/refresh.go
+++ b/internal/sync/refresh.go
@@ -46,8 +46,9 @@ func RefreshDatabase(opts RefreshOptions, onProgress ProgressCallback) (*Databas
 
 	workspacePath := filepath.Dir(opts.FolderPath)
 
-	// Ensure AGENTS.md exists at workspace root (backfill for older imports)
-	if err := WriteAgentsMD(workspacePath); err != nil {
+	// Ensure AGENTS.md at workspace root: backfill for older imports, and
+	// force-upgrade it when this binary is newer than the stamped version.
+	if err := syncAgentsMD(workspacePath); err != nil {
 		log.Printf("warning: failed to write AGENTS.md: %v", err)
 	}
 


### PR DESCRIPTION
## Context

- Addressess #87 
- First bucket of wrok which si refactor the markdown agent.md stsaroge abstrac tinto a go markdown file instead inline go code
   - Increase the amitnainaible of the infomraitn
   - overwite logic on verison bumps


## Action item

- [x] Develop
- [x] Code Review