### PR TITLE
ci(release): announce releases as GitHub Discussions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  discussions: write
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           files: release/*
           generate_release_notes: true
+          discussion_category_name: Announcements
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Context
- Releases publish silently — no notification channel for users watching the repo.
- GitHub's `softprops/action-gh-release` can mirror a release into a Discussion, giving a commentable announcement thread per version.

## Changes
- Add `discussion_category_name: Announcements` to the release step in [`.github/workflows/release.yml`](https://github.com/Drexel-UHC/notion-sync/blob/b4a9fb2b08cdf007fa0cc838cac6d3bb9da1eb89/.github/workflows/release.yml#L85).

## Prerequisite
- Repo must have a Discussions category named **Announcements** (Settings → Discussions). If it's missing, the release step will fail.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)